### PR TITLE
fix(validation): clear committed value when URL is invalid

### DIFF
--- a/src/components/ui/ValidatedInput.tsx
+++ b/src/components/ui/ValidatedInput.tsx
@@ -30,14 +30,20 @@ export function ValidatedInput({
       setDisplayValue(newValue);
       const result = validate(newValue);
       if (result.valid && !result.error) {
+        // Fully valid: commit the value to the store.
         setError(null);
         onChange(newValue);
       } else if (result.valid && result.error) {
-        // Warning (valid but prefix mismatch)
+        // Warning (e.g. prefix mismatch from validateUrlWithPrefix).
+        // Surface the warning but still commit so the user can decide.
         setError(t(result.error, result.errorParams as Record<string, string>));
         onChange(newValue);
       } else {
+        // Invalid: show the error and CLEAR the committed value so the
+        // bad input never reaches the generated description/tags. The
+        // local displayValue is preserved so the user can keep editing.
         setError(t(result.error ?? "", result.errorParams as Record<string, string>));
+        onChange("");
       }
       setTouched(true);
     },


### PR DESCRIPTION
## Summary
- ``ValidatedInput`` now commits ``""`` (not the raw input) when the validator reports a hard error.
- Local ``displayValue`` is preserved so the user can keep editing the bad input.
- Since the engine already filters out empty strings, invalid URLs silently drop out of the generated description/tags until they become valid.
- Warning-level results (prefix mismatch) still commit so the user can override.

## Test plan
- [x] ``npm run typecheck`` passes
- [x] ``npm run test:run`` passes (69 tests)
- [ ] Web: type ``not-a-url`` into Steam -> error shows, output description has no Steam line; fix it to a valid URL -> line reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)