### PR TITLE
fix(platforms): proper URL regex for Steam + itch.io with normalize

### DIFF
--- a/src/components/editor/StoreLinkEditor.tsx
+++ b/src/components/editor/StoreLinkEditor.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from "react-i18next";
 import { ValidatedInput } from "@components/ui/ValidatedInput";
 import { PLATFORMS } from "@config/platforms";
 import { useEditorStore } from "@store/editor-store";
-import { validateUrlWithPrefix } from "@utils/validation";
+import { validateUrlWithPattern } from "@utils/validation";
 
 export function StoreLinkEditor() {
   const { t } = useTranslation("ui");
@@ -19,8 +19,12 @@ export function StoreLinkEditor() {
             label={platform.label}
             placeholder={platform.urlPrefix}
             value={storeLinks[platform.id] ?? ""}
-            onChange={(v) => setNested("storeLinks", platform.id, v)}
-            validate={(v) => validateUrlWithPrefix(v, platform.urlPrefix)}
+            onChange={(v) => {
+              // Normalize (e.g. strip Steam slug) before committing.
+              const final = v && platform.normalize ? platform.normalize(v) : v;
+              setNested("storeLinks", platform.id, final);
+            }}
+            validate={(v) => validateUrlWithPattern(v, platform.urlPattern)}
           />
         ))}
       </div>

--- a/src/config/platforms.ts
+++ b/src/config/platforms.ts
@@ -1,13 +1,92 @@
-export const PLATFORMS = [
-  { id: "steam", label: "Steam", urlPrefix: "https://store.steampowered.com/app/" },
-  { id: "epic", label: "Epic Games Store", urlPrefix: "https://store.epicgames.com/" },
-  { id: "ps", label: "PlayStation Store", urlPrefix: "https://store.playstation.com/" },
-  { id: "xbox", label: "Xbox / Microsoft Store", urlPrefix: "https://www.xbox.com/games/" },
-  { id: "nintendo", label: "Nintendo eShop", urlPrefix: "https://www.nintendo.com/store/" },
-  { id: "gog", label: "GOG", urlPrefix: "https://www.gog.com/game/" },
-  { id: "itchio", label: "itch.io", urlPrefix: "https://itch.io/" },
-  { id: "humble", label: "Humble Bundle", urlPrefix: "https://www.humblebundle.com/store/" },
-  { id: "amazon", label: "Amazon Luna", urlPrefix: "https://www.amazon.com/luna/" },
+export interface PlatformConfig {
+  readonly id: string;
+  readonly label: string;
+  /** Shown as placeholder / hint to the user. */
+  readonly urlPrefix: string;
+  /** Authoritative validator. Must match the entire trimmed URL. */
+  readonly urlPattern: RegExp;
+  /**
+   * Optional canonicaliser run on already-valid URLs before commit.
+   * Useful for stripping trailing slug segments (e.g. Steam app pages
+   * include the game name after the app id).
+   */
+  readonly normalize?: (url: string) => string;
+}
+
+/**
+ * Normaliser for Steam store URLs.
+ *
+ * Valid shape: `https://store.steampowered.com/app/<id>` with an optional
+ * trailing slug such as `/ELDEN_RING/`. This strips everything after the
+ * numeric id, yielding the canonical `.../app/<id>` form.
+ */
+function normalizeSteamUrl(url: string): string {
+  const match = url.match(
+    /^(https:\/\/store\.steampowered\.com\/app\/\d+)(?:\/.*)?$/i,
+  );
+  return match?.[1] ?? url;
+}
+
+export const PLATFORMS: readonly PlatformConfig[] = [
+  {
+    id: "steam",
+    label: "Steam",
+    urlPrefix: "https://store.steampowered.com/app/",
+    // /app/<digits>, optionally followed by /<slug> or trailing slash.
+    urlPattern: /^https:\/\/store\.steampowered\.com\/app\/\d+(?:\/[^\s]*)?$/i,
+    normalize: normalizeSteamUrl,
+  },
+  {
+    id: "epic",
+    label: "Epic Games Store",
+    urlPrefix: "https://store.epicgames.com/",
+    urlPattern: /^https:\/\/store\.epicgames\.com\/[^\s]+$/i,
+  },
+  {
+    id: "ps",
+    label: "PlayStation Store",
+    urlPrefix: "https://store.playstation.com/",
+    urlPattern: /^https:\/\/store\.playstation\.com\/[^\s]+$/i,
+  },
+  {
+    id: "xbox",
+    label: "Xbox / Microsoft Store",
+    urlPrefix: "https://www.xbox.com/games/",
+    urlPattern: /^https:\/\/www\.xbox\.com\/[^\s]+$/i,
+  },
+  {
+    id: "nintendo",
+    label: "Nintendo eShop",
+    urlPrefix: "https://www.nintendo.com/store/",
+    urlPattern: /^https:\/\/www\.nintendo\.com\/[^\s]+$/i,
+  },
+  {
+    id: "gog",
+    label: "GOG",
+    urlPrefix: "https://www.gog.com/game/",
+    urlPattern: /^https:\/\/www\.gog\.com\/[^\s]+$/i,
+  },
+  {
+    id: "itchio",
+    label: "itch.io",
+    urlPrefix: "https://<dev>.itch.io/<game>",
+    // itch.io games live at https://<dev>.itch.io/<game>, where <dev>
+    // is a user subdomain. Reject the bare https://itch.io/... host.
+    urlPattern:
+      /^https:\/\/[a-z0-9][a-z0-9-]*\.itch\.io\/[a-z0-9][a-z0-9_-]*\/?$/i,
+  },
+  {
+    id: "humble",
+    label: "Humble Bundle",
+    urlPrefix: "https://www.humblebundle.com/store/",
+    urlPattern: /^https:\/\/www\.humblebundle\.com\/[^\s]+$/i,
+  },
+  {
+    id: "amazon",
+    label: "Amazon Luna",
+    urlPrefix: "https://www.amazon.com/luna/",
+    urlPattern: /^https:\/\/www\.amazon\.com\/[^\s]+$/i,
+  },
 ] as const;
 
 export type PlatformId = (typeof PLATFORMS)[number]["id"];

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -76,3 +76,25 @@ export function validateUrlWithPrefix(
 
   return { valid: true };
 }
+
+/**
+ * Validate a URL against a platform-specific RegExp. Unlike
+ * validateUrlWithPrefix, prefix-style mismatches are treated as hard
+ * errors so invalid links can be kept out of the output.
+ */
+export function validateUrlWithPattern(
+  input: string,
+  pattern: RegExp,
+): ValidationResult {
+  const trimmed = input.trim();
+  if (!trimmed) return { valid: true };
+
+  const baseResult = validateUrl(trimmed);
+  if (!baseResult.valid) return baseResult;
+
+  if (!pattern.test(trimmed)) {
+    return { valid: false, error: "validation.urlInvalid" };
+  }
+
+  return { valid: true };
+}

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { validateUrlWithPattern } from "@utils/validation";
+import { PLATFORMS } from "@config/platforms";
+
+function platform(id: string) {
+  const p = PLATFORMS.find((x) => x.id === id);
+  if (!p) throw new Error(`unknown platform ${id}`);
+  return p;
+}
+
+describe("validateUrlWithPattern — Steam", () => {
+  const steam = platform("steam");
+
+  it("accepts canonical app URL without trailing slash", () => {
+    const result = validateUrlWithPattern(
+      "https://store.steampowered.com/app/1245620",
+      steam.urlPattern,
+    );
+    expect(result.valid).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("accepts app URL with trailing slug", () => {
+    const result = validateUrlWithPattern(
+      "https://store.steampowered.com/app/1245620/ELDEN_RING/",
+      steam.urlPattern,
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects URLs without /app/<id>", () => {
+    expect(
+      validateUrlWithPattern(
+        "https://store.steampowered.com/",
+        steam.urlPattern,
+      ).valid,
+    ).toBe(false);
+    expect(
+      validateUrlWithPattern(
+        "https://store.steampowered.com/news/app/123",
+        steam.urlPattern,
+      ).valid,
+    ).toBe(false);
+  });
+
+  it("rejects totally unrelated URLs", () => {
+    expect(
+      validateUrlWithPattern("https://example.com", steam.urlPattern).valid,
+    ).toBe(false);
+  });
+
+  it("accepts empty input (not an error)", () => {
+    expect(validateUrlWithPattern("", steam.urlPattern).valid).toBe(true);
+  });
+});
+
+describe("Steam normalize", () => {
+  const steam = platform("steam");
+
+  it("strips trailing slug from canonical URL", () => {
+    expect(
+      steam.normalize?.(
+        "https://store.steampowered.com/app/1245620/ELDEN_RING/",
+      ),
+    ).toBe("https://store.steampowered.com/app/1245620");
+  });
+
+  it("is a no-op on an already-normalized URL", () => {
+    expect(
+      steam.normalize?.("https://store.steampowered.com/app/1245620"),
+    ).toBe("https://store.steampowered.com/app/1245620");
+  });
+
+  it("leaves unrelated URLs alone", () => {
+    expect(steam.normalize?.("https://example.com/app/123")).toBe(
+      "https://example.com/app/123",
+    );
+  });
+});
+
+describe("validateUrlWithPattern — itch.io", () => {
+  const itch = platform("itchio");
+
+  it("accepts dev subdomain URL", () => {
+    expect(
+      validateUrlWithPattern(
+        "https://devname.itch.io/my-game",
+        itch.urlPattern,
+      ).valid,
+    ).toBe(true);
+  });
+
+  it("accepts trailing slash", () => {
+    expect(
+      validateUrlWithPattern(
+        "https://devname.itch.io/my-game/",
+        itch.urlPattern,
+      ).valid,
+    ).toBe(true);
+  });
+
+  it("rejects the bare itch.io host", () => {
+    expect(
+      validateUrlWithPattern("https://itch.io/games", itch.urlPattern).valid,
+    ).toBe(false);
+  });
+
+  it("rejects missing game slug", () => {
+    expect(
+      validateUrlWithPattern("https://devname.itch.io/", itch.urlPattern).valid,
+    ).toBe(false);
+  });
+
+  it("accepts empty input (not an error)", () => {
+    expect(validateUrlWithPattern("", itch.urlPattern).valid).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- ``PLATFORMS`` entries now carry an authoritative ``urlPattern`` RegExp plus an optional ``normalize(url)`` hook.
- Steam accepts ``https://store.steampowered.com/app/<id>`` with optional slug; a normalizer strips the slug so the committed URL is canonical.
- itch.io enforces the ``https://<dev>.itch.io/<game>`` subdomain form (rejecting the bare ``https://itch.io/`` host).
- New ``validateUrlWithPattern()`` helper; prefix mismatches are now hard errors instead of silent warnings.
- 13 new tests cover Steam + itch.io accept/reject plus Steam normalization.

## Test plan
- [x] ``npm run typecheck`` passes
- [x] ``npm run test:run`` passes (69 tests)
- [ ] Paste ``https://store.steampowered.com/app/1245620/ELDEN_RING/`` -> stored as ``https://store.steampowered.com/app/1245620``
- [ ] Paste ``https://itch.io/games`` -> rejected; ``https://devname.itch.io/my-game`` -> accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)