### PR TITLE
feat(playlist): simplify title format to '[status] - Game Name'

### DIFF
--- a/src/i18n/locales/en/templates.json
+++ b/src/i18n/locales/en/templates.json
@@ -63,7 +63,7 @@
       "incomplete": "🔄 Incomplete",
       "in_progress": "▶️ In Progress"
     },
-    "titleFormat": "{{status}} — {{gameName}} — Gameplay No Commentary",
+    "titleFormat": "{{status}} - {{gameName}}",
     "videoCount": "📹 {{count}} video(s)",
     "storeSection": "🎮 Get the game:",
     "footer": "👍 Like | 🔔 Subscribe for more gameplay!",

--- a/src/i18n/locales/es/templates.json
+++ b/src/i18n/locales/es/templates.json
@@ -63,7 +63,7 @@
       "incomplete": "🔄 Incompleto",
       "in_progress": "▶️ En progreso"
     },
-    "titleFormat": "{{status}} — {{gameName}} — Gameplay No Commentary",
+    "titleFormat": "{{status}} - {{gameName}}",
     "videoCount": "📹 {{count}} video(s)",
     "storeSection": "🎮 Obtener el juego:",
     "footer": "👍 Me gusta | 🔔 ¡Suscríbete para más gameplay!",

--- a/src/i18n/locales/ja/templates.json
+++ b/src/i18n/locales/ja/templates.json
@@ -63,7 +63,7 @@
       "incomplete": "🔄 未完了",
       "in_progress": "▶️ プレイ中"
     },
-    "titleFormat": "{{status}} — {{gameName}} — Gameplay No Commentary",
+    "titleFormat": "{{status}} - {{gameName}}",
     "videoCount": "📹 {{count}}本の動画",
     "storeSection": "🎮 ゲーム購入:",
     "footer": "👍 高評価 | 🔔 チャンネル登録お願いします！",

--- a/src/i18n/locales/ko/templates.json
+++ b/src/i18n/locales/ko/templates.json
@@ -63,7 +63,7 @@
       "incomplete": "🔄 미완료",
       "in_progress": "▶️ 진행 중"
     },
-    "titleFormat": "{{status}} — {{gameName}} — Gameplay No Commentary",
+    "titleFormat": "{{status}} - {{gameName}}",
     "videoCount": "📹 {{count}}개 영상",
     "storeSection": "🎮 게임 구매:",
     "footer": "👍 좋아요 | 🔔 구독 부탁드립니다!",

--- a/src/i18n/locales/vi/templates.json
+++ b/src/i18n/locales/vi/templates.json
@@ -63,7 +63,7 @@
       "incomplete": "🔄 Chưa hoàn thành",
       "in_progress": "▶️ Đang chơi"
     },
-    "titleFormat": "{{status}} — {{gameName}} — Gameplay No Commentary",
+    "titleFormat": "{{status}} - {{gameName}}",
     "videoCount": "📹 {{count}} video",
     "storeSection": "🎮 Tải / mua game:",
     "footer": "👍 Like | 🔔 Subscribe để xem thêm gameplay!",

--- a/src/i18n/locales/zh/templates.json
+++ b/src/i18n/locales/zh/templates.json
@@ -63,7 +63,7 @@
       "incomplete": "🔄 未完成",
       "in_progress": "▶️ 进行中"
     },
-    "titleFormat": "{{status}} — {{gameName}} — Gameplay No Commentary",
+    "titleFormat": "{{status}} - {{gameName}}",
     "videoCount": "📹 {{count}}个视频",
     "storeSection": "🎮 获取游戏:",
     "footer": "👍 点赞 | 🔔 订阅获取更多游戏实况！",


### PR DESCRIPTION
## Summary
- New playlist title: ``{{status}} - {{gameName}}`` (e.g. ``✅ Completed - Elden Ring``)
- Removes the redundant ``Gameplay No Commentary`` suffix and normalizes separators to ASCII hyphen
- Applied to all 6 locales (en, vi, ja, es, ko, zh)

## Test plan
- [x] ``npm run validate:locales`` passes
- [ ] Playlist tab renders new title format

🤖 Generated with [Claude Code](https://claude.com/claude-code)