### PR TITLE
feat(timeline): parse and localize chapter markers

### DIFF
--- a/src/engine/description-builder.ts
+++ b/src/engine/description-builder.ts
@@ -2,6 +2,7 @@ import type { GeneratorInput, TranslationFn, CharLimitWarning } from "./types";
 import { YT_LIMITS } from "./types";
 import { PLATFORMS } from "@config/platforms";
 import { SOCIAL_FIELDS } from "@config/social-fields";
+import { parseTimeline, renderTimeline } from "./timeline-parser";
 
 const SOCIAL_ICONS: Record<string, string> = {
   kofi: "☕",
@@ -54,9 +55,11 @@ export function buildDescription(
   // 2. No Commentary tagline
   sections.push(t("description.noCommentaryLine"));
 
-  // 3. Timestamps
+  // 3. Timestamps (parsed + localized keywords)
   if (input.timestamps && input.timestamps.trim()) {
-    sections.push(`${t("description.sections.timestamps")}\n${input.timestamps.trim()}`);
+    const entries = parseTimeline(input.timestamps);
+    const rendered = renderTimeline(entries, input.language, t);
+    sections.push(`${t("description.sections.timestamps")}\n${rendered}`);
   }
 
   // 4. Store Links (use proper brand names from config)

--- a/src/engine/timeline-parser.ts
+++ b/src/engine/timeline-parser.ts
@@ -1,0 +1,181 @@
+import type { SupportedLanguage, TranslationFn } from "./types";
+
+/**
+ * Canonical keyword IDs recognized by the parser. Each corresponds to a
+ * translation key under `timeline.keywords.*` in templates.json.
+ */
+export type TimelineKeyword =
+  | "chapter"
+  | "part"
+  | "boss"
+  | "final_boss"
+  | "intro"
+  | "ending"
+  | "tutorial"
+  | "credits";
+
+export interface TimelineEntry {
+  /** Raw timecode as it appeared in the input (e.g. "0:00", "1:23:45"). */
+  time: string;
+  /** Entire label portion after the timecode (trimmed). */
+  rawLabel: string;
+  /** Keyword that the label was classified as, if any. */
+  keyword?: TimelineKeyword;
+  /** Ordinal number when the keyword supports one (e.g. Chapter 3 -> 3). */
+  number?: number;
+  /** Trailing text after the keyword+number, if any (preserved for context). */
+  rest?: string;
+}
+
+// Regex for extracting time + label from a line. Accepts MM:SS or HH:MM:SS.
+const LINE_RE = /^\s*((?:\d{1,2}:)?\d{1,2}:\d{2})\s+(.+?)\s*$/;
+
+// Keyword patterns. Order matters — "final boss" must be tried before "boss".
+// Each regex captures the optional number group when applicable.
+interface KeywordPattern {
+  re: RegExp;
+  keyword: TimelineKeyword;
+  hasNumber: boolean;
+}
+
+const KEYWORD_PATTERNS: KeywordPattern[] = [
+  // Final boss (multi-language, no number). Must come BEFORE "boss".
+  {
+    re: /^(final\s+boss|boss\s+cuối\s+cùng|boss\s+cuối|ラスボス|最終\s*ボス|jefe\s+final|최종\s*보스|最终\s*boss|最终\s*首领)(.*)$/i,
+    keyword: "final_boss",
+    hasNumber: false,
+  },
+  // Chapter — captures various CJK/Latin forms
+  {
+    re: /^(?:chapter|chap\.?|chương|chuong|capítulo|capitulo|第\s*(\d+)\s*章|제\s*(\d+)\s*장|章|장)\s*(\d+)?(.*)$/i,
+    keyword: "chapter",
+    hasNumber: true,
+  },
+  // Part
+  {
+    re: /^(?:part|phần|phan|パート|parte|파트|第\s*(\d+)\s*部|部分)\s*(\d+)?(.*)$/i,
+    keyword: "part",
+    hasNumber: true,
+  },
+  // Boss (single, with optional number)
+  {
+    re: /^(?:boss|ボス|jefe|보스)\s*(\d+)?(.*)$/i,
+    keyword: "boss",
+    hasNumber: true,
+  },
+  // Intro
+  {
+    re: /^(intro|introduction|mở\s+đầu|mo\s+dau|オープニング|オープン|introducción|introduccion|인트로|开场|序幕)(.*)$/i,
+    keyword: "intro",
+    hasNumber: false,
+  },
+  // Ending
+  {
+    re: /^(ending|kết\s+thúc|ket\s+thuc|エンディング|final|엔딩|结局|结尾)(.*)$/i,
+    keyword: "ending",
+    hasNumber: false,
+  },
+  // Tutorial
+  {
+    re: /^(tutorial|hướng\s+dẫn|huong\s+dan|チュートリアル|튜토리얼|教程)(.*)$/i,
+    keyword: "tutorial",
+    hasNumber: false,
+  },
+  // Credits
+  {
+    re: /^(credits|credit|クレジット|créditos|creditos|크레딧|片尾|职员表)(.*)$/i,
+    keyword: "credits",
+    hasNumber: false,
+  },
+];
+
+/**
+ * Parse a raw timestamp textarea value into structured entries.
+ *
+ * Each non-empty line is expected to start with a timecode. Lines that
+ * don't match the `time + label` shape are still preserved as entries
+ * with `time: ""` so the original text isn't lost.
+ */
+export function parseTimeline(raw: string): TimelineEntry[] {
+  const entries: TimelineEntry[] = [];
+  const lines = raw.split(/\r?\n/);
+
+  for (const line of lines) {
+    if (!line.trim()) continue;
+
+    const lineMatch = line.match(LINE_RE);
+    if (!lineMatch) {
+      // Not a `time label` line — keep the raw text so nothing disappears.
+      entries.push({ time: "", rawLabel: line.trim() });
+      continue;
+    }
+
+    const time = lineMatch[1] ?? "";
+    const label = lineMatch[2] ?? "";
+    const entry: TimelineEntry = { time, rawLabel: label };
+
+    for (const pattern of KEYWORD_PATTERNS) {
+      const m = label.match(pattern.re);
+      if (!m) continue;
+
+      entry.keyword = pattern.keyword;
+
+      if (pattern.hasNumber) {
+        // Scan every capture group for the first numeric one. Different
+        // alternatives (e.g. "第N章" vs "Chapter N") place the number in
+        // different group positions, so treat them uniformly.
+        for (let i = 1; i < m.length - 1; i++) {
+          const g = m[i];
+          if (g && /^\d+$/.test(g)) {
+            entry.number = parseInt(g, 10);
+            break;
+          }
+        }
+      }
+
+      const rest = m[m.length - 1];
+      if (rest && rest.trim()) {
+        entry.rest = rest.trim();
+      }
+      break;
+    }
+
+    entries.push(entry);
+  }
+
+  return entries;
+}
+
+/**
+ * Render parsed entries back into the timestamp block, translating
+ * recognized keywords into the requested language via i18next.
+ *
+ * Lines without a recognized keyword keep their original label so
+ * the user's free-form text is preserved.
+ */
+export function renderTimeline(
+  entries: TimelineEntry[],
+  _language: SupportedLanguage,
+  t: TranslationFn,
+): string {
+  const rendered: string[] = [];
+
+  for (const entry of entries) {
+    if (!entry.time) {
+      rendered.push(entry.rawLabel);
+      continue;
+    }
+
+    if (!entry.keyword) {
+      rendered.push(`${entry.time} ${entry.rawLabel}`);
+      continue;
+    }
+
+    const numberVar = entry.number != null ? String(entry.number) : "";
+    const translated = t(`timeline.keywords.${entry.keyword}`, { n: numberVar });
+    const withRest = entry.rest ? `${translated} ${entry.rest}` : translated;
+    rendered.push(`${entry.time} ${withRest}`);
+  }
+
+  return rendered.join("\n");
+}

--- a/src/i18n/locales/_schema.json
+++ b/src/i18n/locales/_schema.json
@@ -51,6 +51,7 @@
     "hashtags": ["gameplay", "noCommentary", "genre"],
     "playlist.status": ["completed", "dropped", "incomplete", "in_progress"],
     "playlist": ["titleFormat", "videoCount", "storeSection", "footer"],
-    "playlist.description": ["full_gameplay", "boss_fights", "speedrun", "all_endings", "dlc", "100_percent", "guide", "highlights"]
+    "playlist.description": ["full_gameplay", "boss_fights", "speedrun", "all_endings", "dlc", "100_percent", "guide", "highlights"],
+    "timeline.keywords": ["chapter", "part", "boss", "final_boss", "intro", "ending", "tutorial", "credits"]
   }
 }

--- a/src/i18n/locales/en/templates.json
+++ b/src/i18n/locales/en/templates.json
@@ -81,5 +81,17 @@
       "guide": "This playlist is a silent guide for {{gameName}} on {{channelName}}.\nNo Commentary — pure gameplay experience.",
       "highlights": "This playlist contains gameplay highlights from {{gameName}} on {{channelName}}.\nNo Commentary — pure gameplay experience."
     }
+  },
+  "timeline": {
+    "keywords": {
+      "chapter": "Chapter {{n}}",
+      "part": "Part {{n}}",
+      "boss": "Boss {{n}}",
+      "final_boss": "Final Boss",
+      "intro": "Intro",
+      "ending": "Ending",
+      "tutorial": "Tutorial",
+      "credits": "Credits"
+    }
   }
 }

--- a/src/i18n/locales/es/templates.json
+++ b/src/i18n/locales/es/templates.json
@@ -81,5 +81,17 @@
       "guide": "Esta playlist es una guía silenciosa de {{gameName}} en {{channelName}}.\nSin comentarios.",
       "highlights": "Esta playlist contiene los momentos destacados de {{gameName}} en {{channelName}}.\nSin comentarios."
     }
+  },
+  "timeline": {
+    "keywords": {
+      "chapter": "Capítulo {{n}}",
+      "part": "Parte {{n}}",
+      "boss": "Jefe {{n}}",
+      "final_boss": "Jefe Final",
+      "intro": "Introducción",
+      "ending": "Final",
+      "tutorial": "Tutorial",
+      "credits": "Créditos"
+    }
   }
 }

--- a/src/i18n/locales/ja/templates.json
+++ b/src/i18n/locales/ja/templates.json
@@ -81,5 +81,17 @@
       "guide": "このプレイリストは{{channelName}}での{{gameName}}の攻略ガイドです。\n解説なし — 純粋なゲームプレイ体験。",
       "highlights": "このプレイリストは{{channelName}}での{{gameName}}のハイライト集です。\n解説なし — 純粋なゲームプレイ体験。"
     }
+  },
+  "timeline": {
+    "keywords": {
+      "chapter": "第{{n}}章",
+      "part": "パート{{n}}",
+      "boss": "ボス{{n}}",
+      "final_boss": "ラスボス",
+      "intro": "オープニング",
+      "ending": "エンディング",
+      "tutorial": "チュートリアル",
+      "credits": "クレジット"
+    }
   }
 }

--- a/src/i18n/locales/ko/templates.json
+++ b/src/i18n/locales/ko/templates.json
@@ -81,5 +81,17 @@
       "guide": "이 플레이리스트는 {{channelName}}에서 {{gameName}}의 무음 가이드입니다.\n해설 없음.",
       "highlights": "이 플레이리스트는 {{channelName}}에서 {{gameName}}의 하이라이트 모음입니다.\n해설 없음."
     }
+  },
+  "timeline": {
+    "keywords": {
+      "chapter": "제{{n}}장",
+      "part": "파트 {{n}}",
+      "boss": "보스 {{n}}",
+      "final_boss": "최종 보스",
+      "intro": "인트로",
+      "ending": "엔딩",
+      "tutorial": "튜토리얼",
+      "credits": "크레딧"
+    }
   }
 }

--- a/src/i18n/locales/vi/templates.json
+++ b/src/i18n/locales/vi/templates.json
@@ -81,5 +81,17 @@
       "guide": "Playlist này là hướng dẫn không lời cho {{gameName}} trên kênh {{channelName}}.\nKhông bình luận — chỉ có gameplay thuần túy.",
       "highlights": "Playlist này là tổng hợp khoảnh khắc hay nhất của {{gameName}} trên kênh {{channelName}}.\nKhông bình luận — chỉ có gameplay thuần túy."
     }
+  },
+  "timeline": {
+    "keywords": {
+      "chapter": "Chương {{n}}",
+      "part": "Phần {{n}}",
+      "boss": "Boss {{n}}",
+      "final_boss": "Boss cuối",
+      "intro": "Mở đầu",
+      "ending": "Kết thúc",
+      "tutorial": "Hướng dẫn",
+      "credits": "Credits"
+    }
   }
 }

--- a/src/i18n/locales/zh/templates.json
+++ b/src/i18n/locales/zh/templates.json
@@ -81,5 +81,17 @@
       "guide": "本播放列表是{{channelName}}的{{gameName}}无声攻略。\n无解说。",
       "highlights": "本播放列表包含{{channelName}}的{{gameName}}精彩集锦。\n无解说。"
     }
+  },
+  "timeline": {
+    "keywords": {
+      "chapter": "第{{n}}章",
+      "part": "第{{n}}部分",
+      "boss": "Boss {{n}}",
+      "final_boss": "最终Boss",
+      "intro": "开场",
+      "ending": "结局",
+      "tutorial": "教程",
+      "credits": "片尾"
+    }
   }
 }

--- a/tests/engine/timeline-parser.test.ts
+++ b/tests/engine/timeline-parser.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { parseTimeline, renderTimeline } from "@engine/timeline-parser";
+import type { TranslationFn } from "@engine/types";
+
+// Minimal translation lookup keyed by (language, keyword id).
+// Mirrors the shape of the real templates.json entries.
+const DICT: Record<string, Record<string, string>> = {
+  en: {
+    chapter: "Chapter {{n}}",
+    part: "Part {{n}}",
+    boss: "Boss {{n}}",
+    final_boss: "Final Boss",
+    intro: "Intro",
+    ending: "Ending",
+    tutorial: "Tutorial",
+    credits: "Credits",
+  },
+  vi: {
+    chapter: "Chương {{n}}",
+    part: "Phần {{n}}",
+    boss: "Boss {{n}}",
+    final_boss: "Boss cuối",
+    intro: "Mở đầu",
+    ending: "Kết thúc",
+    tutorial: "Hướng dẫn",
+    credits: "Credits",
+  },
+  ja: {
+    chapter: "第{{n}}章",
+    part: "パート{{n}}",
+    boss: "ボス{{n}}",
+    final_boss: "ラスボス",
+    intro: "オープニング",
+    ending: "エンディング",
+    tutorial: "チュートリアル",
+    credits: "クレジット",
+  },
+};
+
+function makeT(lang: "en" | "vi" | "ja"): TranslationFn {
+  return (key, opts) => {
+    const id = key.replace("timeline.keywords.", "");
+    const template = DICT[lang][id] ?? id;
+    if (!opts) return template;
+    return template.replace(/\{\{(\w+)\}\}/g, (_, k) => opts[k] ?? "");
+  };
+}
+
+describe("parseTimeline", () => {
+  it("parses time + label into entries", () => {
+    const entries = parseTimeline("0:00 Intro\n5:30 Chapter 1\n15:00 Boss 2");
+    expect(entries).toHaveLength(3);
+    expect(entries[0].time).toBe("0:00");
+    expect(entries[0].keyword).toBe("intro");
+    expect(entries[1].keyword).toBe("chapter");
+    expect(entries[1].number).toBe(1);
+    expect(entries[2].keyword).toBe("boss");
+    expect(entries[2].number).toBe(2);
+  });
+
+  it("supports HH:MM:SS timecodes", () => {
+    const entries = parseTimeline("1:23:45 Chapter 7");
+    expect(entries[0].time).toBe("1:23:45");
+    expect(entries[0].keyword).toBe("chapter");
+    expect(entries[0].number).toBe(7);
+  });
+
+  it("recognizes final boss before boss", () => {
+    const entries = parseTimeline("10:00 Final Boss");
+    expect(entries[0].keyword).toBe("final_boss");
+  });
+
+  it("recognizes Vietnamese keywords", () => {
+    const entries = parseTimeline("0:00 Mở đầu\n5:00 Chương 3\n20:00 Boss cuối");
+    expect(entries[0].keyword).toBe("intro");
+    expect(entries[1].keyword).toBe("chapter");
+    expect(entries[1].number).toBe(3);
+    expect(entries[2].keyword).toBe("final_boss");
+  });
+
+  it("recognizes Japanese keywords", () => {
+    const entries = parseTimeline("0:00 オープニング\n5:00 パート 2\n20:00 ラスボス");
+    expect(entries[0].keyword).toBe("intro");
+    expect(entries[1].keyword).toBe("part");
+    expect(entries[1].number).toBe(2);
+    expect(entries[2].keyword).toBe("final_boss");
+  });
+
+  it("preserves lines that don't match a known keyword", () => {
+    const entries = parseTimeline("0:00 Random Stuff");
+    expect(entries[0].time).toBe("0:00");
+    expect(entries[0].keyword).toBeUndefined();
+    expect(entries[0].rawLabel).toBe("Random Stuff");
+  });
+
+  it("preserves lines without a time prefix", () => {
+    const entries = parseTimeline("Just a note");
+    expect(entries[0].time).toBe("");
+    expect(entries[0].rawLabel).toBe("Just a note");
+  });
+
+  it("skips blank lines", () => {
+    const entries = parseTimeline("\n0:00 Intro\n\n5:00 Chapter 1\n");
+    expect(entries).toHaveLength(2);
+  });
+});
+
+describe("renderTimeline", () => {
+  it("translates English input to Vietnamese", () => {
+    const entries = parseTimeline("0:00 Intro\n5:30 Chapter 1\n10:00 Boss 2\n20:00 Final Boss");
+    const out = renderTimeline(entries, "vi", makeT("vi"));
+    expect(out).toBe("0:00 Mở đầu\n5:30 Chương 1\n10:00 Boss 2\n20:00 Boss cuối");
+  });
+
+  it("translates English input to Japanese", () => {
+    const entries = parseTimeline("0:00 Intro\n5:30 Chapter 1");
+    const out = renderTimeline(entries, "ja", makeT("ja"));
+    expect(out).toBe("0:00 オープニング\n5:30 第1章");
+  });
+
+  it("keeps unrecognized labels verbatim", () => {
+    const entries = parseTimeline("0:00 Intro\n7:00 Random Stuff");
+    const out = renderTimeline(entries, "vi", makeT("vi"));
+    expect(out).toBe("0:00 Mở đầu\n7:00 Random Stuff");
+  });
+
+  it("renders English (identity) correctly", () => {
+    const entries = parseTimeline("0:00 Intro\n5:30 Chapter 1\n10:00 Boss 2");
+    const out = renderTimeline(entries, "en", makeT("en"));
+    expect(out).toBe("0:00 Intro\n5:30 Chapter 1\n10:00 Boss 2");
+  });
+});


### PR DESCRIPTION
## Summary
- New pure engine module ``src/engine/timeline-parser.ts`` that recognizes chapter-style markers across 6 languages and re-renders them in the user's selected output language.
- Keywords recognized: ``Chapter``, ``Part``, ``Boss``, ``Final Boss``, ``Intro``, ``Ending``, ``Tutorial``, ``Credits`` (with en/vi/ja/es/ko/zh aliases). Ordinal numbers are extracted.
- ``description-builder.ts`` now parses + renders the raw timestamp input instead of dumping it verbatim.
- New ``timeline.keywords`` namespace added to all 6 ``templates.json`` files and to the schema.
- 12 new parser/renderer tests; unrecognized labels pass through unchanged.

## Test plan
- [x] ``npm run validate:locales`` passes
- [x] ``npm run typecheck`` passes
- [x] ``npm run test:run`` passes (56 tests)
- [ ] Pick language=vi, enter ``0:00 Chapter 1`` -> description shows ``0:00 Chương 1``

🤖 Generated with [Claude Code](https://claude.com/claude-code)