### PR TITLE
feat(tags): scope tags to selected language, add visual_novel genre

### DIFF
--- a/src/config/genres.ts
+++ b/src/config/genres.ts
@@ -25,6 +25,7 @@ export const GENRES = [
   { id: "space", labelKey: "genres.space", icon: "🚀" },
   { id: "farming", labelKey: "genres.farming", icon: "🌾" },
   { id: "fmv", labelKey: "genres.fmv", icon: "🎬" },
+  { id: "visual_novel", labelKey: "genres.visual_novel", icon: "💬" },
 ] as const;
 
 export type GenreId = (typeof GENRES)[number]["id"];

--- a/src/engine/tag-generator.ts
+++ b/src/engine/tag-generator.ts
@@ -1,40 +1,81 @@
-import type { GeneratorInput } from "./types";
+import type { GeneratorInput, SupportedLanguage } from "./types";
 import { YT_LIMITS } from "./types";
 
+/**
+ * Genre tag pool registry.
+ *
+ * Each entry returns an array of tags for the given game name. These tags
+ * are language-agnostic (English-based SEO terms commonly searched across
+ * all regions). Language-specific tags come from CORE_TAGS_BY_LANG and
+ * MULTILINGUAL_TAGS.
+ */
 const GENRE_TAG_REGISTRY: Record<string, (gameName: string) => string[]> = {
-  action: (g) => [`${g} action`, "action game no commentary", "action adventure gameplay"],
-  horror: (g) => [`${g} horror`, "horror game no commentary", "survival horror gameplay"],
-  rpg: (g) => [`${g} RPG`, "RPG no commentary", "RPG gameplay", "JRPG no commentary"],
-  fps: (g) => [`${g} FPS`, "FPS no commentary", "shooter gameplay no commentary"],
-  openworld: (g) => [`${g} open world`, "open world no commentary", "free roam gameplay"],
-  indie: (g) => [`${g} indie`, "indie game no commentary", "indie gameplay"],
-  soulslike: (g) => [`${g} souls like`, "soulsborne no commentary", "souls like gameplay"],
-  racing: (g) => [`${g} racing`, "racing game no commentary", "racing gameplay"],
-  story: (g) => [`${g} story`, "story game no commentary", "narrative gameplay"],
-  simulation: (g) => [`${g} simulation`, "simulation game no commentary", "strategy gameplay"],
-  fighting: (g) => [`${g} fighting`, "fighting game no commentary", "combo gameplay"],
-  stealth: (g) => [`${g} stealth`, "stealth game no commentary", "stealth gameplay"],
-  survival_craft: (g) => [`${g} survival`, "survival crafting no commentary", "base building"],
-  roguelike: (g) => [`${g} roguelike`, "roguelike no commentary", "roguelite gameplay"],
-  metroidvania: (g) => [`${g} metroidvania`, "metroidvania no commentary", "exploration gameplay"],
-  mmo: (g) => [`${g} MMO`, "MMO no commentary", "MMORPG gameplay"],
-  rhythm: (g) => [`${g} rhythm`, "rhythm game no commentary", "music game gameplay"],
-  puzzle: (g) => [`${g} puzzle`, "puzzle game no commentary", "brain teaser gameplay"],
-  tower_defense: (g) => [`${g} tower defense`, "tower defense no commentary", "TD gameplay"],
-  card_game: (g) => [`${g} card game`, "deck builder no commentary", "card game gameplay"],
-  battle_royale: (g) => [`${g} battle royale`, "battle royale no commentary", "BR gameplay"],
-  crpg: (g) => [`${g} CRPG`, "CRPG no commentary", "isometric RPG gameplay"],
-  tactical: (g) => [`${g} tactical`, "tactical game no commentary", "turn based strategy"],
-  space: (g) => [`${g} space`, "space game no commentary", "sci-fi gameplay"],
-  farming: (g) => [`${g} farming`, "farming sim no commentary", "cozy game gameplay"],
-  fmv: (g) => [`${g} FMV`, "FMV game no commentary", "interactive movie gameplay"],
+  action: (g) => [`${g} action`, "action game no commentary", "action adventure gameplay", `${g} combat`],
+  horror: (g) => [`${g} horror`, "horror game no commentary", "survival horror gameplay", `${g} scary`],
+  rpg: (g) => [`${g} RPG`, "RPG no commentary", "RPG gameplay", "JRPG no commentary", `${g} role playing`],
+  fps: (g) => [`${g} FPS`, "FPS no commentary", "shooter gameplay no commentary", `${g} shooter`],
+  openworld: (g) => [`${g} open world`, "open world no commentary", "free roam gameplay", `${g} exploration`],
+  indie: (g) => [`${g} indie`, `${g} indie game`, "indie game no commentary", "indie gameplay", "best indie games"],
+  soulslike: (g) => [`${g} souls like`, "soulsborne no commentary", "souls like gameplay", `${g} hardcore`],
+  racing: (g) => [`${g} racing`, "racing game no commentary", "racing gameplay", `${g} cars`],
+  story: (g) => [
+    `${g} story`,
+    `${g} story mode`,
+    "story game no commentary",
+    "narrative gameplay",
+    "cinematic adventure no commentary",
+  ],
+  simulation: (g) => [`${g} simulation`, "simulation game no commentary", "strategy gameplay", `${g} sim`],
+  fighting: (g) => [`${g} fighting`, "fighting game no commentary", "combo gameplay", `${g} fight`],
+  stealth: (g) => [`${g} stealth`, "stealth game no commentary", "stealth gameplay", `${g} ghost run`],
+  survival_craft: (g) => [
+    `${g} survival`,
+    "survival crafting no commentary",
+    "base building",
+    `${g} crafting`,
+  ],
+  roguelike: (g) => [`${g} roguelike`, "roguelike no commentary", "roguelite gameplay", `${g} run`],
+  metroidvania: (g) => [
+    `${g} metroidvania`,
+    "metroidvania no commentary",
+    "exploration gameplay",
+    `${g} platformer`,
+  ],
+  mmo: (g) => [`${g} MMO`, "MMO no commentary", "MMORPG gameplay", `${g} online`],
+  rhythm: (g) => [`${g} rhythm`, "rhythm game no commentary", "music game gameplay", `${g} music`],
+  puzzle: (g) => [`${g} puzzle`, "puzzle game no commentary", "brain teaser gameplay", `${g} logic`],
+  tower_defense: (g) => [`${g} tower defense`, "tower defense no commentary", "TD gameplay", `${g} strategy`],
+  card_game: (g) => [`${g} card game`, "deck builder no commentary", "card game gameplay", `${g} TCG`],
+  battle_royale: (g) => [`${g} battle royale`, "battle royale no commentary", "BR gameplay", `${g} solo`],
+  crpg: (g) => [`${g} CRPG`, "CRPG no commentary", "isometric RPG gameplay", `${g} party`],
+  tactical: (g) => [`${g} tactical`, "tactical game no commentary", "turn based strategy", `${g} tactics`],
+  space: (g) => [`${g} space`, "space game no commentary", "sci-fi gameplay", `${g} sci fi`],
+  farming: (g) => [`${g} farming`, "farming sim no commentary", "cozy game gameplay", `${g} cozy`],
+  fmv: (g) => [`${g} FMV`, "FMV game no commentary", "interactive movie gameplay", `${g} live action`],
+  visual_novel: (g) => [
+    `${g} visual novel`,
+    `${g} VN no commentary`,
+    "visual novel gameplay",
+    "kinetic novel no commentary",
+    `${g} story mode`,
+  ],
 };
 
 const VIDEO_TYPE_TAGS: Record<string, (gameName: string) => string[]> = {
   full: (g) => [`${g} full game`, `${g} full gameplay no commentary`, `${g} longplay`],
   part: (g) => [`${g} walkthrough`, `${g} playthrough`, `${g} let's play no commentary`],
-  full_demo: (g) => [`${g} demo`, `${g} full demo`, `${g} demo gameplay no commentary`, "game demo no commentary"],
-  demo_part: (g) => [`${g} demo part`, `${g} demo playthrough`, `${g} demo walkthrough`, "demo gameplay no commentary"],
+  full_demo: (g) => [
+    `${g} demo`,
+    `${g} full demo`,
+    `${g} demo gameplay no commentary`,
+    "game demo no commentary",
+  ],
+  demo_part: (g) => [
+    `${g} demo part`,
+    `${g} demo playthrough`,
+    `${g} demo walkthrough`,
+    "demo gameplay no commentary",
+  ],
   boss: (g) => [`${g} boss fight`, `${g} boss battle`, "boss fight no commentary"],
   boss_nohit: (g) => [`${g} boss no hit`, `${g} no damage boss`, "no hit boss fight"],
   ending: (g) => [`${g} ending`, `${g} all endings`, `${g} final boss`],
@@ -49,29 +90,70 @@ const VIDEO_TYPE_TAGS: Record<string, (gameName: string) => string[]> = {
   guide: (g) => [`${g} guide`, `${g} silent guide`, "guide no commentary"],
 };
 
-const MULTILINGUAL_TAGS: Record<string, (gameName: string) => string[]> = {
-  ja: (g) => [`${g} ゲームプレイ`, `${g} 実況なし`, "ゲームプレイ 実況なし"],
-  vi: (g) => [`${g} gameplay không bình luận`, `${g} không bình luận`],
-  es: (g) => [`${g} sin comentarios`, `${g} gameplay completo`],
-  ko: (g) => [`${g} 게임플레이`, `${g} 무편집`],
-  zh: (g) => [`${g} 无解说`, `${g} 游戏实况`],
+/**
+ * Language-specific "core" tag pool. Replaces the previous English-only
+ * getCoreTags. Selected by GeneratorInput.language so the channel can
+ * match the viewer's region.
+ */
+const CORE_TAGS_BY_LANG: Record<SupportedLanguage, (gameName: string) => string[]> = {
+  en: (g) => [
+    `${g} gameplay`,
+    `${g} no commentary`,
+    "gameplay no commentary",
+    `${g} walkthrough`,
+    `${g} full game`,
+    `${g} gameplay no commentary`,
+  ],
+  vi: (g) => [
+    `${g} gameplay`,
+    `${g} không bình luận`,
+    `${g} gameplay không bình luận`,
+    "gameplay không bình luận",
+    `${g} chơi thử`,
+    `${g} let's play`,
+  ],
+  ja: (g) => [
+    `${g} ゲームプレイ`,
+    `${g} 実況なし`,
+    "ゲームプレイ 実況なし",
+    `${g} 攻略`,
+    `${g} プレイ動画`,
+    `${g} 実況プレイ`,
+  ],
+  es: (g) => [
+    `${g} gameplay`,
+    `${g} sin comentarios`,
+    "gameplay sin comentarios",
+    `${g} completo`,
+    `${g} guía`,
+    `${g} español`,
+  ],
+  ko: (g) => [`${g} 게임플레이`, `${g} 무편집`, "게임플레이 무편집", `${g} 공략`, `${g} 플레이`, `${g} 한국어`],
+  zh: (g) => [`${g} 游戏实况`, `${g} 无解说`, "游戏实况 无解说", `${g} 攻略`, `${g} 流程`, `${g} 通关`],
 };
 
-function getCoreTags(gameName: string): string[] {
-  return [
-    `${gameName} gameplay`,
-    `${gameName} no commentary`,
-    "gameplay no commentary",
-    `${gameName} walkthrough`,
-    `${gameName} full game`,
-    `${gameName} gameplay no commentary`,
-  ];
-}
+/**
+ * Extra region-specific tags added when includeMultilingualTags is true.
+ * Only the selected language's entry is used — v0.2.0 incorrectly mixed
+ * all languages regardless of the user's choice.
+ */
+const MULTILINGUAL_TAGS: Record<SupportedLanguage, (gameName: string) => string[]> = {
+  en: (g) => [`${g} english`, "gameplay english no commentary"],
+  ja: (g) => [`${g} 日本語`, `${g} 実況`, "日本語 ゲームプレイ"],
+  vi: (g) => [`${g} tiếng Việt`, `${g} thuyết minh`, "gameplay tiếng Việt"],
+  es: (g) => [`${g} español`, `${g} en español`, "gameplay en español"],
+  ko: (g) => [`${g} 한국어`, `${g} 플레이`, "한국어 게임플레이"],
+  zh: (g) => [`${g} 中文`, `${g} 游戏`, "中文 游戏实况"],
+};
 
 function getPlatformTags(gameName: string, platform: string): string[] {
   if (!platform) return [];
   const platformLabel = platform.toUpperCase();
-  return [`${gameName} ${platformLabel}`, `${platformLabel} gameplay`, `${gameName} ${platformLabel} gameplay`];
+  return [
+    `${gameName} ${platformLabel}`,
+    `${platformLabel} gameplay`,
+    `${gameName} ${platformLabel} gameplay`,
+  ];
 }
 
 function getQualityTags(gameName: string, resolution?: string, fps?: string): string[] {
@@ -100,13 +182,13 @@ export interface TagOptions {
 
 export function generateTags(input: GeneratorInput, options?: TagOptions): string[] {
   const { includeMultilingualTags = true, includeTrendingTags = true } = options ?? {};
-  const gameName =
-    input.gameNameLocalized?.[input.language] ?? input.gameName;
+  const gameName = input.gameNameLocalized?.[input.language] ?? input.gameName;
 
   const allTags: string[] = [];
 
-  // Core tags (highest priority)
-  allTags.push(...getCoreTags(gameName));
+  // Core tags — language-specific (highest priority)
+  const coreFn = CORE_TAGS_BY_LANG[input.language] ?? CORE_TAGS_BY_LANG.en;
+  allTags.push(...coreFn(gameName));
 
   // Genre tags
   const genreFn = GENRE_TAG_REGISTRY[input.genre];
@@ -126,9 +208,11 @@ export function generateTags(input: GeneratorInput, options?: TagOptions): strin
   // Quality tags
   allTags.push(...getQualityTags(gameName, input.resolution, input.fps));
 
-  // Multilingual tags
+  // Multilingual tags — only the selected language (v0.3.0 fix: was
+  // previously iterating over every language entry).
   if (includeMultilingualTags) {
-    for (const [, langFn] of Object.entries(MULTILINGUAL_TAGS)) {
+    const langFn = MULTILINGUAL_TAGS[input.language];
+    if (langFn) {
       allTags.push(...langFn(gameName));
     }
   }
@@ -138,7 +222,7 @@ export function generateTags(input: GeneratorInput, options?: TagOptions): strin
     allTags.push(...getTrendingTags(gameName, input.genre));
   }
 
-  // Dedup (case-insensitive)
+  // Dedup (case-insensitive) and enforce per-tag char limit
   const seen = new Set<string>();
   const deduped: string[] = [];
   for (const tag of allTags) {

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -1,6 +1,8 @@
 export type VideoType =
   | "full"
   | "part"
+  | "full_demo"
+  | "demo_part"
   | "boss"
   | "boss_nohit"
   | "ending"
@@ -40,7 +42,8 @@ export type Genre =
   | "tactical"
   | "space"
   | "farming"
-  | "fmv";
+  | "fmv"
+  | "visual_novel";
 
 export type SupportedLanguage = "en" | "vi" | "ja" | "es" | "ko" | "zh";
 

--- a/src/i18n/locales/_schema.json
+++ b/src/i18n/locales/_schema.json
@@ -23,7 +23,7 @@
     ],
     "common": ["save", "cancel", "delete", "confirm", "export", "import", "reset", "search", "generate"],
     "videoTypes": ["full", "part", "full_demo", "demo_part", "boss", "boss_nohit", "ending", "speedrun", "100percent", "dlc", "newgame_plus", "challenge", "side_quest", "secret", "comparison", "guide"],
-    "genres": ["action", "horror", "rpg", "fps", "openworld", "indie", "soulslike", "racing", "story", "simulation", "fighting", "stealth", "survival_craft", "roguelike", "metroidvania", "mmo", "rhythm", "puzzle", "tower_defense", "card_game", "battle_royale", "crpg", "tactical", "space", "farming", "fmv"],
+    "genres": ["action", "horror", "rpg", "fps", "openworld", "indie", "soulslike", "racing", "story", "simulation", "fighting", "stealth", "survival_craft", "roguelike", "metroidvania", "mmo", "rhythm", "puzzle", "tower_defense", "card_game", "battle_royale", "crpg", "tactical", "space", "farming", "fmv", "visual_novel"],
     "rig": ["cpu", "gpu", "ram", "storage", "monitor", "capture", "motherboard", "controller"],
     "social": ["kofi", "patreon", "buymeacoffee", "paypal", "github", "twitter", "discord", "website", "twitch", "tiktok", "instagram", "streamlabs", "bluesky", "mastodon", "facebook", "fb_page", "fb_group"],
     "resolutions": ["720p", "1080p", "1440p", "4K"],

--- a/src/i18n/locales/en/ui.json
+++ b/src/i18n/locales/en/ui.json
@@ -119,7 +119,8 @@
     "tactical": "Tactical / Turn-based",
     "space": "Space / Sci-Fi",
     "farming": "Farming / Life Sim",
-    "fmv": "FMV / Interactive Movie"
+    "fmv": "FMV / Interactive Movie",
+    "visual_novel": "Visual Novel"
   },
   "rig": {
     "cpu": "CPU",

--- a/src/i18n/locales/es/ui.json
+++ b/src/i18n/locales/es/ui.json
@@ -119,7 +119,8 @@
     "tactical": "Táctico / Por Turnos",
     "space": "Espacio / Sci-Fi",
     "farming": "Granja / Life Sim",
-    "fmv": "FMV / Película Interactiva"
+    "fmv": "FMV / Película Interactiva",
+    "visual_novel": "Novela Visual"
   },
   "rig": {
     "cpu": "CPU",

--- a/src/i18n/locales/ja/ui.json
+++ b/src/i18n/locales/ja/ui.json
@@ -119,7 +119,8 @@
     "tactical": "タクティカル / ターン制",
     "space": "宇宙 / SF",
     "farming": "農業 / ライフシム",
-    "fmv": "FMV / インタラクティブムービー"
+    "fmv": "FMV / インタラクティブムービー",
+    "visual_novel": "ビジュアルノベル"
   },
   "rig": {
     "cpu": "CPU",

--- a/src/i18n/locales/ko/ui.json
+++ b/src/i18n/locales/ko/ui.json
@@ -119,7 +119,8 @@
     "tactical": "전술 / 턴제",
     "space": "우주 / SF",
     "farming": "농장 / 라이프 시뮬",
-    "fmv": "FMV / 인터랙티브 무비"
+    "fmv": "FMV / 인터랙티브 무비",
+    "visual_novel": "비주얼 노벨"
   },
   "rig": {
     "cpu": "CPU",

--- a/src/i18n/locales/vi/ui.json
+++ b/src/i18n/locales/vi/ui.json
@@ -119,7 +119,8 @@
     "tactical": "Chiến thuật",
     "space": "Vũ trụ / Sci-Fi",
     "farming": "Nông trại / Life Sim",
-    "fmv": "FMV / Phim tương tác"
+    "fmv": "FMV / Phim tương tác",
+    "visual_novel": "Visual Novel / Tiểu thuyết đồ họa"
   },
   "rig": {
     "cpu": "CPU",

--- a/src/i18n/locales/zh/ui.json
+++ b/src/i18n/locales/zh/ui.json
@@ -119,7 +119,8 @@
     "tactical": "战术 / 回合制",
     "space": "太空 / 科幻",
     "farming": "农场 / 生活模拟",
-    "fmv": "FMV / 互动电影"
+    "fmv": "FMV / 互动电影",
+    "visual_novel": "视觉小说"
   },
   "rig": {
     "cpu": "CPU",

--- a/tests/engine/tag-generator.test.ts
+++ b/tests/engine/tag-generator.test.ts
@@ -52,14 +52,29 @@ describe("generateTags", () => {
     expect(tags.some((t) => t.toLowerCase().includes("speedrun"))).toBe(true);
   });
 
-  it("includes multilingual tags (Japanese)", () => {
-    const tags = generateTags(makeInput());
+  it("includes multilingual tags only for the selected language (Japanese)", () => {
+    const tags = generateTags(makeInput({ language: "ja" }));
     expect(tags.some((t) => t.includes("ゲームプレイ"))).toBe(true);
+    // Should NOT leak other languages
+    expect(tags.some((t) => t.includes("không bình luận"))).toBe(false);
+    expect(tags.some((t) => t.includes("게임플레이"))).toBe(false);
   });
 
-  it("includes multilingual tags (Vietnamese)", () => {
-    const tags = generateTags(makeInput());
+  it("includes multilingual tags only for the selected language (Vietnamese)", () => {
+    const tags = generateTags(makeInput({ language: "vi" }));
     expect(tags.some((t) => t.includes("không bình luận"))).toBe(true);
+    expect(tags.some((t) => t.includes("ゲームプレイ"))).toBe(false);
+    expect(tags.some((t) => t.includes("游戏实况"))).toBe(false);
+  });
+
+  it("includes visual novel tags for visual_novel genre", () => {
+    const tags = generateTags(makeInput({ genre: "visual_novel" }));
+    expect(tags.some((t) => t.toLowerCase().includes("visual novel"))).toBe(true);
+  });
+
+  it("includes full_demo tags for full_demo video type", () => {
+    const tags = generateTags(makeInput({ videoType: "full_demo" }));
+    expect(tags.some((t) => t.toLowerCase().includes("demo"))).toBe(true);
   });
 
   it("has no duplicate tags (case-insensitive)", () => {


### PR DESCRIPTION
## Summary
- **Fix:** Multilingual tag pool now uses only the selected ``language`` instead of mixing every locale's tags into every video.
- **Upgrade:** Core tag pool is now language-specific (``CORE_TAGS_BY_LANG``).
- **New genre:** ``visual_novel`` added end-to-end (engine type, config, registry, schema, 6 ui.json locales).
- **Expanded pools:** ``story``, ``indie``, ``action``, ``horror``, ``rpg``, and several others now include more common search terms.
- **Types:** ``VideoType`` / ``Genre`` now include ``full_demo`` / ``demo_part`` / ``visual_novel``.

## Test plan
- [x] ``npm run validate:locales`` passes
- [x] ``npm run typecheck`` passes
- [x] ``npm run test:run`` passes (44 tests, incl. new per-language isolation tests)
- [ ] Pick language=vi, genre=visual_novel in editor -> tags are Vietnamese + visual novel

🤖 Generated with [Claude Code](https://claude.com/claude-code)