### PR TITLE
feat(rig): add Video Editor dropdown + version field

### DIFF
--- a/src/components/editor/RigEditor.tsx
+++ b/src/components/editor/RigEditor.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { Input } from "@components/ui/Input";
+import { Select } from "@components/ui/Select";
 import { RIG_FIELDS } from "@config/rig-fields";
 import { useEditorStore } from "@store/editor-store";
 
@@ -12,15 +13,46 @@ export function RigEditor() {
     <div className="flex flex-col gap-3">
       <span className="text-sm font-medium text-text-secondary">{t("editor.rig")}</span>
       <div className="grid grid-cols-2 gap-2">
-        {RIG_FIELDS.map((field) => (
-          <Input
-            key={field.id}
-            label={t(field.labelKey)}
-            placeholder={field.placeholder}
-            value={rig[field.id] ?? ""}
-            onChange={(e) => setNested("rig", field.id, e.target.value)}
-          />
-        ))}
+        {RIG_FIELDS.map((field) => {
+          if (field.type === "dropdown_with_version") {
+            const raw = rig[field.id] ?? "";
+            const [value = "", version = ""] = raw.split("|");
+
+            const commit = (nextValue: string, nextVersion: string) => {
+              // Keep the stored form compact: drop the pipe when empty.
+              const next =
+                !nextValue && !nextVersion ? "" : `${nextValue}|${nextVersion}`;
+              setNested("rig", field.id, next);
+            };
+
+            return (
+              <div key={field.id} className="col-span-2 grid grid-cols-[1fr_auto] gap-2">
+                <Select
+                  label={t(field.labelKey)}
+                  value={value}
+                  options={field.options ?? []}
+                  onChange={(v) => commit(v, version)}
+                />
+                <Input
+                  label={t("editor.version")}
+                  placeholder={field.versionPlaceholder}
+                  value={version}
+                  onChange={(e) => commit(value, e.target.value)}
+                />
+              </div>
+            );
+          }
+
+          return (
+            <Input
+              key={field.id}
+              label={t(field.labelKey)}
+              placeholder={field.placeholder}
+              value={rig[field.id] ?? ""}
+              onChange={(e) => setNested("rig", field.id, e.target.value)}
+            />
+          );
+        })}
       </div>
     </div>
   );

--- a/src/config/rig-fields.ts
+++ b/src/config/rig-fields.ts
@@ -1,12 +1,91 @@
-export const RIG_FIELDS = [
-  { id: "cpu", labelKey: "rig.cpu", placeholder: "Intel i9-14900K / AMD Ryzen 9 7950X" },
-  { id: "gpu", labelKey: "rig.gpu", placeholder: "NVIDIA RTX 4090 / AMD RX 7900 XTX" },
-  { id: "ram", labelKey: "rig.ram", placeholder: "32GB DDR5-6000" },
-  { id: "storage", labelKey: "rig.storage", placeholder: "2TB Samsung 990 PRO NVMe" },
-  { id: "monitor", labelKey: "rig.monitor", placeholder: "LG 27GP950 27\" 4K 144Hz" },
-  { id: "capture", labelKey: "rig.capture", placeholder: "OBS Studio 30.x" },
-  { id: "motherboard", labelKey: "rig.motherboard", placeholder: "ASUS ROG Maximus Z790 Hero" },
-  { id: "controller", labelKey: "rig.controller", placeholder: "DualSense / Xbox Elite Series 2" },
-] as const;
+/**
+ * Supported rig field input types.
+ *
+ * - `text`: plain text input (existing behaviour).
+ * - `dropdown_with_version`: a dropdown of preset options paired with a
+ *   free-form version text input. The stored value is
+ *   `"<option_value>|<version>"` so we don't break the flat
+ *   `Partial<Record<string, string>>` rig shape in the editor store.
+ */
+export type RigFieldType = "text" | "dropdown_with_version";
+
+export interface RigFieldOption {
+  readonly value: string;
+  /** Display label (not translated — software names are brand-preserved). */
+  readonly label: string;
+}
+
+export interface RigField {
+  readonly id: string;
+  readonly labelKey: string;
+  readonly type: RigFieldType;
+  readonly placeholder?: string;
+  readonly options?: readonly RigFieldOption[];
+  readonly versionPlaceholder?: string;
+}
+
+/**
+ * Dropdown options for the video editing software field.
+ *
+ * Order loosely reflects popularity among no-commentary gameplay
+ * creators. Add new entries here — the UI picks them up automatically.
+ */
+export const VIDEO_EDITOR_OPTIONS: readonly RigFieldOption[] = [
+  { value: "", label: "—" },
+  { value: "davinci_resolve", label: "DaVinci Resolve" },
+  { value: "davinci_resolve_studio", label: "DaVinci Resolve Studio" },
+  { value: "premiere", label: "Adobe Premiere Pro" },
+  { value: "after_effects", label: "Adobe After Effects" },
+  { value: "capcut", label: "CapCut" },
+  { value: "vegas", label: "Vegas Pro" },
+  { value: "final_cut", label: "Final Cut Pro" },
+  { value: "kdenlive", label: "Kdenlive" },
+  { value: "shotcut", label: "Shotcut" },
+  { value: "filmora", label: "Wondershare Filmora" },
+  { value: "other", label: "Other" },
+];
+
+export const RIG_FIELDS: readonly RigField[] = [
+  { id: "cpu", labelKey: "rig.cpu", type: "text", placeholder: "Intel i9-14900K / AMD Ryzen 9 7950X" },
+  { id: "gpu", labelKey: "rig.gpu", type: "text", placeholder: "NVIDIA RTX 4090 / AMD RX 7900 XTX" },
+  { id: "ram", labelKey: "rig.ram", type: "text", placeholder: "32GB DDR5-6000" },
+  { id: "storage", labelKey: "rig.storage", type: "text", placeholder: "2TB Samsung 990 PRO NVMe" },
+  { id: "monitor", labelKey: "rig.monitor", type: "text", placeholder: "LG 27GP950 27\" 4K 144Hz" },
+  { id: "capture", labelKey: "rig.capture", type: "text", placeholder: "OBS Studio 30.x" },
+  { id: "motherboard", labelKey: "rig.motherboard", type: "text", placeholder: "ASUS ROG Maximus Z790 Hero" },
+  { id: "controller", labelKey: "rig.controller", type: "text", placeholder: "DualSense / Xbox Elite Series 2" },
+  {
+    id: "video_editor",
+    labelKey: "rig.video_editor",
+    type: "dropdown_with_version",
+    options: VIDEO_EDITOR_OPTIONS,
+    versionPlaceholder: "19.1 / 2024 / v5.0",
+  },
+];
 
 export type RigFieldId = (typeof RIG_FIELDS)[number]["id"];
+
+/**
+ * Format a stored rig value for display in the description output.
+ * For dropdown_with_version fields, this turns `"davinci_resolve_studio|19.1"`
+ * into `"DaVinci Resolve Studio 19.1"`. Other values pass through.
+ */
+export function formatRigValue(fieldId: string, raw: string): string {
+  const field = RIG_FIELDS.find((f) => f.id === fieldId);
+  if (!field || field.type !== "dropdown_with_version") return raw;
+
+  const [value = "", version = ""] = raw.split("|");
+  const trimmedVersion = version.trim();
+  if (!value && !trimmedVersion) return "";
+
+  // The empty-value sentinel option renders as "—" in the dropdown but
+  // should act as "no selection" in the output.
+  let label = "";
+  if (value) {
+    const option = field.options?.find((o) => o.value === value);
+    label = option?.label ?? value;
+  }
+
+  if (!label) return trimmedVersion;
+  return trimmedVersion ? `${label} ${trimmedVersion}` : label;
+}

--- a/src/engine/description-builder.ts
+++ b/src/engine/description-builder.ts
@@ -2,6 +2,7 @@ import type { GeneratorInput, TranslationFn, CharLimitWarning } from "./types";
 import { YT_LIMITS } from "./types";
 import { PLATFORMS } from "@config/platforms";
 import { SOCIAL_FIELDS } from "@config/social-fields";
+import { formatRigValue } from "@config/rig-fields";
 import { parseTimeline, renderTimeline } from "./timeline-parser";
 
 const SOCIAL_ICONS: Record<string, string> = {
@@ -83,10 +84,13 @@ export function buildDescription(
   // 6. Rig
   if (hasEntries(input.rig)) {
     const rigLines = Object.entries(input.rig)
+      .map(([k, v]) => [k, formatRigValue(k, v ?? "")] as const)
       .filter(([, v]) => v && v.trim() !== "")
       .map(([k, v]) => `${k.toUpperCase()}: ${v}`)
       .join("\n");
-    sections.push(`${t("description.sections.rig")}\n${rigLines}`);
+    if (rigLines) {
+      sections.push(`${t("description.sections.rig")}\n${rigLines}`);
+    }
   }
 
   // 7. Spoiler Warning

--- a/src/i18n/locales/_schema.json
+++ b/src/i18n/locales/_schema.json
@@ -13,7 +13,7 @@
       "spoilerWarning", "matureWarning",
       "playlistLink", "playlistLinkPlaceholder",
       "contactEmail", "contactEmailPlaceholder", "contactEmailHelp",
-      "videoSettings", "quickPreview",
+      "videoSettings", "quickPreview", "version",
       "clearDraft", "draftSaved", "clearDraftConfirm"
     ],
     "output": [
@@ -24,7 +24,7 @@
     "common": ["save", "cancel", "delete", "confirm", "export", "import", "reset", "search", "generate"],
     "videoTypes": ["full", "part", "full_demo", "demo_part", "boss", "boss_nohit", "ending", "speedrun", "100percent", "dlc", "newgame_plus", "challenge", "side_quest", "secret", "comparison", "guide"],
     "genres": ["action", "horror", "rpg", "fps", "openworld", "indie", "soulslike", "racing", "story", "simulation", "fighting", "stealth", "survival_craft", "roguelike", "metroidvania", "mmo", "rhythm", "puzzle", "tower_defense", "card_game", "battle_royale", "crpg", "tactical", "space", "farming", "fmv", "visual_novel"],
-    "rig": ["cpu", "gpu", "ram", "storage", "monitor", "capture", "motherboard", "controller"],
+    "rig": ["cpu", "gpu", "ram", "storage", "monitor", "capture", "motherboard", "controller", "video_editor"],
     "social": ["kofi", "patreon", "buymeacoffee", "paypal", "github", "twitter", "discord", "website", "twitch", "tiktok", "instagram", "streamlabs", "bluesky", "mastodon", "facebook", "fb_page", "fb_group"],
     "resolutions": ["720p", "1080p", "1440p", "4K"],
     "fpsOptions": ["30", "60", "120", "144"],

--- a/src/i18n/locales/en/ui.json
+++ b/src/i18n/locales/en/ui.json
@@ -47,6 +47,7 @@
     "contactEmailPlaceholder": "business@example.com",
     "videoSettings": "Video Settings",
     "quickPreview": "Quick Preview",
+    "version": "Version",
     "clearDraft": "Clear Draft",
     "draftSaved": "Draft saved",
     "clearDraftConfirm": "Are you sure you want to clear all form data?",
@@ -130,7 +131,8 @@
     "monitor": "Monitor",
     "capture": "Capture Software",
     "motherboard": "Motherboard",
-    "controller": "Controller"
+    "controller": "Controller",
+    "video_editor": "Video Editor"
   },
   "social": {
     "kofi": "Ko-fi",

--- a/src/i18n/locales/es/ui.json
+++ b/src/i18n/locales/es/ui.json
@@ -47,6 +47,7 @@
     "contactEmailPlaceholder": "negocios@ejemplo.com",
     "videoSettings": "Ajustes de Video",
     "quickPreview": "Vista Previa Rápida",
+    "version": "Versión",
     "clearDraft": "Limpiar Borrador",
     "draftSaved": "Borrador guardado",
     "clearDraftConfirm": "¿Estás seguro de que quieres borrar todos los datos del formulario?",
@@ -130,7 +131,8 @@
     "monitor": "Monitor",
     "capture": "Software de Captura",
     "motherboard": "Placa Base",
-    "controller": "Mando"
+    "controller": "Mando",
+    "video_editor": "Editor de Video"
   },
   "social": {
     "kofi": "Ko-fi",

--- a/src/i18n/locales/ja/ui.json
+++ b/src/i18n/locales/ja/ui.json
@@ -47,6 +47,7 @@
     "contactEmailPlaceholder": "business@example.com",
     "videoSettings": "動画設定",
     "quickPreview": "クイックプレビュー",
+    "version": "バージョン",
     "clearDraft": "下書きをクリア",
     "draftSaved": "下書き保存済み",
     "clearDraftConfirm": "フォームデータをすべてクリアしますか？",
@@ -130,7 +131,8 @@
     "monitor": "モニター",
     "capture": "キャプチャソフト",
     "motherboard": "マザーボード",
-    "controller": "コントローラー"
+    "controller": "コントローラー",
+    "video_editor": "動画編集ソフト"
   },
   "social": {
     "kofi": "Ko-fi",

--- a/src/i18n/locales/ko/ui.json
+++ b/src/i18n/locales/ko/ui.json
@@ -47,6 +47,7 @@
     "contactEmailPlaceholder": "business@example.com",
     "videoSettings": "영상 설정",
     "quickPreview": "빠른 미리보기",
+    "version": "버전",
     "clearDraft": "초안 지우기",
     "draftSaved": "초안 저장됨",
     "clearDraftConfirm": "모든 양식 데이터를 지우시겠습니까?",
@@ -130,7 +131,8 @@
     "monitor": "모니터",
     "capture": "캡처 소프트웨어",
     "motherboard": "메인보드",
-    "controller": "컨트롤러"
+    "controller": "컨트롤러",
+    "video_editor": "영상 편집 프로그램"
   },
   "social": {
     "kofi": "Ko-fi",

--- a/src/i18n/locales/vi/ui.json
+++ b/src/i18n/locales/vi/ui.json
@@ -47,6 +47,7 @@
     "contactEmailPlaceholder": "business@example.com",
     "videoSettings": "Cài đặt Video",
     "quickPreview": "Xem trước nhanh",
+    "version": "Phiên bản",
     "clearDraft": "Xóa bản nháp",
     "draftSaved": "Đã lưu nháp",
     "clearDraftConfirm": "Bạn có chắc muốn xóa toàn bộ dữ liệu form?",
@@ -130,7 +131,8 @@
     "monitor": "Màn hình",
     "capture": "Phần mềm quay",
     "motherboard": "Bo mạch chủ",
-    "controller": "Tay cầm"
+    "controller": "Tay cầm",
+    "video_editor": "Phần mềm dựng video"
   },
   "social": {
     "kofi": "Ko-fi",

--- a/src/i18n/locales/zh/ui.json
+++ b/src/i18n/locales/zh/ui.json
@@ -47,6 +47,7 @@
     "contactEmailPlaceholder": "business@example.com",
     "videoSettings": "视频设置",
     "quickPreview": "快速预览",
+    "version": "版本",
     "clearDraft": "清除草稿",
     "draftSaved": "草稿已保存",
     "clearDraftConfirm": "确定要清除所有表单数据吗？",
@@ -130,7 +131,8 @@
     "monitor": "显示器",
     "capture": "录制软件",
     "motherboard": "主板",
-    "controller": "手柄"
+    "controller": "手柄",
+    "video_editor": "视频编辑软件"
   },
   "social": {
     "kofi": "Ko-fi",

--- a/tests/engine/rig-fields.test.ts
+++ b/tests/engine/rig-fields.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { formatRigValue, RIG_FIELDS } from "@config/rig-fields";
+
+describe("formatRigValue", () => {
+  it("passes text fields through unchanged", () => {
+    expect(formatRigValue("cpu", "Ryzen 9 7950X")).toBe("Ryzen 9 7950X");
+  });
+
+  it("formats dropdown_with_version with both parts", () => {
+    expect(formatRigValue("video_editor", "davinci_resolve_studio|19.1")).toBe(
+      "DaVinci Resolve Studio 19.1",
+    );
+  });
+
+  it("formats dropdown_with_version with no version", () => {
+    expect(formatRigValue("video_editor", "capcut|")).toBe("CapCut");
+  });
+
+  it("formats dropdown_with_version with only version", () => {
+    // Only a version with an empty option renders just the version —
+    // this is technically malformed input but we shouldn't crash.
+    expect(formatRigValue("video_editor", "|1.0")).toBe("1.0");
+  });
+
+  it("returns empty string when the whole value is blank", () => {
+    expect(formatRigValue("video_editor", "")).toBe("");
+    expect(formatRigValue("video_editor", "|")).toBe("");
+  });
+
+  it("falls back to the raw option id when unknown", () => {
+    expect(formatRigValue("video_editor", "unknown_tool|1.0")).toBe(
+      "unknown_tool 1.0",
+    );
+  });
+
+  it("includes a video_editor entry in RIG_FIELDS", () => {
+    const field = RIG_FIELDS.find((f) => f.id === "video_editor");
+    expect(field?.type).toBe("dropdown_with_version");
+    expect(field?.options?.length).toBeGreaterThan(3);
+  });
+});


### PR DESCRIPTION
## Summary
- New rig field ``video_editor`` with a dropdown of popular editors (DaVinci Resolve / Studio, Premiere, After Effects, CapCut, Vegas, Final Cut, Kdenlive, Shotcut, Filmora, Other) and a separate version text input.
- Introduces a ``RigFieldType`` discriminant so future rig fields can use new input types without touching every callsite.
- Stored form is ``"<option_id>|<version>"``; ``formatRigValue()`` expands this to e.g. ``"DaVinci Resolve Studio 19.1"`` for the description output.
- All 6 ui.json locales gain ``editor.version`` and ``rig.video_editor``.

## Test plan
- [x] ``npm run validate:locales`` passes (213 ui keys)
- [x] ``npm run typecheck`` passes
- [x] ``npm run test:run`` passes (76 tests)
- [ ] Pick DaVinci Resolve Studio + version 19.1 in editor -> description shows ``VIDEO_EDITOR: DaVinci Resolve Studio 19.1``

🤖 Generated with [Claude Code](https://claude.com/claude-code)