### PR TITLE
feat: real-time log viewer tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,9 @@ const BatchPage = lazy(() =>
 const PlaylistPage = lazy(() =>
   import("@pages/PlaylistPage").then((m) => ({ default: m.PlaylistPage })),
 );
+const LogPage = lazy(() =>
+  import("@pages/LogPage").then((m) => ({ default: m.LogPage })),
+);
 
 function PageLoader() {
   return <div className="flex items-center justify-center p-12 text-text-muted">Loading...</div>;
@@ -79,6 +82,14 @@ export default function App() {
               element={
                 <Suspense fallback={<PageLoader />}>
                   <PlaylistPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="logs"
+              element={
+                <Suspense fallback={<PageLoader />}>
+                  <LogPage />
                 </Suspense>
               }
             />

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -4,6 +4,7 @@ import { Header } from "./Header";
 import { TabBar } from "./TabBar";
 import { ShortcutHelpModal } from "@components/ui/ShortcutHelpModal";
 import { useKeyboardShortcuts } from "@hooks/use-keyboard-shortcuts";
+import { useGlobalErrorHandler } from "@hooks/use-global-error-handler";
 
 export function AppShell() {
   const [showShortcuts, setShowShortcuts] = useState(false);
@@ -11,6 +12,7 @@ export function AppShell() {
   useKeyboardShortcuts({
     onToggleHelp: () => setShowShortcuts((v) => !v),
   });
+  useGlobalErrorHandler();
 
   return (
     <div className="flex min-h-screen flex-col bg-surface-0">

--- a/src/components/layout/TabBar.tsx
+++ b/src/components/layout/TabBar.tsx
@@ -1,6 +1,6 @@
 import { NavLink } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { Pencil, FileText, User, Clock, Settings, Layers, ListVideo } from "lucide-react";
+import { Pencil, FileText, User, Clock, Settings, Layers, ListVideo, ScrollText } from "lucide-react";
 import clsx from "clsx";
 
 const tabs = [
@@ -10,6 +10,7 @@ const tabs = [
   { to: "/profiles", labelKey: "tabs.profiles", icon: User },
   { to: "/history", labelKey: "tabs.history", icon: Clock },
   { to: "/playlist", labelKey: "tabs.playlist", icon: ListVideo },
+  { to: "/logs", labelKey: "tabs.logs", icon: ScrollText },
   { to: "/settings", labelKey: "tabs.settings", icon: Settings },
 ] as const;
 

--- a/src/components/logs/LogEntry.tsx
+++ b/src/components/logs/LogEntry.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import { ChevronDown, ChevronUp, Trash2, Copy, Check } from "lucide-react";
+import { useLogStore, type LogEntry as LogEntryType, type LogLevel } from "@store/log-store";
+import clsx from "clsx";
+
+const LEVEL_STYLES: Record<LogLevel, string> = {
+  error: "bg-red-500/20 text-red-400",
+  warn: "bg-yellow-500/20 text-yellow-400",
+  info: "bg-blue-500/20 text-blue-400",
+  debug: "bg-gray-500/20 text-gray-400",
+};
+
+interface LogEntryProps {
+  entry: LogEntryType;
+}
+
+export function LogEntryCard({ entry }: LogEntryProps) {
+  const deleteEntry = useLogStore((s) => s.deleteEntry);
+  const [expanded, setExpanded] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const time = new Date(entry.timestamp).toLocaleTimeString();
+
+  const handleCopy = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const text = `[${entry.level.toUpperCase()}] [${entry.source}] ${entry.message}${entry.details ? `\n${entry.details}` : ""}`;
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  return (
+    <div
+      className={clsx(
+        "rounded-lg border bg-surface-2 transition-colors",
+        entry.level === "error" ? "border-red-500/30" : "border-border",
+      )}
+    >
+      <div
+        className="flex cursor-pointer items-center gap-2 px-3 py-2"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <span
+          className={clsx(
+            "shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] font-bold uppercase",
+            LEVEL_STYLES[entry.level],
+          )}
+        >
+          {entry.level}
+        </span>
+        <span className="shrink-0 rounded bg-surface-3 px-1.5 py-0.5 text-[10px] text-text-muted">
+          {entry.source}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-xs text-text-primary">{entry.message}</span>
+        <span className="shrink-0 text-[10px] text-text-muted">{time}</span>
+        <div className="flex shrink-0 items-center gap-0.5">
+          <button
+            onClick={handleCopy}
+            className="rounded p-1 text-text-muted hover:bg-surface-3 hover:text-text-primary"
+          >
+            {copied ? <Check className="h-3 w-3 text-success" /> : <Copy className="h-3 w-3" />}
+          </button>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              deleteEntry(entry.id);
+            }}
+            className="rounded p-1 text-text-muted hover:bg-surface-3 hover:text-danger"
+          >
+            <Trash2 className="h-3 w-3" />
+          </button>
+          {entry.details &&
+            (expanded ? (
+              <ChevronUp className="h-3.5 w-3.5 text-text-muted" />
+            ) : (
+              <ChevronDown className="h-3.5 w-3.5 text-text-muted" />
+            ))}
+        </div>
+      </div>
+
+      {expanded && entry.details && (
+        <div className="border-t border-border px-3 py-2">
+          <pre className="max-h-40 overflow-auto whitespace-pre-wrap font-mono text-[11px] text-text-secondary">
+            {entry.details}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/use-clipboard.ts
+++ b/src/hooks/use-clipboard.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef } from "react";
 import toast from "react-hot-toast";
+import { logger } from "@utils/logger";
 
 interface UseClipboardReturn {
   copy: (text: string) => Promise<void>;
@@ -18,8 +19,9 @@ export function useClipboard(): UseClipboardReturn {
 
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
       timeoutRef.current = setTimeout(() => setCopied(false), 2000);
-    } catch {
+    } catch (e) {
       toast.error("Failed to copy");
+      logger.error("clipboard", "Failed to copy to clipboard", String(e));
     }
   }, []);
 

--- a/src/hooks/use-global-error-handler.ts
+++ b/src/hooks/use-global-error-handler.ts
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+import { logger } from "@utils/logger";
+
+export function useGlobalErrorHandler() {
+  useEffect(() => {
+    const handleError = (event: ErrorEvent) => {
+      logger.error(
+        "runtime",
+        event.message || "Unknown error",
+        [
+          event.filename ? `${event.filename}:${event.lineno}:${event.colno}` : "",
+          event.error?.stack ?? "",
+        ]
+          .filter(Boolean)
+          .join("\n"),
+      );
+    };
+
+    const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+      const reason = event.reason;
+      logger.error(
+        "promise",
+        reason instanceof Error ? reason.message : String(reason),
+        reason instanceof Error ? reason.stack : undefined,
+      );
+    };
+
+    window.addEventListener("error", handleError);
+    window.addEventListener("unhandledrejection", handleUnhandledRejection);
+    return () => {
+      window.removeEventListener("error", handleError);
+      window.removeEventListener("unhandledrejection", handleUnhandledRejection);
+    };
+  }, []);
+}

--- a/src/i18n/locales/_schema.json
+++ b/src/i18n/locales/_schema.json
@@ -1,7 +1,7 @@
 {
   "ui": {
     "app": ["title", "subtitle"],
-    "tabs": ["editor", "output", "profiles", "history", "settings", "batch", "playlist"],
+    "tabs": ["editor", "output", "profiles", "history", "settings", "batch", "playlist", "logs"],
     "editor": [
       "videoType", "language", "genre", "gameName", "gameNamePlaceholder",
       "channelName", "channelNamePlaceholder", "platform",
@@ -35,6 +35,7 @@
     "batch": ["title", "startPart", "endPart", "generateBatch", "copyAllBatch", "emptyState"],
     "shortcuts": ["title", "generate", "copyAll", "saveDraft", "help", "close"],
     "validation": ["emailInvalid", "emailMaxExceeded", "urlInvalid", "urlPrefixMismatch"],
+    "logs": ["title", "emptyState", "clearAll", "clearConfirm", "searchPlaceholder"],
     "playlist": ["title", "status", "contentType", "totalVideos", "customNote", "generatePlaylist"]
   },
   "templates": {

--- a/src/i18n/locales/en/ui.json
+++ b/src/i18n/locales/en/ui.json
@@ -10,7 +10,8 @@
     "history": "History",
     "settings": "Settings",
     "batch": "Batch",
-    "playlist": "Playlist"
+    "playlist": "Playlist",
+    "logs": "Logs"
   },
   "editor": {
     "videoType": "Video Type",
@@ -238,5 +239,12 @@
     "totalVideos": "Total Videos",
     "customNote": "Custom Note",
     "generatePlaylist": "Generate Playlist"
+  },
+  "logs": {
+    "title": "Logs",
+    "emptyState": "No log entries yet.",
+    "clearAll": "Clear All",
+    "clearConfirm": "Are you sure you want to clear all logs?",
+    "searchPlaceholder": "Search logs..."
   }
 }

--- a/src/i18n/locales/es/ui.json
+++ b/src/i18n/locales/es/ui.json
@@ -10,7 +10,8 @@
     "history": "Historial",
     "settings": "Ajustes",
     "batch": "Lote",
-    "playlist": "Playlist"
+    "playlist": "Playlist",
+    "logs": "Registros"
   },
   "editor": {
     "videoType": "Tipo de Video",
@@ -238,5 +239,12 @@
     "totalVideos": "Total de Videos",
     "customNote": "Nota Personal",
     "generatePlaylist": "Generar Playlist"
+  },
+  "logs": {
+    "title": "Registros",
+    "emptyState": "No hay registros.",
+    "clearAll": "Borrar Todo",
+    "clearConfirm": "¿Estás seguro de borrar todos los registros?",
+    "searchPlaceholder": "Buscar registros..."
   }
 }

--- a/src/i18n/locales/ja/ui.json
+++ b/src/i18n/locales/ja/ui.json
@@ -10,7 +10,8 @@
     "history": "履歴",
     "settings": "設定",
     "batch": "一括",
-    "playlist": "プレイリスト"
+    "playlist": "プレイリスト",
+    "logs": "ログ"
   },
   "editor": {
     "videoType": "動画タイプ",
@@ -238,5 +239,12 @@
     "totalVideos": "動画総数",
     "customNote": "カスタムノート",
     "generatePlaylist": "プレイリスト生成"
+  },
+  "logs": {
+    "title": "ログ",
+    "emptyState": "ログはありません。",
+    "clearAll": "すべて削除",
+    "clearConfirm": "すべてのログを削除しますか？",
+    "searchPlaceholder": "ログを検索..."
   }
 }

--- a/src/i18n/locales/ko/ui.json
+++ b/src/i18n/locales/ko/ui.json
@@ -10,7 +10,8 @@
     "history": "기록",
     "settings": "설정",
     "batch": "일괄",
-    "playlist": "플레이리스트"
+    "playlist": "플레이리스트",
+    "logs": "로그"
   },
   "editor": {
     "videoType": "영상 유형",
@@ -238,5 +239,12 @@
     "totalVideos": "총 영상 수",
     "customNote": "사용자 메모",
     "generatePlaylist": "플레이리스트 생성"
+  },
+  "logs": {
+    "title": "로그",
+    "emptyState": "로그가 없습니다.",
+    "clearAll": "모두 삭제",
+    "clearConfirm": "모든 로그를 삭제하시겠습니까?",
+    "searchPlaceholder": "로그 검색..."
   }
 }

--- a/src/i18n/locales/vi/ui.json
+++ b/src/i18n/locales/vi/ui.json
@@ -10,7 +10,8 @@
     "history": "Lịch sử",
     "settings": "Cài đặt",
     "batch": "Hàng loạt",
-    "playlist": "Playlist"
+    "playlist": "Playlist",
+    "logs": "Nhật ký"
   },
   "editor": {
     "videoType": "Loại Video",
@@ -238,5 +239,12 @@
     "totalVideos": "Tổng video",
     "customNote": "Ghi chú",
     "generatePlaylist": "Tạo Playlist"
+  },
+  "logs": {
+    "title": "Nhật ký",
+    "emptyState": "Chưa có nhật ký.",
+    "clearAll": "Xóa tất cả",
+    "clearConfirm": "Bạn có chắc muốn xóa toàn bộ nhật ký?",
+    "searchPlaceholder": "Tìm kiếm nhật ký..."
   }
 }

--- a/src/i18n/locales/zh/ui.json
+++ b/src/i18n/locales/zh/ui.json
@@ -10,7 +10,8 @@
     "history": "历史",
     "settings": "设置",
     "batch": "批量",
-    "playlist": "播放列表"
+    "playlist": "播放列表",
+    "logs": "日志"
   },
   "editor": {
     "videoType": "视频类型",
@@ -238,5 +239,12 @@
     "totalVideos": "视频总数",
     "customNote": "自定义备注",
     "generatePlaylist": "生成播放列表"
+  },
+  "logs": {
+    "title": "日志",
+    "emptyState": "暂无日志。",
+    "clearAll": "清除全部",
+    "clearConfirm": "确定要清除所有日志吗？",
+    "searchPlaceholder": "搜索日志..."
   }
 }

--- a/src/pages/LogPage.tsx
+++ b/src/pages/LogPage.tsx
@@ -1,0 +1,137 @@
+import { useState, useRef, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { Trash2 } from "lucide-react";
+import { Input } from "@components/ui/Input";
+import { Button } from "@components/ui/Button";
+import { ConfirmDialog } from "@components/ui/ConfirmDialog";
+import { LogEntryCard } from "@components/logs/LogEntry";
+import { useLogStore, type LogLevel } from "@store/log-store";
+import clsx from "clsx";
+
+const LEVEL_FILTERS: Array<{ value: LogLevel | "all"; label: string; color: string }> = [
+  { value: "all", label: "All", color: "" },
+  { value: "error", label: "Error", color: "text-red-400" },
+  { value: "warn", label: "Warn", color: "text-yellow-400" },
+  { value: "info", label: "Info", color: "text-blue-400" },
+  { value: "debug", label: "Debug", color: "text-gray-400" },
+];
+
+export function LogPage() {
+  const { t } = useTranslation("ui");
+  const { entries, clearAll } = useLogStore();
+  const [search, setSearch] = useState("");
+  const [levelFilter, setLevelFilter] = useState<LogLevel | "all">("all");
+  const [showClearAll, setShowClearAll] = useState(false);
+  const [autoScroll, setAutoScroll] = useState(true);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const filtered = entries.filter((e) => {
+    if (levelFilter !== "all" && e.level !== levelFilter) return false;
+    if (search) {
+      const q = search.toLowerCase();
+      return (
+        e.message.toLowerCase().includes(q) ||
+        e.source.toLowerCase().includes(q) ||
+        (e.details?.toLowerCase().includes(q) ?? false)
+      );
+    }
+    return true;
+  });
+
+  const errorCount = entries.filter((e) => e.level === "error").length;
+  const warnCount = entries.filter((e) => e.level === "warn").length;
+
+  useEffect(() => {
+    if (autoScroll && listRef.current) {
+      listRef.current.scrollTop = 0;
+    }
+  }, [entries.length, autoScroll]);
+
+  return (
+    <div className="mx-auto max-w-4xl p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <h1 className="text-lg font-bold text-text-primary">{t("logs.title")}</h1>
+          <span className="text-xs text-text-muted">
+            {entries.length} entries
+            {errorCount > 0 && (
+              <span className="ml-1 text-red-400">({errorCount} errors)</span>
+            )}
+            {warnCount > 0 && (
+              <span className="ml-1 text-yellow-400">({warnCount} warnings)</span>
+            )}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <label className="flex items-center gap-1.5 text-xs text-text-muted">
+            <input
+              type="checkbox"
+              checked={autoScroll}
+              onChange={(e) => setAutoScroll(e.target.checked)}
+              className="rounded"
+            />
+            Auto-scroll
+          </label>
+          {entries.length > 0 && (
+            <Button variant="ghost" size="sm" onClick={() => setShowClearAll(true)}>
+              <Trash2 className="h-3.5 w-3.5" />
+              {t("logs.clearAll")}
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="flex gap-1 rounded-lg bg-surface-1 p-1">
+          {LEVEL_FILTERS.map((f) => (
+            <button
+              key={f.value}
+              onClick={() => setLevelFilter(f.value)}
+              className={clsx(
+                "rounded-md px-3 py-1 text-xs font-medium transition-colors",
+                levelFilter === f.value
+                  ? "bg-accent text-white"
+                  : clsx("text-text-muted hover:text-text-primary", f.color),
+              )}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+        <div className="flex-1">
+          <Input
+            placeholder={t("logs.searchPlaceholder")}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+      </div>
+
+      {/* Log entries */}
+      {filtered.length === 0 ? (
+        <p className="rounded-lg border border-dashed border-border py-12 text-center text-sm text-text-muted">
+          {t("logs.emptyState")}
+        </p>
+      ) : (
+        <div ref={listRef} className="flex max-h-[65vh] flex-col gap-1.5 overflow-y-auto">
+          {filtered.map((entry) => (
+            <LogEntryCard key={entry.id} entry={entry} />
+          ))}
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={showClearAll}
+        onConfirm={() => {
+          clearAll();
+          setShowClearAll(false);
+        }}
+        onCancel={() => setShowClearAll(false)}
+        title={t("logs.clearAll")}
+        message={t("logs.clearConfirm")}
+        variant="danger"
+      />
+    </div>
+  );
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -10,6 +10,7 @@ import { useSettingsStore } from "@store/settings-store";
 import { IS_TAURI } from "@utils/platform";
 import type { SupportedLanguage } from "@engine/types";
 import toast from "react-hot-toast";
+import { logger } from "@utils/logger";
 
 async function openSettingsFolder() {
   try {
@@ -17,8 +18,9 @@ async function openSettingsFolder() {
     const { open } = await import("@tauri-apps/plugin-shell");
     const dir = await appDataDir();
     await open(dir);
-  } catch {
+  } catch (e) {
     toast.error("Could not open settings folder");
+    logger.error("settings", "Failed to open settings folder", String(e));
   }
 }
 
@@ -35,8 +37,9 @@ async function exportSettingsToFile() {
       await invoke("save_to_file", { path: destPath, content });
       toast.success("Settings exported!");
     }
-  } catch {
+  } catch (e) {
     toast.error("Export failed");
+    logger.error("settings", "Failed to export settings", String(e));
   }
 }
 

--- a/src/store/log-store.ts
+++ b/src/store/log-store.ts
@@ -1,0 +1,43 @@
+import { create } from "zustand";
+import { generateId } from "@utils/uuid";
+
+export type LogLevel = "error" | "warn" | "info" | "debug";
+
+export interface LogEntry {
+  id: string;
+  timestamp: string;
+  level: LogLevel;
+  source: string;
+  message: string;
+  details?: string;
+}
+
+interface LogState {
+  entries: LogEntry[];
+  addEntry: (data: Omit<LogEntry, "id" | "timestamp">) => void;
+  deleteEntry: (id: string) => void;
+  clearAll: () => void;
+}
+
+const MAX_ENTRIES = 500;
+
+export const useLogStore = create<LogState>()((set) => ({
+  entries: [],
+
+  addEntry: (data) => {
+    const entry: LogEntry = {
+      ...data,
+      id: generateId(),
+      timestamp: new Date().toISOString(),
+    };
+    set((state) => ({
+      entries: [entry, ...state.entries].slice(0, MAX_ENTRIES),
+    }));
+  },
+
+  deleteEntry: (id) => {
+    set((state) => ({ entries: state.entries.filter((e) => e.id !== id) }));
+  },
+
+  clearAll: () => set({ entries: [] }),
+}));

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,16 @@
+import { useLogStore, type LogLevel } from "@store/log-store";
+
+function log(level: LogLevel, source: string, message: string, details?: string) {
+  useLogStore.getState().addEntry({ level, source, message, details });
+}
+
+export const logger = {
+  error: (source: string, message: string, details?: string) =>
+    log("error", source, message, details),
+  warn: (source: string, message: string, details?: string) =>
+    log("warn", source, message, details),
+  info: (source: string, message: string, details?: string) =>
+    log("info", source, message, details),
+  debug: (source: string, message: string, details?: string) =>
+    log("debug", source, message, details),
+};

--- a/src/utils/storage-adapter.ts
+++ b/src/utils/storage-adapter.ts
@@ -1,4 +1,5 @@
 import { IS_TAURI } from "./platform";
+import { logger } from "./logger";
 
 const SETTINGS_FILENAME = "settings.json";
 
@@ -16,16 +17,16 @@ export async function loadSettings<T>(key: string, fallback: T): Promise<T> {
       const raw: string = await invoke("read_from_file", { path });
       const allSettings = JSON.parse(raw) as Record<string, unknown>;
       if (key in allSettings) return allSettings[key] as T;
-    } catch {
-      // File doesn't exist yet or read error
+    } catch (e) {
+      logger.debug("storage", `Tauri file read failed for "${key}"`, String(e));
     }
   }
 
   try {
     const raw = localStorage.getItem(key);
     if (raw) return JSON.parse(raw) as T;
-  } catch {
-    // Parse error
+  } catch (e) {
+    logger.warn("storage", `localStorage parse failed for "${key}"`, String(e));
   }
 
   return fallback;
@@ -79,8 +80,8 @@ export async function checkDataFileHealth(): Promise<string | null> {
 export async function saveSettings<T>(key: string, value: T): Promise<void> {
   try {
     localStorage.setItem(key, JSON.stringify(value));
-  } catch {
-    // Storage full or disabled
+  } catch (e) {
+    logger.warn("storage", `localStorage write failed for "${key}"`, String(e));
   }
 
   if (IS_TAURI) {
@@ -93,7 +94,7 @@ export async function saveSettings<T>(key: string, value: T): Promise<void> {
         const raw: string = await invoke("read_from_file", { path });
         allSettings = JSON.parse(raw) as Record<string, unknown>;
       } catch {
-        // File doesn't exist yet
+        // File doesn't exist yet — start fresh
       }
 
       allSettings[key] = value;
@@ -101,8 +102,8 @@ export async function saveSettings<T>(key: string, value: T): Promise<void> {
         path,
         content: JSON.stringify(allSettings, null, 2),
       });
-    } catch {
-      // Write error — localStorage is the fallback
+    } catch (e) {
+      logger.warn("storage", `Tauri file write failed for "${key}"`, String(e));
     }
   }
 }


### PR DESCRIPTION
## Summary
- Log store (in-memory, 500 max entries) + standalone logger utility
- Global error handler: window.onerror + unhandledrejection
- LogPage: level filter chips, search, auto-scroll, clear all
- LogEntry: colored level badges, expandable details, copy/delete
- Instrumented: storage-adapter (4 catches), clipboard, settings page
- i18n: 208 UI keys across 6 languages

## Test plan
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm run test:run` — 42/42 tests pass
- [x] `npm run validate:locales` — 6 languages complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)