### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yt-desc-gen",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yt-desc-gen",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yt-desc-gen",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5070,7 +5070,7 @@ dependencies = [
 
 [[package]]
 name = "yt-desc-gen"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yt-desc-gen"
-version = "0.2.0"
+version = "0.4.0"
 description = "YouTube Gameplay Description Generator"
 authors = ["poli0981"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "YTDescGen",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "identifier": "com.skullmute.ytdescgen",
   "build": {
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
## Summary
Bumps the application version across all version-bearing files in preparation for the ``v0.4.0`` signed tag.

Covers every PR merged since ``v0.2.0``:

**Phase A** (PR #9–#15)
- fix(tauri): tray Quit actually exits
- ci: drop macOS from release matrix
- feat(playlist): ``[status] - Game`` title format
- feat(video-types): ``full_demo`` + ``demo_part``
- feat(tags): per-language scoping + ``visual_novel`` genre
- feat(timeline): i18n chapter parser

**Phase B** (PR #16–#19)
- fix(platforms): proper Steam/itch.io regex + Steam normalize
- fix(validation): clear committed value when URL invalid
- feat(rig): Video Editor dropdown + version field
- feat(store-links): per-link Free/Paid/Demo + dynamic heading

## Files
- ``package.json`` / ``package-lock.json``
- ``src-tauri/Cargo.toml`` / ``Cargo.lock``
- ``src-tauri/tauri.conf.json``

## Test plan
- [x] ``npm run validate:locales``
- [x] ``npm run typecheck``
- [x] ``npm run test:run`` (81 tests)
- [x] ``cargo check``

🤖 Generated with [Claude Code](https://claude.com/claude-code)