### PR TITLE
fix(tauri): remove extra arg from TrayIconBuilder::with_id

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,7 +28,7 @@ pub fn run() {
             let quit = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
             let menu = Menu::with_items(app, &[&show, &quit])?;
 
-            let _tray = TrayIconBuilder::with_id("ytdescgen-tray", app)
+            let _tray = TrayIconBuilder::with_id("ytdescgen-tray")
                 .tooltip("YTDescGen — YouTube Description Generator")
                 .menu(&menu)
                 .on_menu_event(|app, event| match event.id.as_ref() {


### PR DESCRIPTION
## Summary
- Fix macOS CI build failure caused by passing `app` as a second argument to `TrayIconBuilder::with_id()`, which only accepts 1 argument in Tauri 2.10.3
- The `app` handle is already correctly passed to `.build(app)`

## Test plan
- [x] `cargo check` passes locally
- [ ] macOS CI build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)