### PR TITLE
ci: drop macOS from desktop release matrix

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -14,10 +14,6 @@ jobs:
         include:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-          - os: macos-latest
-            target: aarch64-apple-darwin
-          - os: macos-latest
-            target: x86_64-apple-darwin
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Removes both macOS matrix entries (aarch64-apple-darwin, x86_64-apple-darwin) from ``release-desktop.yml``.
- Desktop releases now only build for Windows.

## Test plan
- [ ] Next tagged release builds only Windows artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)