### PR TITLE
feat: Phase 2 — Profiles, Presets, expanded content

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,124 +4,130 @@
 
 ---
 
-## Phase 1 — MVP Core (Priority: P0)
+## Phase 1 — MVP Core (Priority: P0) ✅ COMPLETED 2026-04-07
 **Goal**: Ứng dụng web chạy được, generate title + description + tags, copy to clipboard.
-**Estimated**: 3-4 days
+**Estimated**: 3-4 days | **Actual**: 1 day
 
 ### Tasks
 ```
 1.1  Project scaffold
      - [x] Vite + React 18 + TypeScript setup
-     - [ ] Tailwind CSS configuration (dark theme default)
-     - [ ] ESLint + Prettier config
-     - [ ] Directory structure per CLAUDE.md
-     - [ ] Package.json scripts
+     - [x] Tailwind CSS configuration (dark theme default)
+     - [x] ESLint + Prettier config
+     - [x] Directory structure per CLAUDE.md
+     - [x] Package.json scripts
 
 1.2  Config layer
-     - [ ] src/config/video-types.ts (7 initial types)
-     - [ ] src/config/genres.ts (10 initial genres)
-     - [ ] src/config/platforms.ts (7 platforms)
-     - [ ] src/config/rig-fields.ts
-     - [ ] src/config/social-fields.ts
-     - [ ] src/config/defaults.ts
+     - [x] src/config/video-types.ts (7 initial types)
+     - [x] src/config/genres.ts (10 initial genres)
+     - [x] src/config/platforms.ts (7 platforms)
+     - [x] src/config/rig-fields.ts
+     - [x] src/config/social-fields.ts
+     - [x] src/config/defaults.ts
 
 1.3  i18n setup
-     - [ ] i18next + react-i18next install & config
-     - [ ] locales/en/ui.json + templates.json
-     - [ ] locales/vi/ui.json + templates.json
-     - [ ] locales/ja/ui.json + templates.json
-     - [ ] Locale validation script
+     - [x] i18next + react-i18next install & config
+     - [x] locales/en/ui.json + templates.json
+     - [x] locales/vi/ui.json + templates.json
+     - [x] locales/ja/ui.json + templates.json
+     - [x] Locale validation script
 
 1.4  Core engine
-     - [ ] engine/types.ts
-     - [ ] engine/title-builder.ts + tests
-     - [ ] engine/description-builder.ts + tests
-     - [ ] engine/tag-generator.ts + tests
-     - [ ] engine/template-renderer.ts (orchestrator)
+     - [x] engine/types.ts
+     - [x] engine/title-builder.ts + tests
+     - [x] engine/description-builder.ts + tests
+     - [x] engine/tag-generator.ts + tests
+     - [x] engine/template-renderer.ts (orchestrator)
 
 1.5  State management
-     - [ ] Zustand setup
-     - [ ] editor-store.ts (form state)
-     - [ ] settings-store.ts (theme, default language)
+     - [x] Zustand setup
+     - [x] editor-store.ts (form state)
+     - [x] settings-store.ts (theme, default language)
 
 1.6  UI components
-     - [ ] ui/ primitives: Button, Input, Textarea, Toggle, ChipGroup, Select
-     - [ ] editor/ components: VideoTypeSelector, LanguageSelector, GenreSelector
-     - [ ] editor/ components: GameInfoForm, VideoSettingsForm, TimestampEditor
-     - [ ] editor/ components: StoreLinkEditor, RigEditor, SocialEditor, WarningToggles
-     - [ ] editor/ components: QuickPreview
-     - [ ] output/ components: OutputPreview, CopyButton, CharCounter, CopyAllBar
-     - [ ] layout/ components: AppShell, Header, TabBar
+     - [x] ui/ primitives: Button, Input, Textarea, Toggle, ChipGroup, Select
+     - [x] editor/ components: VideoTypeSelector, LanguageSelector, GenreSelector
+     - [x] editor/ components: GameInfoForm, VideoSettingsForm, TimestampEditor
+     - [x] editor/ components: StoreLinkEditor, RigEditor, SocialEditor, WarningToggles
+     - [x] editor/ components: QuickPreview
+     - [x] output/ components: OutputPreview, CopyButton, CharCounter, CopyAllBar
+     - [x] layout/ components: AppShell, Header, TabBar
 
 1.7  Pages
-     - [ ] EditorPage (form + quick preview)
-     - [ ] OutputPage (title + desc + tags + copy)
-     - [ ] React Router setup (HashRouter)
+     - [x] EditorPage (form + quick preview)
+     - [x] OutputPage (title + desc + tags + copy)
+     - [x] React Router setup (HashRouter)
 
 1.8  Testing
-     - [ ] Vitest config
-     - [ ] Engine unit tests (title, description, tags)
-     - [ ] Smoke tests for main pages
+     - [x] Vitest config
+     - [x] Engine unit tests (title, description, tags) — 42 tests
+     - [ ] Smoke tests for main pages (deferred to Phase 3)
 
 1.9  CI/CD
-     - [ ] GitHub Actions: lint + typecheck + test
-     - [ ] GitHub Actions: deploy to GitHub Pages
+     - [x] GitHub Actions: lint + typecheck + test
+     - [x] GitHub Actions: deploy to GitHub Pages
 
 ### Definition of Done
-- [ ] User can select video type, language, genre
-- [ ] User can enter game name, timestamps, store links, rig, social, warnings
-- [ ] Title, description, and tags generate correctly in EN/VI/JA
-- [ ] Copy buttons work for title, description, tags, and all
-- [ ] Character counts displayed (5000 desc, 500 tags)
-- [ ] CI passes, deploys to GitHub Pages
+- [x] User can select video type, language, genre
+- [x] User can enter game name, timestamps, store links, rig, social, warnings
+- [x] Title, description, and tags generate correctly in EN/VI/JA
+- [x] Copy buttons work for title, description, tags, and all
+- [x] Character counts displayed (5000 desc, 500 tags)
+- [x] CI passes, deploys to GitHub Pages
 ```
 
 ---
 
-## Phase 2 — Profiles & Presets (Priority: P1)
+## Phase 2 — Profiles & Presets (Priority: P1) ✅ COMPLETED 2026-04-07
 **Goal**: Lưu thông tin tái sử dụng, không phải nhập lại mỗi lần.
-**Estimated**: 2-3 days
+**Estimated**: 2-3 days | **Actual**: 1 day
 
 ### Tasks
 ```
 2.1  Profile system
-     - [ ] profile-store.ts (Zustand + persist)
-     - [ ] ProfileSaveForm component
-     - [ ] ProfileList + ProfileCard components
-     - [ ] Load profile → populate editor form
-     - [ ] Delete profile with confirmation
-     - [ ] Multiple profiles support
+     - [x] profile-store.ts (Zustand + persist)
+     - [x] ProfileSaveForm component
+     - [x] ProfileList + ProfileCard components
+     - [x] Load profile → populate editor form
+     - [x] Delete profile with confirmation
+     - [x] Multiple profiles support
 
 2.2  Game preset system
-     - [ ] preset-store.ts (Zustand + persist)
-     - [ ] GamePresetManager component
-     - [ ] Save game (name + genre + platform + store links + warnings)
-     - [ ] Load preset → populate game fields
-     - [ ] Preset selector dropdown in editor
+     - [x] preset-store.ts (Zustand + persist)
+     - [x] PresetSaveForm + PresetCard + PresetList + PresetSelector
+     - [x] Save game (name + genre + platform + store links + warnings)
+     - [x] Load preset → populate game fields
+     - [x] Preset selector dropdown in editor
 
 2.3  ProfilesPage
-     - [ ] Profile management tab
-     - [ ] Game preset management tab
-     - [ ] Import/Export JSON
+     - [x] Profile management tab
+     - [x] Game preset management tab
+     - [x] Import/Export JSON
 
 2.4  Auto-save draft
-     - [ ] Debounced save of editor state to localStorage
-     - [ ] Restore on page load
-     - [ ] Clear draft button
+     - [x] Debounced save of editor state to localStorage (via Zustand persist)
+     - [x] Restore on page load
+     - [x] Clear draft button + DraftIndicator
 
 2.5  Expand content
-     - [ ] Add video types: dlc, newgame_plus, challenge, side_quest, secret
-     - [ ] Add genres to 15+: fighting, stealth, survival_craft, roguelike, metroidvania
-     - [ ] Add social fields: twitch, tiktok, instagram, streamlabs
-     - [ ] Add rig fields: motherboard, controller
-     - [ ] Add store: humble, amazon
+     - [x] Add video types: dlc, newgame_plus, challenge, side_quest, secret (12 total)
+     - [x] Add genres: fighting, stealth, survival_craft, roguelike, metroidvania (15 total)
+     - [x] Add social fields: twitch, tiktok, instagram, streamlabs (12 total)
+     - [x] Add rig fields: motherboard, controller (8 total)
+     - [x] Add store: humble, amazon (9 total)
+
+2.6  Foundation additions
+     - [x] Modal + ConfirmDialog UI primitives
+     - [x] Import/Export utility (src/utils/import-export.ts)
+     - [x] UUID utility (src/utils/uuid.ts)
+     - [x] Updated i18n: 134 UI keys + 41 template keys across EN/VI/JA
 
 ### Definition of Done
-- [ ] User creates profile → social/rig/channel info saved
-- [ ] User loads profile → form populated instantly
-- [ ] User creates game preset → reused across parts
-- [ ] Form state auto-saved, survives page reload
-- [ ] Export/Import profiles as JSON works
+- [x] User creates profile → social/rig/channel info saved
+- [x] User loads profile → form populated instantly
+- [x] User creates game preset → reused across parts
+- [x] Form state auto-saved, survives page reload
+- [x] Export/Import profiles as JSON works
 ```
 
 ---

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Toaster } from "react-hot-toast";
 import { AppShell } from "@components/layout/AppShell";
 import { EditorPage } from "@pages/EditorPage";
 import { OutputPage } from "@pages/OutputPage";
+import { ProfilesPage } from "@pages/ProfilesPage";
 import "@i18n/index";
 
 export default function App() {
@@ -13,6 +14,7 @@ export default function App() {
           <Route element={<AppShell />}>
             <Route index element={<EditorPage />} />
             <Route path="output" element={<OutputPage />} />
+            <Route path="profiles" element={<ProfilesPage />} />
           </Route>
         </Routes>
       </HashRouter>

--- a/src/components/editor/DraftIndicator.tsx
+++ b/src/components/editor/DraftIndicator.tsx
@@ -1,0 +1,26 @@
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { Check } from "lucide-react";
+import { useEditorStore } from "@store/editor-store";
+
+export function DraftIndicator() {
+  const { t } = useTranslation("ui");
+  const [showSaved, setShowSaved] = useState(false);
+  const gameName = useEditorStore((s) => s.gameName);
+  const videoType = useEditorStore((s) => s.videoType);
+
+  useEffect(() => {
+    setShowSaved(true);
+    const timer = setTimeout(() => setShowSaved(false), 2000);
+    return () => clearTimeout(timer);
+  }, [gameName, videoType]);
+
+  if (!showSaved) return null;
+
+  return (
+    <span className="flex items-center gap-1 text-xs text-success">
+      <Check className="h-3 w-3" />
+      {t("editor.draftSaved")}
+    </span>
+  );
+}

--- a/src/components/editor/GameInfoForm.tsx
+++ b/src/components/editor/GameInfoForm.tsx
@@ -50,6 +50,22 @@ export function GameInfoForm() {
           onChange={(e) => store.set("bossName", e.target.value)}
         />
       )}
+      {extraFields.includes("dlcName") && (
+        <Input
+          label={t("editor.dlcName")}
+          placeholder={t("editor.dlcNamePlaceholder")}
+          value={store.dlcName ?? ""}
+          onChange={(e) => store.set("dlcName", e.target.value)}
+        />
+      )}
+      {extraFields.includes("challengeName") && (
+        <Input
+          label={t("editor.challengeName")}
+          placeholder={t("editor.challengeNamePlaceholder")}
+          value={store.challengeName ?? ""}
+          onChange={(e) => store.set("challengeName", e.target.value)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/layout/TabBar.tsx
+++ b/src/components/layout/TabBar.tsx
@@ -1,11 +1,12 @@
 import { NavLink } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { Pencil, FileText } from "lucide-react";
+import { Pencil, FileText, User } from "lucide-react";
 import clsx from "clsx";
 
 const tabs = [
   { to: "/", labelKey: "tabs.editor", icon: Pencil },
   { to: "/output", labelKey: "tabs.output", icon: FileText },
+  { to: "/profiles", labelKey: "tabs.profiles", icon: User },
 ] as const;
 
 export function TabBar() {

--- a/src/components/presets/PresetCard.tsx
+++ b/src/components/presets/PresetCard.tsx
@@ -1,0 +1,84 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Upload, Pencil, Trash2 } from "lucide-react";
+import { Button } from "@components/ui/Button";
+import { ConfirmDialog } from "@components/ui/ConfirmDialog";
+import { useEditorStore } from "@store/editor-store";
+import { usePresetStore, type GamePreset } from "@store/preset-store";
+import { GENRES } from "@config/genres";
+import { PresetSaveForm } from "./PresetSaveForm";
+
+interface PresetCardProps {
+  preset: GamePreset;
+}
+
+export function PresetCard({ preset }: PresetCardProps) {
+  const { t } = useTranslation("ui");
+  const loadPreset = useEditorStore((s) => s.loadPreset);
+  const deletePreset = usePresetStore((s) => s.deletePreset);
+  const [showDelete, setShowDelete] = useState(false);
+  const [showEdit, setShowEdit] = useState(false);
+
+  const handleLoad = () => {
+    loadPreset({
+      gameName: preset.gameName,
+      gameNameLocalized: preset.gameNameLocalized ? { ...preset.gameNameLocalized } : {},
+      genre: preset.genre,
+      platform: preset.platform,
+      storeLinks: { ...preset.storeLinks },
+      spoilerWarning: preset.spoilerWarning,
+      matureWarning: preset.matureWarning,
+    });
+  };
+
+  const genre = GENRES.find((g) => g.id === preset.genre);
+
+  return (
+    <>
+      <div className="flex items-center justify-between rounded-lg border border-border bg-surface-1 p-4">
+        <div className="flex-1">
+          <h3 className="text-sm font-semibold text-text-primary">{preset.gameName}</h3>
+          <div className="mt-1.5 flex items-center gap-2 text-xs text-text-muted">
+            {genre && (
+              <span className="rounded bg-surface-2 px-1.5 py-0.5">
+                {genre.icon} {t(genre.labelKey)}
+              </span>
+            )}
+            <span>{preset.platform}</span>
+          </div>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Button variant="primary" size="sm" onClick={handleLoad}>
+            <Upload className="h-3.5 w-3.5" />
+            {t("presets.loadPreset")}
+          </Button>
+          <Button variant="ghost" size="sm" onClick={() => setShowEdit(true)}>
+            <Pencil className="h-3.5 w-3.5" />
+          </Button>
+          <Button variant="ghost" size="sm" onClick={() => setShowDelete(true)}>
+            <Trash2 className="h-3.5 w-3.5 text-danger" />
+          </Button>
+        </div>
+      </div>
+
+      <ConfirmDialog
+        open={showDelete}
+        onConfirm={() => {
+          deletePreset(preset.id);
+          setShowDelete(false);
+        }}
+        onCancel={() => setShowDelete(false)}
+        title={t("common.delete")}
+        message={t("presets.deleteConfirm")}
+        confirmLabel={t("common.delete")}
+        variant="danger"
+      />
+
+      <PresetSaveForm
+        open={showEdit}
+        onClose={() => setShowEdit(false)}
+        editPreset={preset}
+      />
+    </>
+  );
+}

--- a/src/components/presets/PresetList.tsx
+++ b/src/components/presets/PresetList.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Plus } from "lucide-react";
+import { Button } from "@components/ui/Button";
+import { usePresetStore } from "@store/preset-store";
+import { PresetCard } from "./PresetCard";
+import { PresetSaveForm } from "./PresetSaveForm";
+
+export function PresetList() {
+  const { t } = useTranslation("ui");
+  const presets = usePresetStore((s) => s.presets);
+  const [showCreate, setShowCreate] = useState(false);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-base font-semibold text-text-primary">{t("presets.title")}</h2>
+        <Button size="sm" onClick={() => setShowCreate(true)}>
+          <Plus className="h-4 w-4" />
+          {t("presets.createNew")}
+        </Button>
+      </div>
+
+      {presets.length === 0 ? (
+        <p className="rounded-lg border border-dashed border-border py-8 text-center text-sm text-text-muted">
+          {t("presets.emptyState")}
+        </p>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {presets.map((preset) => (
+            <PresetCard key={preset.id} preset={preset} />
+          ))}
+        </div>
+      )}
+
+      <PresetSaveForm open={showCreate} onClose={() => setShowCreate(false)} />
+    </div>
+  );
+}

--- a/src/components/presets/PresetSaveForm.tsx
+++ b/src/components/presets/PresetSaveForm.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Modal } from "@components/ui/Modal";
+import { Button } from "@components/ui/Button";
+import { Input } from "@components/ui/Input";
+import { useEditorStore } from "@store/editor-store";
+import { usePresetStore, type GamePreset } from "@store/preset-store";
+
+interface PresetSaveFormProps {
+  open: boolean;
+  onClose: () => void;
+  editPreset?: GamePreset;
+}
+
+export function PresetSaveForm({ open, onClose, editPreset }: PresetSaveFormProps) {
+  const { t } = useTranslation("ui");
+  const editor = useEditorStore();
+  const { addPreset, updatePreset } = usePresetStore();
+
+  const [gameName, setGameName] = useState(editPreset?.gameName ?? editor.gameName);
+
+  const handleSave = () => {
+    const data = {
+      gameName: gameName.trim() || "Unnamed Game",
+      gameNameLocalized: editPreset?.gameNameLocalized ?? { ...editor.gameNameLocalized },
+      genre: editPreset?.genre ?? editor.genre,
+      platform: editPreset?.platform ?? editor.platform,
+      storeLinks: editPreset?.storeLinks ?? { ...editor.storeLinks },
+      spoilerWarning: editPreset?.spoilerWarning ?? editor.spoilerWarning,
+      matureWarning: editPreset?.matureWarning ?? editor.matureWarning,
+    };
+
+    if (editPreset) {
+      updatePreset(editPreset.id, { ...data });
+    } else {
+      addPreset(data);
+    }
+    onClose();
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={editPreset ? t("presets.editPreset") : t("presets.createNew")}
+      footer={
+        <>
+          <Button variant="ghost" onClick={onClose}>
+            {t("common.cancel")}
+          </Button>
+          <Button onClick={handleSave}>{t("common.save")}</Button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        <Input
+          label={t("editor.gameName")}
+          placeholder={t("editor.gameNamePlaceholder")}
+          value={gameName}
+          onChange={(e) => setGameName(e.target.value)}
+          autoFocus
+        />
+        <p className="text-xs text-text-muted">
+          {editPreset
+            ? "Update the game name. Other fields are saved from the editor."
+            : "Preset will save your current game name, genre, platform, store links, and warning settings."}
+        </p>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/presets/PresetSelector.tsx
+++ b/src/components/presets/PresetSelector.tsx
@@ -1,0 +1,34 @@
+import { useTranslation } from "react-i18next";
+import { Select } from "@components/ui/Select";
+import { usePresetStore } from "@store/preset-store";
+import { useEditorStore } from "@store/editor-store";
+
+export function PresetSelector() {
+  const { t } = useTranslation("ui");
+  const presets = usePresetStore((s) => s.presets);
+  const loadPreset = useEditorStore((s) => s.loadPreset);
+
+  if (presets.length === 0) return null;
+
+  const options = [
+    { value: "", label: `-- ${t("presets.selectPreset")} --` },
+    ...presets.map((p) => ({ value: p.id, label: p.gameName })),
+  ];
+
+  const handleSelect = (id: string) => {
+    if (!id) return;
+    const preset = presets.find((p) => p.id === id);
+    if (!preset) return;
+    loadPreset({
+      gameName: preset.gameName,
+      gameNameLocalized: preset.gameNameLocalized ? { ...preset.gameNameLocalized } : {},
+      genre: preset.genre,
+      platform: preset.platform,
+      storeLinks: { ...preset.storeLinks },
+      spoilerWarning: preset.spoilerWarning,
+      matureWarning: preset.matureWarning,
+    });
+  };
+
+  return <Select label={t("presets.selectPreset")} options={options} value="" onChange={handleSelect} />;
+}

--- a/src/components/profiles/ProfileCard.tsx
+++ b/src/components/profiles/ProfileCard.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Upload, Pencil, Trash2 } from "lucide-react";
+import { Button } from "@components/ui/Button";
+import { ConfirmDialog } from "@components/ui/ConfirmDialog";
+import { useEditorStore } from "@store/editor-store";
+import { useProfileStore, type Profile } from "@store/profile-store";
+import { ProfileSaveForm } from "./ProfileSaveForm";
+
+interface ProfileCardProps {
+  profile: Profile;
+}
+
+export function ProfileCard({ profile }: ProfileCardProps) {
+  const { t } = useTranslation("ui");
+  const loadProfile = useEditorStore((s) => s.loadProfile);
+  const deleteProfile = useProfileStore((s) => s.deleteProfile);
+  const [showDelete, setShowDelete] = useState(false);
+  const [showEdit, setShowEdit] = useState(false);
+
+  const handleLoad = () => {
+    loadProfile({
+      channelName: profile.channelName,
+      contactEmail: profile.contactEmail,
+      social: { ...profile.social },
+      rig: { ...profile.rig },
+      resolution: profile.resolution,
+      fps: profile.fps,
+      graphicsPreset: profile.graphicsPreset,
+    });
+  };
+
+  const socialCount = Object.values(profile.social).filter((v) => v).length;
+  const rigCount = Object.values(profile.rig).filter((v) => v).length;
+
+  return (
+    <>
+      <div className="flex items-center justify-between rounded-lg border border-border bg-surface-1 p-4">
+        <div className="flex-1">
+          <h3 className="text-sm font-semibold text-text-primary">{profile.name}</h3>
+          <p className="mt-0.5 text-xs text-text-secondary">{profile.channelName || "No channel"}</p>
+          <div className="mt-1.5 flex gap-3 text-xs text-text-muted">
+            {socialCount > 0 && <span>{socialCount} social links</span>}
+            {rigCount > 0 && <span>{rigCount} rig fields</span>}
+          </div>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Button variant="primary" size="sm" onClick={handleLoad}>
+            <Upload className="h-3.5 w-3.5" />
+            {t("profiles.loadProfile")}
+          </Button>
+          <Button variant="ghost" size="sm" onClick={() => setShowEdit(true)}>
+            <Pencil className="h-3.5 w-3.5" />
+          </Button>
+          <Button variant="ghost" size="sm" onClick={() => setShowDelete(true)}>
+            <Trash2 className="h-3.5 w-3.5 text-danger" />
+          </Button>
+        </div>
+      </div>
+
+      <ConfirmDialog
+        open={showDelete}
+        onConfirm={() => {
+          deleteProfile(profile.id);
+          setShowDelete(false);
+        }}
+        onCancel={() => setShowDelete(false)}
+        title={t("common.delete")}
+        message={t("profiles.deleteConfirm")}
+        confirmLabel={t("common.delete")}
+        variant="danger"
+      />
+
+      <ProfileSaveForm
+        open={showEdit}
+        onClose={() => setShowEdit(false)}
+        editProfile={profile}
+      />
+    </>
+  );
+}

--- a/src/components/profiles/ProfileList.tsx
+++ b/src/components/profiles/ProfileList.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Plus } from "lucide-react";
+import { Button } from "@components/ui/Button";
+import { useProfileStore } from "@store/profile-store";
+import { ProfileCard } from "./ProfileCard";
+import { ProfileSaveForm } from "./ProfileSaveForm";
+
+export function ProfileList() {
+  const { t } = useTranslation("ui");
+  const profiles = useProfileStore((s) => s.profiles);
+  const [showCreate, setShowCreate] = useState(false);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-base font-semibold text-text-primary">{t("profiles.title")}</h2>
+        <Button size="sm" onClick={() => setShowCreate(true)}>
+          <Plus className="h-4 w-4" />
+          {t("profiles.createNew")}
+        </Button>
+      </div>
+
+      {profiles.length === 0 ? (
+        <p className="rounded-lg border border-dashed border-border py-8 text-center text-sm text-text-muted">
+          {t("profiles.emptyState")}
+        </p>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {profiles.map((profile) => (
+            <ProfileCard key={profile.id} profile={profile} />
+          ))}
+        </div>
+      )}
+
+      <ProfileSaveForm open={showCreate} onClose={() => setShowCreate(false)} />
+    </div>
+  );
+}

--- a/src/components/profiles/ProfileSaveForm.tsx
+++ b/src/components/profiles/ProfileSaveForm.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Modal } from "@components/ui/Modal";
+import { Button } from "@components/ui/Button";
+import { Input } from "@components/ui/Input";
+import { useEditorStore } from "@store/editor-store";
+import { useProfileStore, type Profile } from "@store/profile-store";
+
+interface ProfileSaveFormProps {
+  open: boolean;
+  onClose: () => void;
+  editProfile?: Profile;
+}
+
+export function ProfileSaveForm({ open, onClose, editProfile }: ProfileSaveFormProps) {
+  const { t } = useTranslation("ui");
+  const editor = useEditorStore();
+  const { addProfile, updateProfile } = useProfileStore();
+
+  const [name, setName] = useState(editProfile?.name ?? "");
+
+  const handleSave = () => {
+    const data = {
+      name: name.trim() || "Unnamed Profile",
+      channelName: editProfile?.channelName ?? editor.channelName,
+      contactEmail: editProfile?.contactEmail ?? editor.contactEmail,
+      social: editProfile?.social ?? { ...editor.social },
+      rig: editProfile?.rig ?? { ...editor.rig },
+      resolution: editProfile?.resolution ?? editor.resolution,
+      fps: editProfile?.fps ?? editor.fps,
+      graphicsPreset: editProfile?.graphicsPreset ?? editor.graphicsPreset,
+    };
+
+    if (editProfile) {
+      updateProfile(editProfile.id, { ...data });
+    } else {
+      addProfile(data);
+    }
+    onClose();
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={editProfile ? t("profiles.editProfile") : t("profiles.createNew")}
+      footer={
+        <>
+          <Button variant="ghost" onClick={onClose}>
+            {t("common.cancel")}
+          </Button>
+          <Button onClick={handleSave}>{t("common.save")}</Button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        <Input
+          label={t("profiles.profileName")}
+          placeholder={t("profiles.profileNamePlaceholder")}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          autoFocus
+        />
+        <p className="text-xs text-text-muted">
+          {editProfile
+            ? "Update this profile's name. Other fields are saved from the editor."
+            : "Profile will save your current channel name, social links, rig info, and video settings."}
+        </p>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,49 @@
+import { useTranslation } from "react-i18next";
+import { Modal } from "./Modal";
+import { Button } from "./Button";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  variant?: "danger" | "default";
+}
+
+export function ConfirmDialog({
+  open,
+  onConfirm,
+  onCancel,
+  title,
+  message,
+  confirmLabel,
+  variant = "default",
+}: ConfirmDialogProps) {
+  const { t } = useTranslation("ui");
+
+  return (
+    <Modal
+      open={open}
+      onClose={onCancel}
+      title={title}
+      footer={
+        <>
+          <Button variant="ghost" onClick={onCancel}>
+            {t("common.cancel")}
+          </Button>
+          <Button
+            variant="primary"
+            onClick={onConfirm}
+            className={variant === "danger" ? "bg-danger hover:bg-danger/80" : ""}
+          >
+            {confirmLabel ?? t("common.confirm")}
+          </Button>
+        </>
+      }
+    >
+      <p className="text-sm text-text-secondary">{message}</p>
+    </Modal>
+  );
+}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useRef, type ReactNode } from "react";
+import { X } from "lucide-react";
+import clsx from "clsx";
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  children: ReactNode;
+  footer?: ReactNode;
+  className?: string;
+}
+
+export function Modal({ open, onClose, title, children, footer, className }: ModalProps) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleEsc);
+    return () => document.removeEventListener("keydown", handleEsc);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      ref={overlayRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={(e) => {
+        if (e.target === overlayRef.current) onClose();
+      }}
+    >
+      <div
+        className={clsx(
+          "mx-4 flex max-h-[85vh] w-full max-w-lg flex-col rounded-xl border border-border bg-surface-1 shadow-2xl",
+          className,
+        )}
+      >
+        {title && (
+          <div className="flex items-center justify-between border-b border-border px-5 py-4">
+            <h2 className="text-base font-semibold text-text-primary">{title}</h2>
+            <button
+              onClick={onClose}
+              className="rounded-lg p-1 text-text-muted hover:bg-surface-2 hover:text-text-primary"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        )}
+        <div className="flex-1 overflow-y-auto px-5 py-4">{children}</div>
+        {footer && (
+          <div className="flex justify-end gap-2 border-t border-border px-5 py-3">{footer}</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/config/genres.ts
+++ b/src/config/genres.ts
@@ -9,6 +9,11 @@ export const GENRES = [
   { id: "racing", labelKey: "genres.racing", icon: "🏎" },
   { id: "story", labelKey: "genres.story", icon: "📖" },
   { id: "simulation", labelKey: "genres.simulation", icon: "🏗" },
+  { id: "fighting", labelKey: "genres.fighting", icon: "🥊" },
+  { id: "stealth", labelKey: "genres.stealth", icon: "🥷" },
+  { id: "survival_craft", labelKey: "genres.survival_craft", icon: "⛏" },
+  { id: "roguelike", labelKey: "genres.roguelike", icon: "🎲" },
+  { id: "metroidvania", labelKey: "genres.metroidvania", icon: "🗺" },
 ] as const;
 
 export type GenreId = (typeof GENRES)[number]["id"];

--- a/src/config/platforms.ts
+++ b/src/config/platforms.ts
@@ -6,6 +6,8 @@ export const PLATFORMS = [
   { id: "nintendo", label: "Nintendo eShop", urlPrefix: "https://www.nintendo.com/store/" },
   { id: "gog", label: "GOG", urlPrefix: "https://www.gog.com/game/" },
   { id: "itchio", label: "itch.io", urlPrefix: "https://itch.io/" },
+  { id: "humble", label: "Humble Bundle", urlPrefix: "https://www.humblebundle.com/store/" },
+  { id: "amazon", label: "Amazon Luna", urlPrefix: "https://www.amazon.com/luna/" },
 ] as const;
 
 export type PlatformId = (typeof PLATFORMS)[number]["id"];

--- a/src/config/rig-fields.ts
+++ b/src/config/rig-fields.ts
@@ -5,6 +5,8 @@ export const RIG_FIELDS = [
   { id: "storage", labelKey: "rig.storage", placeholder: "2TB Samsung 990 PRO NVMe" },
   { id: "monitor", labelKey: "rig.monitor", placeholder: "LG 27GP950 27\" 4K 144Hz" },
   { id: "capture", labelKey: "rig.capture", placeholder: "OBS Studio 30.x" },
+  { id: "motherboard", labelKey: "rig.motherboard", placeholder: "ASUS ROG Maximus Z790 Hero" },
+  { id: "controller", labelKey: "rig.controller", placeholder: "DualSense / Xbox Elite Series 2" },
 ] as const;
 
 export type RigFieldId = (typeof RIG_FIELDS)[number]["id"];

--- a/src/config/social-fields.ts
+++ b/src/config/social-fields.ts
@@ -22,6 +22,20 @@ export const SOCIAL_FIELDS = [
   { id: "twitter", labelKey: "social.twitter", urlPrefix: "https://x.com/", category: "social" },
   { id: "discord", labelKey: "social.discord", urlPrefix: "https://discord.gg/", category: "social" },
   { id: "website", labelKey: "social.website", urlPrefix: "", category: "social" },
+  { id: "twitch", labelKey: "social.twitch", urlPrefix: "https://twitch.tv/", category: "social" },
+  { id: "tiktok", labelKey: "social.tiktok", urlPrefix: "https://tiktok.com/@", category: "social" },
+  {
+    id: "instagram",
+    labelKey: "social.instagram",
+    urlPrefix: "https://instagram.com/",
+    category: "social",
+  },
+  {
+    id: "streamlabs",
+    labelKey: "social.streamlabs",
+    urlPrefix: "https://streamlabs.com/",
+    category: "donate",
+  },
 ] as const;
 
 export type SocialFieldId = (typeof SOCIAL_FIELDS)[number]["id"];

--- a/src/config/video-types.ts
+++ b/src/config/video-types.ts
@@ -6,6 +6,11 @@ export const VIDEO_TYPES = [
   { id: "ending", labelKey: "videoTypes.ending", icon: "🏁", extraFields: [] },
   { id: "speedrun", labelKey: "videoTypes.speedrun", icon: "⚡", extraFields: [] },
   { id: "100percent", labelKey: "videoTypes.100percent", icon: "💯", extraFields: [] },
+  { id: "dlc", labelKey: "videoTypes.dlc", icon: "📦", extraFields: ["dlcName"] },
+  { id: "newgame_plus", labelKey: "videoTypes.newgame_plus", icon: "🔄", extraFields: [] },
+  { id: "challenge", labelKey: "videoTypes.challenge", icon: "🏆", extraFields: ["challengeName"] },
+  { id: "side_quest", labelKey: "videoTypes.side_quest", icon: "📌", extraFields: [] },
+  { id: "secret", labelKey: "videoTypes.secret", icon: "🔍", extraFields: [] },
 ] as const;
 
 export type VideoTypeId = (typeof VIDEO_TYPES)[number]["id"];

--- a/src/engine/tag-generator.ts
+++ b/src/engine/tag-generator.ts
@@ -12,6 +12,11 @@ const GENRE_TAG_REGISTRY: Record<string, (gameName: string) => string[]> = {
   racing: (g) => [`${g} racing`, "racing game no commentary", "racing gameplay"],
   story: (g) => [`${g} story`, "story game no commentary", "narrative gameplay"],
   simulation: (g) => [`${g} simulation`, "simulation game no commentary", "strategy gameplay"],
+  fighting: (g) => [`${g} fighting`, "fighting game no commentary", "combo gameplay"],
+  stealth: (g) => [`${g} stealth`, "stealth game no commentary", "stealth gameplay"],
+  survival_craft: (g) => [`${g} survival`, "survival crafting no commentary", "base building"],
+  roguelike: (g) => [`${g} roguelike`, "roguelike no commentary", "roguelite gameplay"],
+  metroidvania: (g) => [`${g} metroidvania`, "metroidvania no commentary", "exploration gameplay"],
 };
 
 const VIDEO_TYPE_TAGS: Record<string, (gameName: string) => string[]> = {
@@ -22,6 +27,11 @@ const VIDEO_TYPE_TAGS: Record<string, (gameName: string) => string[]> = {
   ending: (g) => [`${g} ending`, `${g} all endings`, `${g} final boss`],
   speedrun: (g) => [`${g} speedrun`, "speedrun no commentary", `${g} speed run`],
   "100percent": (g) => [`${g} 100%`, `${g} 100 percent`, `${g} completionist`],
+  dlc: (g) => [`${g} DLC`, `${g} DLC gameplay`, "DLC no commentary"],
+  newgame_plus: (g) => [`${g} new game plus`, `${g} NG+`, "new game plus no commentary"],
+  challenge: (g) => [`${g} challenge`, `${g} challenge run`, "challenge no commentary"],
+  side_quest: (g) => [`${g} side quest`, `${g} optional content`, "side quest no commentary"],
+  secret: (g) => [`${g} secret`, `${g} hidden`, "secret content no commentary"],
 };
 
 const MULTILINGUAL_TAGS: Record<string, (gameName: string) => string[]> = {

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -5,7 +5,12 @@ export type VideoType =
   | "boss_nohit"
   | "ending"
   | "speedrun"
-  | "100percent";
+  | "100percent"
+  | "dlc"
+  | "newgame_plus"
+  | "challenge"
+  | "side_quest"
+  | "secret";
 
 export type Genre =
   | "action"
@@ -17,7 +22,12 @@ export type Genre =
   | "soulslike"
   | "racing"
   | "story"
-  | "simulation";
+  | "simulation"
+  | "fighting"
+  | "stealth"
+  | "survival_craft"
+  | "roguelike"
+  | "metroidvania";
 
 export type SupportedLanguage = "en" | "vi" | "ja";
 

--- a/src/i18n/locales/_schema.json
+++ b/src/i18n/locales/_schema.json
@@ -1,7 +1,7 @@
 {
   "ui": {
     "app": ["title", "subtitle"],
-    "tabs": ["editor", "output"],
+    "tabs": ["editor", "output", "profiles"],
     "editor": [
       "videoType", "language", "genre", "gameName", "gameNamePlaceholder",
       "channelName", "channelNamePlaceholder", "platform",
@@ -13,7 +13,8 @@
       "spoilerWarning", "matureWarning",
       "playlistLink", "playlistLinkPlaceholder",
       "contactEmail", "contactEmailPlaceholder",
-      "videoSettings", "quickPreview"
+      "videoSettings", "quickPreview",
+      "clearDraft", "draftSaved", "clearDraftConfirm"
     ],
     "output": [
       "title", "description", "tags",
@@ -21,17 +22,19 @@
       "copied", "charCount"
     ],
     "common": ["save", "cancel", "delete", "confirm", "export", "import", "reset", "search", "generate"],
-    "videoTypes": ["full", "part", "boss", "boss_nohit", "ending", "speedrun", "100percent"],
-    "genres": ["action", "horror", "rpg", "fps", "openworld", "indie", "soulslike", "racing", "story", "simulation"],
-    "rig": ["cpu", "gpu", "ram", "storage", "monitor", "capture"],
-    "social": ["kofi", "patreon", "buymeacoffee", "paypal", "github", "twitter", "discord", "website"],
+    "videoTypes": ["full", "part", "boss", "boss_nohit", "ending", "speedrun", "100percent", "dlc", "newgame_plus", "challenge", "side_quest", "secret"],
+    "genres": ["action", "horror", "rpg", "fps", "openworld", "indie", "soulslike", "racing", "story", "simulation", "fighting", "stealth", "survival_craft", "roguelike", "metroidvania"],
+    "rig": ["cpu", "gpu", "ram", "storage", "monitor", "capture", "motherboard", "controller"],
+    "social": ["kofi", "patreon", "buymeacoffee", "paypal", "github", "twitter", "discord", "website", "twitch", "tiktok", "instagram", "streamlabs"],
     "resolutions": ["720p", "1080p", "1440p", "4K"],
-    "fpsOptions": ["30", "60", "120", "144"]
+    "fpsOptions": ["30", "60", "120", "144"],
+    "profiles": ["title", "createNew", "editProfile", "profileName", "profileNamePlaceholder", "loadProfile", "deleteConfirm", "emptyState", "exportProfiles", "importProfiles"],
+    "presets": ["title", "createNew", "editPreset", "loadPreset", "deleteConfirm", "emptyState", "selectPreset", "noPresets", "exportPresets", "importPresets"]
   },
   "templates": {
     "title": ["separator", "suffix"],
-    "title.videoType": ["full", "part", "boss", "boss_nohit", "ending", "speedrun", "100percent"],
-    "description.intro": ["full", "part", "boss", "boss_nohit", "ending", "speedrun", "100percent"],
+    "title.videoType": ["full", "part", "boss", "boss_nohit", "ending", "speedrun", "100percent", "dlc", "newgame_plus", "challenge", "side_quest", "secret"],
+    "description.intro": ["full", "part", "boss", "boss_nohit", "ending", "speedrun", "100percent", "dlc", "newgame_plus", "challenge", "side_quest", "secret"],
     "description": ["noCommentaryLine"],
     "description.sections": [
       "timestamps", "storeLinks", "videoSettings", "rig",

--- a/src/i18n/locales/en/templates.json
+++ b/src/i18n/locales/en/templates.json
@@ -9,7 +9,12 @@
       "boss_nohit": "{{bossName}} Boss No Hit",
       "ending": "Ending",
       "speedrun": "Speedrun",
-      "100percent": "100% Completion"
+      "100percent": "100% Completion",
+      "dlc": "{{dlcName}} DLC",
+      "newgame_plus": "New Game+",
+      "challenge": "{{challengeName}} Challenge",
+      "side_quest": "Side Quest",
+      "secret": "Secret"
     }
   },
   "description": {
@@ -20,7 +25,12 @@
       "boss_nohit": "This video features the {{bossName}} boss fight (No Hit) from {{gameName}} on {{channelName}}.",
       "ending": "This video features the ending of {{gameName}} on {{channelName}}.",
       "speedrun": "This video features a speedrun of {{gameName}} on {{channelName}}.",
-      "100percent": "This video features the 100% completion of {{gameName}} on {{channelName}}."
+      "100percent": "This video features the 100% completion of {{gameName}} on {{channelName}}.",
+      "dlc": "This video features the {{dlcName}} DLC for {{gameName}} on {{channelName}}.",
+      "newgame_plus": "This video features the New Game+ playthrough of {{gameName}} on {{channelName}}.",
+      "challenge": "This video features the {{challengeName}} challenge of {{gameName}} on {{channelName}}.",
+      "side_quest": "This video features side quests and optional content from {{gameName}} on {{channelName}}.",
+      "secret": "This video features secrets and hidden content from {{gameName}} on {{channelName}}."
     },
     "noCommentaryLine": "No Commentary — pure gameplay for your enjoyment.",
     "sections": {

--- a/src/i18n/locales/en/ui.json
+++ b/src/i18n/locales/en/ui.json
@@ -5,7 +5,8 @@
   },
   "tabs": {
     "editor": "Editor",
-    "output": "Output"
+    "output": "Output",
+    "profiles": "Profiles"
   },
   "editor": {
     "videoType": "Video Type",
@@ -40,7 +41,10 @@
     "contactEmail": "Contact Email",
     "contactEmailPlaceholder": "business@example.com",
     "videoSettings": "Video Settings",
-    "quickPreview": "Quick Preview"
+    "quickPreview": "Quick Preview",
+    "clearDraft": "Clear Draft",
+    "draftSaved": "Draft saved",
+    "clearDraftConfirm": "Are you sure you want to clear all form data?"
   },
   "output": {
     "title": "Title",
@@ -71,7 +75,12 @@
     "boss_nohit": "Boss No Hit",
     "ending": "Ending / All Endings",
     "speedrun": "Speedrun",
-    "100percent": "100% Completion"
+    "100percent": "100% Completion",
+    "dlc": "DLC Content",
+    "newgame_plus": "New Game+",
+    "challenge": "Challenge Run",
+    "side_quest": "Side Quests",
+    "secret": "Secrets / Hidden"
   },
   "genres": {
     "action": "Action / Adventure",
@@ -83,7 +92,12 @@
     "soulslike": "Souls-like",
     "racing": "Racing / Sports",
     "story": "Story / Visual Novel",
-    "simulation": "Simulation / Strategy"
+    "simulation": "Simulation / Strategy",
+    "fighting": "Fighting",
+    "stealth": "Stealth / Espionage",
+    "survival_craft": "Survival / Crafting",
+    "roguelike": "Roguelike / Roguelite",
+    "metroidvania": "Metroidvania"
   },
   "rig": {
     "cpu": "CPU",
@@ -91,7 +105,9 @@
     "ram": "RAM",
     "storage": "Storage",
     "monitor": "Monitor",
-    "capture": "Capture Software"
+    "capture": "Capture Software",
+    "motherboard": "Motherboard",
+    "controller": "Controller"
   },
   "social": {
     "kofi": "Ko-fi",
@@ -101,7 +117,11 @@
     "github": "GitHub",
     "twitter": "Twitter / X",
     "discord": "Discord",
-    "website": "Website"
+    "website": "Website",
+    "twitch": "Twitch",
+    "tiktok": "TikTok",
+    "instagram": "Instagram",
+    "streamlabs": "Streamlabs"
   },
   "resolutions": {
     "720p": "720p",
@@ -114,5 +134,29 @@
     "60": "60 FPS",
     "120": "120 FPS",
     "144": "144 FPS"
+  },
+  "profiles": {
+    "title": "Profiles",
+    "createNew": "Create Profile",
+    "editProfile": "Edit Profile",
+    "profileName": "Profile Name",
+    "profileNamePlaceholder": "e.g. Main Channel",
+    "loadProfile": "Load",
+    "deleteConfirm": "Are you sure you want to delete this profile?",
+    "emptyState": "No profiles yet. Create one to save your channel info.",
+    "exportProfiles": "Export Profiles",
+    "importProfiles": "Import Profiles"
+  },
+  "presets": {
+    "title": "Game Presets",
+    "createNew": "Create Preset",
+    "editPreset": "Edit Preset",
+    "loadPreset": "Load",
+    "deleteConfirm": "Are you sure you want to delete this preset?",
+    "emptyState": "No game presets yet. Create one to save game info for reuse.",
+    "selectPreset": "Load Game Preset",
+    "noPresets": "No presets",
+    "exportPresets": "Export Presets",
+    "importPresets": "Import Presets"
   }
 }

--- a/src/i18n/locales/ja/templates.json
+++ b/src/i18n/locales/ja/templates.json
@@ -9,7 +9,12 @@
       "boss_nohit": "{{bossName}} ボス ノーヒット",
       "ending": "エンディング",
       "speedrun": "スピードラン",
-      "100percent": "100%クリア"
+      "100percent": "100%クリア",
+      "dlc": "{{dlcName}} DLC",
+      "newgame_plus": "強くてニューゲーム",
+      "challenge": "{{challengeName}} チャレンジ",
+      "side_quest": "サブクエスト",
+      "secret": "隠し要素"
     }
   },
   "description": {
@@ -20,7 +25,12 @@
       "boss_nohit": "この動画は{{channelName}}による{{gameName}}の{{bossName}}ボス戦（ノーヒット）です。",
       "ending": "この動画は{{channelName}}による{{gameName}}のエンディングです。",
       "speedrun": "この動画は{{channelName}}による{{gameName}}のスピードランです。",
-      "100percent": "この動画は{{channelName}}による{{gameName}}の100%クリアです。"
+      "100percent": "この動画は{{channelName}}による{{gameName}}の100%クリアです。",
+      "dlc": "この動画は{{channelName}}による{{gameName}}の{{dlcName}} DLCです。",
+      "newgame_plus": "この動画は{{channelName}}による{{gameName}}の強くてニューゲームです。",
+      "challenge": "この動画は{{channelName}}による{{gameName}}の{{challengeName}}チャレンジです。",
+      "side_quest": "この動画は{{channelName}}による{{gameName}}のサブクエストです。",
+      "secret": "この動画は{{channelName}}による{{gameName}}の隠し要素です。"
     },
     "noCommentaryLine": "実況なし — 純粋なゲームプレイをお楽しみください。",
     "sections": {

--- a/src/i18n/locales/ja/ui.json
+++ b/src/i18n/locales/ja/ui.json
@@ -5,7 +5,8 @@
   },
   "tabs": {
     "editor": "エディター",
-    "output": "出力"
+    "output": "出力",
+    "profiles": "プロフィール"
   },
   "editor": {
     "videoType": "動画タイプ",
@@ -40,7 +41,10 @@
     "contactEmail": "連絡先メール",
     "contactEmailPlaceholder": "business@example.com",
     "videoSettings": "動画設定",
-    "quickPreview": "クイックプレビュー"
+    "quickPreview": "クイックプレビュー",
+    "clearDraft": "下書きをクリア",
+    "draftSaved": "下書き保存済み",
+    "clearDraftConfirm": "フォームデータをすべてクリアしますか？"
   },
   "output": {
     "title": "タイトル",
@@ -71,7 +75,12 @@
     "boss_nohit": "ボス ノーヒット",
     "ending": "エンディング",
     "speedrun": "スピードラン",
-    "100percent": "100%クリア"
+    "100percent": "100%クリア",
+    "dlc": "DLCコンテンツ",
+    "newgame_plus": "強くてニューゲーム",
+    "challenge": "チャレンジラン",
+    "side_quest": "サブクエスト",
+    "secret": "隠し要素"
   },
   "genres": {
     "action": "アクション / アドベンチャー",
@@ -83,7 +92,12 @@
     "soulslike": "ソウルライク",
     "racing": "レーシング / スポーツ",
     "story": "ストーリー / ビジュアルノベル",
-    "simulation": "シミュレーション / ストラテジー"
+    "simulation": "シミュレーション / ストラテジー",
+    "fighting": "格闘ゲーム",
+    "stealth": "ステルス / スパイ",
+    "survival_craft": "サバイバル / クラフト",
+    "roguelike": "ローグライク / ローグライト",
+    "metroidvania": "メトロイドヴァニア"
   },
   "rig": {
     "cpu": "CPU",
@@ -91,7 +105,9 @@
     "ram": "RAM",
     "storage": "ストレージ",
     "monitor": "モニター",
-    "capture": "キャプチャソフト"
+    "capture": "キャプチャソフト",
+    "motherboard": "マザーボード",
+    "controller": "コントローラー"
   },
   "social": {
     "kofi": "Ko-fi",
@@ -101,7 +117,11 @@
     "github": "GitHub",
     "twitter": "Twitter / X",
     "discord": "Discord",
-    "website": "ウェブサイト"
+    "website": "ウェブサイト",
+    "twitch": "Twitch",
+    "tiktok": "TikTok",
+    "instagram": "Instagram",
+    "streamlabs": "Streamlabs"
   },
   "resolutions": {
     "720p": "720p",
@@ -114,5 +134,29 @@
     "60": "60 FPS",
     "120": "120 FPS",
     "144": "144 FPS"
+  },
+  "profiles": {
+    "title": "プロフィール",
+    "createNew": "プロフィール作成",
+    "editProfile": "プロフィール編集",
+    "profileName": "プロフィール名",
+    "profileNamePlaceholder": "例：メインチャンネル",
+    "loadProfile": "読み込む",
+    "deleteConfirm": "このプロフィールを削除しますか？",
+    "emptyState": "プロフィールがありません。チャンネル情報を保存するために作成してください。",
+    "exportProfiles": "プロフィールをエクスポート",
+    "importProfiles": "プロフィールをインポート"
+  },
+  "presets": {
+    "title": "ゲームプリセット",
+    "createNew": "プリセット作成",
+    "editPreset": "プリセット編集",
+    "loadPreset": "読み込む",
+    "deleteConfirm": "このプリセットを削除しますか？",
+    "emptyState": "プリセットがありません。ゲーム情報を保存するために作成してください。",
+    "selectPreset": "ゲームプリセットを選択",
+    "noPresets": "プリセットなし",
+    "exportPresets": "プリセットをエクスポート",
+    "importPresets": "プリセットをインポート"
   }
 }

--- a/src/i18n/locales/vi/templates.json
+++ b/src/i18n/locales/vi/templates.json
@@ -9,7 +9,12 @@
       "boss_nohit": "{{bossName}} Boss No Hit",
       "ending": "Kết thúc",
       "speedrun": "Speedrun",
-      "100percent": "100% Completion"
+      "100percent": "100% Completion",
+      "dlc": "{{dlcName}} DLC",
+      "newgame_plus": "New Game+",
+      "challenge": "{{challengeName}} Challenge",
+      "side_quest": "Nhiệm vụ phụ",
+      "secret": "Bí mật"
     }
   },
   "description": {
@@ -20,7 +25,12 @@
       "boss_nohit": "Video này là trận đánh boss {{bossName}} (No Hit) trong {{gameName}} trên kênh {{channelName}}.",
       "ending": "Video này là phần kết thúc của {{gameName}} trên kênh {{channelName}}.",
       "speedrun": "Video này là speedrun của {{gameName}} trên kênh {{channelName}}.",
-      "100percent": "Video này là 100% completion của {{gameName}} trên kênh {{channelName}}."
+      "100percent": "Video này là 100% completion của {{gameName}} trên kênh {{channelName}}.",
+      "dlc": "Video này là DLC {{dlcName}} của {{gameName}} trên kênh {{channelName}}.",
+      "newgame_plus": "Video này là New Game+ của {{gameName}} trên kênh {{channelName}}.",
+      "challenge": "Video này là thử thách {{challengeName}} của {{gameName}} trên kênh {{channelName}}.",
+      "side_quest": "Video này là các nhiệm vụ phụ trong {{gameName}} trên kênh {{channelName}}.",
+      "secret": "Video này là nội dung bí mật và ẩn trong {{gameName}} trên kênh {{channelName}}."
     },
     "noCommentaryLine": "Không bình luận — gameplay thuần túy để bạn thưởng thức.",
     "sections": {

--- a/src/i18n/locales/vi/ui.json
+++ b/src/i18n/locales/vi/ui.json
@@ -5,7 +5,8 @@
   },
   "tabs": {
     "editor": "Chỉnh sửa",
-    "output": "Kết quả"
+    "output": "Kết quả",
+    "profiles": "Hồ sơ"
   },
   "editor": {
     "videoType": "Loại Video",
@@ -40,7 +41,10 @@
     "contactEmail": "Email liên hệ",
     "contactEmailPlaceholder": "business@example.com",
     "videoSettings": "Cài đặt Video",
-    "quickPreview": "Xem trước nhanh"
+    "quickPreview": "Xem trước nhanh",
+    "clearDraft": "Xóa bản nháp",
+    "draftSaved": "Đã lưu nháp",
+    "clearDraftConfirm": "Bạn có chắc muốn xóa toàn bộ dữ liệu form?"
   },
   "output": {
     "title": "Tiêu đề",
@@ -71,7 +75,12 @@
     "boss_nohit": "Boss No Hit",
     "ending": "Kết thúc",
     "speedrun": "Speedrun",
-    "100percent": "100% Completion"
+    "100percent": "100% Completion",
+    "dlc": "Nội dung DLC",
+    "newgame_plus": "New Game+",
+    "challenge": "Challenge Run",
+    "side_quest": "Nhiệm vụ phụ",
+    "secret": "Bí mật / Ẩn"
   },
   "genres": {
     "action": "Hành động / Phiêu lưu",
@@ -83,7 +92,12 @@
     "soulslike": "Souls-like",
     "racing": "Đua xe / Thể thao",
     "story": "Cốt truyện / Visual Novel",
-    "simulation": "Mô phỏng / Chiến thuật"
+    "simulation": "Mô phỏng / Chiến thuật",
+    "fighting": "Đối kháng",
+    "stealth": "Hành động lén",
+    "survival_craft": "Sinh tồn / Chế tạo",
+    "roguelike": "Roguelike / Roguelite",
+    "metroidvania": "Metroidvania"
   },
   "rig": {
     "cpu": "CPU",
@@ -91,7 +105,9 @@
     "ram": "RAM",
     "storage": "Ổ cứng",
     "monitor": "Màn hình",
-    "capture": "Phần mềm quay"
+    "capture": "Phần mềm quay",
+    "motherboard": "Bo mạch chủ",
+    "controller": "Tay cầm"
   },
   "social": {
     "kofi": "Ko-fi",
@@ -101,7 +117,11 @@
     "github": "GitHub",
     "twitter": "Twitter / X",
     "discord": "Discord",
-    "website": "Website"
+    "website": "Website",
+    "twitch": "Twitch",
+    "tiktok": "TikTok",
+    "instagram": "Instagram",
+    "streamlabs": "Streamlabs"
   },
   "resolutions": {
     "720p": "720p",
@@ -114,5 +134,29 @@
     "60": "60 FPS",
     "120": "120 FPS",
     "144": "144 FPS"
+  },
+  "profiles": {
+    "title": "Hồ sơ",
+    "createNew": "Tạo hồ sơ",
+    "editProfile": "Sửa hồ sơ",
+    "profileName": "Tên hồ sơ",
+    "profileNamePlaceholder": "VD: Kênh chính",
+    "loadProfile": "Tải",
+    "deleteConfirm": "Bạn có chắc muốn xóa hồ sơ này?",
+    "emptyState": "Chưa có hồ sơ. Tạo một hồ sơ để lưu thông tin kênh.",
+    "exportProfiles": "Xuất hồ sơ",
+    "importProfiles": "Nhập hồ sơ"
+  },
+  "presets": {
+    "title": "Cài đặt Game",
+    "createNew": "Tạo preset",
+    "editPreset": "Sửa preset",
+    "loadPreset": "Tải",
+    "deleteConfirm": "Bạn có chắc muốn xóa preset này?",
+    "emptyState": "Chưa có preset. Tạo một preset để lưu thông tin game.",
+    "selectPreset": "Chọn Game Preset",
+    "noPresets": "Chưa có preset",
+    "exportPresets": "Xuất presets",
+    "importPresets": "Nhập presets"
   }
 }

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -9,24 +9,50 @@ import { RigEditor } from "@components/editor/RigEditor";
 import { SocialEditor } from "@components/editor/SocialEditor";
 import { WarningToggles } from "@components/editor/WarningToggles";
 import { QuickPreview } from "@components/editor/QuickPreview";
+import { DraftIndicator } from "@components/editor/DraftIndicator";
+import { PresetSelector } from "@components/presets/PresetSelector";
 import { Input } from "@components/ui/Input";
+import { Button } from "@components/ui/Button";
+import { ConfirmDialog } from "@components/ui/ConfirmDialog";
 import { useEditorStore } from "@store/editor-store";
 import { useTranslation } from "react-i18next";
+import { RotateCcw } from "lucide-react";
+import { useState } from "react";
 
 export function EditorPage() {
   const { t } = useTranslation("ui");
   const store = useEditorStore();
+  const [showClearDraft, setShowClearDraft] = useState(false);
 
   return (
     <div className="mx-auto flex max-w-6xl gap-6 p-6">
       {/* Form */}
       <div className="flex flex-1 flex-col gap-6">
+        <div className="flex items-center justify-between">
+          <DraftIndicator />
+          <Button variant="ghost" size="sm" onClick={() => setShowClearDraft(true)}>
+            <RotateCcw className="h-3.5 w-3.5" />
+            {t("editor.clearDraft")}
+          </Button>
+        </div>
+        <ConfirmDialog
+          open={showClearDraft}
+          onConfirm={() => {
+            store.reset();
+            setShowClearDraft(false);
+          }}
+          onCancel={() => setShowClearDraft(false)}
+          title={t("editor.clearDraft")}
+          message={t("editor.clearDraftConfirm")}
+          variant="danger"
+        />
         <VideoTypeSelector />
         <div className="grid grid-cols-2 gap-4">
           <LanguageSelector />
           <div />
         </div>
         <GenreSelector />
+        <PresetSelector />
         <GameInfoForm />
         <VideoSettingsForm />
         <TimestampEditor />

--- a/src/pages/ProfilesPage.tsx
+++ b/src/pages/ProfilesPage.tsx
@@ -1,0 +1,102 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Download, Upload } from "lucide-react";
+import { Button } from "@components/ui/Button";
+import { ProfileList } from "@components/profiles/ProfileList";
+import { PresetList } from "@components/presets/PresetList";
+import { useProfileStore, type Profile } from "@store/profile-store";
+import { usePresetStore, type GamePreset } from "@store/preset-store";
+import { exportToJsonFile, importFromJsonFile } from "@utils/import-export";
+import toast from "react-hot-toast";
+import clsx from "clsx";
+
+type Tab = "profiles" | "presets";
+
+export function ProfilesPage() {
+  const { t } = useTranslation("ui");
+  const [tab, setTab] = useState<Tab>("profiles");
+  const { profiles, importProfiles } = useProfileStore();
+  const { presets, importPresets } = usePresetStore();
+
+  const handleExportProfiles = () => {
+    exportToJsonFile(profiles, "ytdescgen-profiles.json");
+    toast.success("Exported!");
+  };
+
+  const handleImportProfiles = async () => {
+    try {
+      const data = await importFromJsonFile<Profile[]>();
+      if (!Array.isArray(data)) throw new Error("Invalid format");
+      importProfiles(data);
+      toast.success("Imported!");
+    } catch {
+      toast.error("Import failed");
+    }
+  };
+
+  const handleExportPresets = () => {
+    exportToJsonFile(presets, "ytdescgen-presets.json");
+    toast.success("Exported!");
+  };
+
+  const handleImportPresets = async () => {
+    try {
+      const data = await importFromJsonFile<GamePreset[]>();
+      if (!Array.isArray(data)) throw new Error("Invalid format");
+      importPresets(data);
+      toast.success("Imported!");
+    } catch {
+      toast.error("Import failed");
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      <div className="mb-6 flex items-center justify-between">
+        <div className="flex gap-1 rounded-lg bg-surface-1 p-1">
+          {(["profiles", "presets"] as const).map((t2) => (
+            <button
+              key={t2}
+              onClick={() => setTab(t2)}
+              className={clsx(
+                "rounded-md px-4 py-1.5 text-sm font-medium transition-colors",
+                tab === t2
+                  ? "bg-accent text-white"
+                  : "text-text-muted hover:text-text-primary",
+              )}
+            >
+              {t(`${t2}.title`)}
+            </button>
+          ))}
+        </div>
+        <div className="flex gap-2">
+          {tab === "profiles" ? (
+            <>
+              <Button variant="ghost" size="sm" onClick={handleExportProfiles}>
+                <Download className="h-3.5 w-3.5" />
+                {t("profiles.exportProfiles")}
+              </Button>
+              <Button variant="ghost" size="sm" onClick={handleImportProfiles}>
+                <Upload className="h-3.5 w-3.5" />
+                {t("profiles.importProfiles")}
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button variant="ghost" size="sm" onClick={handleExportPresets}>
+                <Download className="h-3.5 w-3.5" />
+                {t("presets.exportPresets")}
+              </Button>
+              <Button variant="ghost" size="sm" onClick={handleImportPresets}>
+                <Upload className="h-3.5 w-3.5" />
+                {t("presets.importPresets")}
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {tab === "profiles" ? <ProfileList /> : <PresetList />}
+    </div>
+  );
+}

--- a/src/store/preset-store.ts
+++ b/src/store/preset-store.ts
@@ -1,0 +1,67 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import { generateId } from "@utils/uuid";
+import type { Genre } from "@engine/types";
+
+export interface GamePreset {
+  id: string;
+  gameName: string;
+  gameNameLocalized?: Record<string, string>;
+  genre: Genre;
+  platform: string;
+  storeLinks: Record<string, string>;
+  spoilerWarning: boolean;
+  matureWarning: boolean;
+  createdAt: string;
+}
+
+interface PresetState {
+  presets: GamePreset[];
+  addPreset: (data: Omit<GamePreset, "id" | "createdAt">) => string;
+  updatePreset: (id: string, data: Partial<Omit<GamePreset, "id" | "createdAt">>) => void;
+  deletePreset: (id: string) => void;
+  getPreset: (id: string) => GamePreset | undefined;
+  importPresets: (presets: GamePreset[]) => void;
+}
+
+export const usePresetStore = create<PresetState>()(
+  persist(
+    (set, get) => ({
+      presets: [],
+
+      addPreset: (data) => {
+        const id = generateId();
+        const preset: GamePreset = { ...data, id, createdAt: new Date().toISOString() };
+        set((state) => ({ presets: [...state.presets, preset] }));
+        return id;
+      },
+
+      updatePreset: (id, data) => {
+        set((state) => ({
+          presets: state.presets.map((p) => (p.id === id ? { ...p, ...data } : p)),
+        }));
+      },
+
+      deletePreset: (id) => {
+        set((state) => ({ presets: state.presets.filter((p) => p.id !== id) }));
+      },
+
+      getPreset: (id) => {
+        return get().presets.find((p) => p.id === id);
+      },
+
+      importPresets: (presets) => {
+        set((state) => {
+          const existingIds = new Set(state.presets.map((p) => p.id));
+          const newPresets = presets.filter((p) => !existingIds.has(p.id));
+          return { presets: [...state.presets, ...newPresets] };
+        });
+      },
+    }),
+    {
+      name: "ytdescgen-presets",
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({ presets: state.presets }),
+    },
+  ),
+);

--- a/src/store/profile-store.ts
+++ b/src/store/profile-store.ts
@@ -1,0 +1,71 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import { generateId } from "@utils/uuid";
+
+export interface Profile {
+  id: string;
+  name: string;
+  channelName: string;
+  contactEmail: string;
+  social: Record<string, string>;
+  rig: Record<string, string>;
+  resolution: string;
+  fps: string;
+  graphicsPreset: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ProfileState {
+  profiles: Profile[];
+  addProfile: (data: Omit<Profile, "id" | "createdAt" | "updatedAt">) => string;
+  updateProfile: (id: string, data: Partial<Omit<Profile, "id" | "createdAt" | "updatedAt">>) => void;
+  deleteProfile: (id: string) => void;
+  getProfile: (id: string) => Profile | undefined;
+  importProfiles: (profiles: Profile[]) => void;
+}
+
+export const useProfileStore = create<ProfileState>()(
+  persist(
+    (set, get) => ({
+      profiles: [],
+
+      addProfile: (data) => {
+        const id = generateId();
+        const now = new Date().toISOString();
+        const profile: Profile = { ...data, id, createdAt: now, updatedAt: now };
+        set((state) => ({ profiles: [...state.profiles, profile] }));
+        return id;
+      },
+
+      updateProfile: (id, data) => {
+        set((state) => ({
+          profiles: state.profiles.map((p) =>
+            p.id === id ? { ...p, ...data, updatedAt: new Date().toISOString() } : p,
+          ),
+        }));
+      },
+
+      deleteProfile: (id) => {
+        set((state) => ({ profiles: state.profiles.filter((p) => p.id !== id) }));
+      },
+
+      getProfile: (id) => {
+        return get().profiles.find((p) => p.id === id);
+      },
+
+      importProfiles: (profiles) => {
+        set((state) => {
+          const existingIds = new Set(state.profiles.map((p) => p.id));
+          const newProfiles = profiles.filter((p) => !existingIds.has(p.id));
+          return { profiles: [...state.profiles, ...newProfiles] };
+        });
+      },
+    }),
+    {
+      name: "ytdescgen-profiles",
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({ profiles: state.profiles }),
+    },
+  ),
+);

--- a/src/utils/import-export.ts
+++ b/src/utils/import-export.ts
@@ -1,0 +1,37 @@
+export function exportToJsonFile(data: unknown, filename: string): void {
+  const json = JSON.stringify(data, null, 2);
+  const blob = new Blob([json], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export function importFromJsonFile<T>(): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = ".json";
+    input.onchange = () => {
+      const file = input.files?.[0];
+      if (!file) {
+        reject(new Error("No file selected"));
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = () => {
+        try {
+          const data = JSON.parse(reader.result as string) as T;
+          resolve(data);
+        } catch {
+          reject(new Error("Invalid JSON file"));
+        }
+      };
+      reader.onerror = () => reject(new Error("Failed to read file"));
+      reader.readAsText(file);
+    };
+    input.click();
+  });
+}

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,0 +1,3 @@
+export function generateId(): string {
+  return crypto.randomUUID();
+}


### PR DESCRIPTION
## Summary
- Profile system: save/load channel identity (social, rig, video settings)
- Game preset system: save/load game config (name, genre, platform, store links)
- ProfilesPage with tab-based management + JSON import/export
- Expanded: 12 video types, 15 genres, 12 social, 8 rig, 9 platforms
- Modal + ConfirmDialog UI primitives, DraftIndicator, Clear draft button
- i18n: 134 UI keys + 41 template keys validated across EN/VI/JA

## Test plan
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm run test:run` — 42/42 tests pass
- [x] `npm run validate:locales` — all 3 languages complete (134 UI + 41 template keys)
- [x] `npm run build` — ~316KB JS (under 500KB limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)