### PR TITLE
fix: output language sync, card UI, settings file ops, data health check

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useEffect } from "react";
 import { HashRouter, Routes, Route } from "react-router-dom";
 import { Toaster } from "react-hot-toast";
+import toast from "react-hot-toast";
 import { AppShell } from "@components/layout/AppShell";
 import { EditorPage } from "@pages/EditorPage";
 import { OutputPage } from "@pages/OutputPage";
+import { checkDataFileHealth } from "@utils/storage-adapter";
 import "@i18n/index";
 
 const ProfilesPage = lazy(() =>
@@ -27,6 +29,12 @@ function PageLoader() {
 }
 
 export default function App() {
+  useEffect(() => {
+    checkDataFileHealth().then((msg) => {
+      if (msg) toast(msg, { icon: "⚠️", duration: 5000 });
+    });
+  }, []);
+
   return (
     <>
       <HashRouter>

--- a/src/components/history/HistoryCard.tsx
+++ b/src/components/history/HistoryCard.tsx
@@ -19,7 +19,7 @@ export function HistoryCard({ entry }: HistoryCardProps) {
   const date = new Date(entry.createdAt).toLocaleDateString();
 
   return (
-    <div className="rounded-lg border border-border bg-surface-1">
+    <div className="rounded-lg border border-border-strong bg-surface-2 shadow-md shadow-black/10 transition-colors hover:border-accent/30">
       <div
         className="flex cursor-pointer items-center justify-between p-3"
         onClick={() => setExpanded(!expanded)}

--- a/src/components/presets/PresetCard.tsx
+++ b/src/components/presets/PresetCard.tsx
@@ -35,7 +35,7 @@ export function PresetCard({ preset }: PresetCardProps) {
 
   return (
     <>
-      <div className="flex items-center justify-between rounded-lg border border-border bg-surface-1 p-4">
+      <div className="flex items-center justify-between rounded-lg border border-border-strong bg-surface-2 p-4 shadow-md shadow-black/10 transition-colors hover:border-accent/30">
         <div className="flex-1">
           <h3 className="text-sm font-semibold text-text-primary">{preset.gameName}</h3>
           <div className="mt-1.5 flex items-center gap-2 text-xs text-text-muted">

--- a/src/components/profiles/ProfileCard.tsx
+++ b/src/components/profiles/ProfileCard.tsx
@@ -35,7 +35,7 @@ export function ProfileCard({ profile }: ProfileCardProps) {
 
   return (
     <>
-      <div className="flex items-center justify-between rounded-lg border border-border bg-surface-1 p-4">
+      <div className="flex items-center justify-between rounded-lg border border-border-strong bg-surface-2 p-4 shadow-md shadow-black/10 transition-colors hover:border-accent/30">
         <div className="flex-1">
           <h3 className="text-sm font-semibold text-text-primary">{profile.name}</h3>
           <p className="mt-0.5 text-xs text-text-secondary">{profile.channelName || "No channel"}</p>

--- a/src/hooks/use-generated-output.ts
+++ b/src/hooks/use-generated-output.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useTranslation } from "react-i18next";
+import i18n from "i18next";
 import { useEditorStore } from "@store/editor-store";
 import { useSettingsStore } from "@store/settings-store";
 import { renderAll } from "@engine/template-renderer";
@@ -8,7 +8,6 @@ import type { GeneratorOutput, GeneratorInput } from "@engine/types";
 export function useGeneratedOutput(): GeneratorOutput {
   const state = useEditorStore();
   const { includeMultilingualTags, includeTrendingTags, hashtagCount } = useSettingsStore();
-  const { t } = useTranslation("templates");
 
   const input: GeneratorInput = useMemo(
     () => ({
@@ -60,6 +59,8 @@ export function useGeneratedOutput(): GeneratorOutput {
       state.rig,
     ],
   );
+
+  const t = useMemo(() => i18n.getFixedT(state.language, "templates"), [state.language]);
 
   return useMemo(
     () =>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,11 +1,44 @@
 import { useTranslation } from "react-i18next";
+import { FolderOpen, Save } from "lucide-react";
 import { Toggle } from "@components/ui/Toggle";
 import { Select } from "@components/ui/Select";
 import { Input } from "@components/ui/Input";
+import { Button } from "@components/ui/Button";
 import { SUPPORTED_LANGUAGES } from "@i18n/index";
 import { GENRES } from "@config/genres";
 import { useSettingsStore } from "@store/settings-store";
+import { IS_TAURI } from "@utils/platform";
 import type { SupportedLanguage } from "@engine/types";
+import toast from "react-hot-toast";
+
+async function openSettingsFolder() {
+  try {
+    const { appDataDir } = await import("@tauri-apps/api/path");
+    const { open } = await import("@tauri-apps/plugin-shell");
+    const dir = await appDataDir();
+    await open(dir);
+  } catch {
+    toast.error("Could not open settings folder");
+  }
+}
+
+async function exportSettingsToFile() {
+  try {
+    const { save } = await import("@tauri-apps/plugin-dialog");
+    const { invoke } = await import("@tauri-apps/api/core");
+    const { appDataDir } = await import("@tauri-apps/api/path");
+    const dir = await appDataDir();
+    const srcPath = `${dir}settings.json`;
+    const content: string = await invoke("read_from_file", { path: srcPath });
+    const destPath = await save({ defaultPath: "ytdescgen-settings.json" });
+    if (destPath) {
+      await invoke("save_to_file", { path: destPath, content });
+      toast.success("Settings exported!");
+    }
+  } catch {
+    toast.error("Export failed");
+  }
+}
 
 export function SettingsPage() {
   const { t, i18n } = useTranslation("ui");
@@ -29,7 +62,21 @@ export function SettingsPage() {
 
   return (
     <div className="mx-auto max-w-2xl p-6">
-      <h1 className="mb-6 text-lg font-bold text-text-primary">{t("settings.title")}</h1>
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-lg font-bold text-text-primary">{t("settings.title")}</h1>
+        {IS_TAURI && (
+          <div className="flex gap-2">
+            <Button variant="ghost" size="sm" onClick={openSettingsFolder}>
+              <FolderOpen className="h-3.5 w-3.5" />
+              Open Folder
+            </Button>
+            <Button variant="ghost" size="sm" onClick={exportSettingsToFile}>
+              <Save className="h-3.5 w-3.5" />
+              Export
+            </Button>
+          </div>
+        )}
+      </div>
 
       <div className="flex flex-col gap-8">
         <section className="flex flex-col gap-3">

--- a/src/utils/storage-adapter.ts
+++ b/src/utils/storage-adapter.ts
@@ -31,6 +31,51 @@ export async function loadSettings<T>(key: string, fallback: T): Promise<T> {
   return fallback;
 }
 
+/**
+ * Check if the Tauri data file exists and is valid JSON.
+ * If missing or corrupt, recreate it from localStorage data.
+ * Returns a status message or null if not in Tauri / all good.
+ */
+export async function checkDataFileHealth(): Promise<string | null> {
+  if (!IS_TAURI) return null;
+
+  try {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const path = await getSettingsPath();
+
+    try {
+      const raw: string = await invoke("read_from_file", { path });
+      JSON.parse(raw);
+      return null; // File exists and is valid
+    } catch {
+      // File missing or corrupt — rebuild from localStorage
+      const rebuilt: Record<string, unknown> = {};
+      const keys = [
+        "ytdescgen-settings",
+        "ytdescgen-profiles",
+        "ytdescgen-presets",
+        "ytdescgen-history",
+        "ytdescgen-editor-draft",
+      ];
+      for (const key of keys) {
+        try {
+          const raw = localStorage.getItem(key);
+          if (raw) rebuilt[key] = JSON.parse(raw);
+        } catch {
+          // Skip corrupt entries
+        }
+      }
+      await invoke("save_to_file", {
+        path,
+        content: JSON.stringify(rebuilt, null, 2),
+      });
+      return "Data file was missing or corrupt. Restored from local cache.";
+    }
+  } catch {
+    return null;
+  }
+}
+
 export async function saveSettings<T>(key: string, value: T): Promise<void> {
   try {
     localStorage.setItem(key, JSON.stringify(value));


### PR DESCRIPTION
## Summary
- **#5 Output language sync**: QuickPreview and OutputPage now render in the editor's selected output language, not the app UI language
- **#6 Card UI**: Cards use bg-surface-2 + border-strong + shadow + hover:accent for better visibility
- **#1 Settings file ops**: Open Folder + Export buttons on Settings page (Tauri only)
- **#4 Data health check**: On startup, checks if Tauri data file exists; if missing/corrupt, rebuilds from localStorage with toast warning

## Test plan
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm run test:run` — 42/42 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)