### PR TITLE
Phase 1: fix underscore leaks + Tauri settings-folder opener

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",
         "@tauri-apps/plugin-fs": "^2.0.0",
+        "@tauri-apps/plugin-opener": "^2.0.0",
         "@tauri-apps/plugin-shell": "^2.0.0",
         "clsx": "^2.1.0",
         "i18next": "^23.15.0",
@@ -1511,6 +1512,15 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-opener": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.3.tgz",
+      "integrity": "sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/plugin-shell": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",
     "@tauri-apps/plugin-fs": "^2.0.0",
+    "@tauri-apps/plugin-opener": "^2.0.0",
     "@tauri-apps/plugin-shell": "^2.0.0"
   },
   "devDependencies": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
+tauri-plugin-opener = "2"
 tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -10,6 +10,15 @@
     "fs:default",
     "fs:allow-read-text-file",
     "fs:allow-write-text-file",
-    "shell:default"
+    "shell:default",
+    "opener:default",
+    {
+      "identifier": "opener:allow-open-path",
+      "allow": [{ "path": "$APPDATA" }, { "path": "$APPDATA/**" }]
+    },
+    {
+      "identifier": "opener:allow-reveal-item-in-dir",
+      "allow": [{ "path": "$APPDATA" }, { "path": "$APPDATA/**" }]
+    }
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,6 +33,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
+        .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_shell::init())
         .setup(move |app| {
             let show = MenuItem::with_id(app, "show", "Show YTDescGen", true, None::<&str>)?;

--- a/src/engine/description-builder.ts
+++ b/src/engine/description-builder.ts
@@ -4,6 +4,7 @@ import { PLATFORMS } from "@config/platforms";
 import { SOCIAL_FIELDS } from "@config/social-fields";
 import { formatRigValue } from "@config/rig-fields";
 import { parseTimeline, renderTimeline } from "./timeline-parser";
+import { sanitizeHashtag } from "@utils/sanitize";
 
 const SOCIAL_ICONS: Record<string, string> = {
   kofi: "☕",
@@ -66,10 +67,12 @@ export function buildDescription(
   // 4. Store Links (heading + per-link suffix by pricing category)
   if (hasEntries(input.storeLinks)) {
     const entries = Object.entries(input.storeLinks)
-      .filter(([, url]) => url && url.trim() !== "")
+      .filter((entry): entry is [string, string] =>
+        typeof entry[1] === "string" && entry[1].trim() !== "",
+      )
       .map(([id, url]) => ({
         id,
-        url: url!.trim(),
+        url: url.trim(),
         type: (input.storeLinkTypes?.[id] ?? "paid") as "paid" | "free" | "demo",
       }));
 
@@ -113,7 +116,7 @@ export function buildDescription(
     const rigLines = Object.entries(input.rig)
       .map(([k, v]) => [k, formatRigValue(k, v ?? "")] as const)
       .filter(([, v]) => v && v.trim() !== "")
-      .map(([k, v]) => `${k.toUpperCase()}: ${v}`)
+      .map(([k, v]) => `${k.replace(/_/g, " ").toUpperCase()}: ${v}`)
       .join("\n");
     if (rigLines) {
       sections.push(`${t("description.sections.rig")}\n${rigLines}`);
@@ -167,9 +170,9 @@ export function buildDescription(
 
   // 14. Hashtags
   const allHashtags = [
-    `#${gameName.replace(/\s+/g, "")}`,
+    `#${sanitizeHashtag(gameName)}`,
     "#GameplayNoCommentary",
-    `#${input.genre}`,
+    `#${sanitizeHashtag(input.genre)}`,
   ];
   sections.push(allHashtags.slice(0, hashtagCount).join(" "));
 

--- a/src/engine/tag-generator.ts
+++ b/src/engine/tag-generator.ts
@@ -1,5 +1,6 @@
 import type { GeneratorInput, SupportedLanguage } from "./types";
 import { YT_LIMITS } from "./types";
+import { humanizeId } from "@utils/sanitize";
 
 /**
  * Genre tag pool registry.
@@ -172,7 +173,8 @@ function getQualityTags(gameName: string, resolution?: string, fps?: string): st
 
 function getTrendingTags(gameName: string, genre: string): string[] {
   const year = new Date().getFullYear().toString();
-  return [`${gameName} ${year}`, `best ${genre} games ${year}`, `${genre} gameplay ${year}`];
+  const genreLabel = humanizeId(genre);
+  return [`${gameName} ${year}`, `best ${genreLabel} games ${year}`, `${genreLabel} gameplay ${year}`];
 }
 
 export interface TagOptions {

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -15,9 +15,9 @@ import { logger } from "@utils/logger";
 async function openSettingsFolder() {
   try {
     const { appDataDir } = await import("@tauri-apps/api/path");
-    const { open } = await import("@tauri-apps/plugin-shell");
+    const { openPath } = await import("@tauri-apps/plugin-opener");
     const dir = await appDataDir();
-    await open(dir);
+    await openPath(dir);
   } catch (e) {
     toast.error("Could not open settings folder");
     logger.error("settings", "Failed to open settings folder", String(e));

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,0 +1,26 @@
+/**
+ * Strip every character that is not a Unicode letter or digit.
+ *
+ * Used to turn a free-form game name or genre id into a valid hashtag body.
+ * Spaces, punctuation, separators, and emoji are all removed; accented
+ * letters and non-Latin scripts are preserved via `\p{L}` / `\p{N}`.
+ *
+ *   "S.T.A.L.K.E.R. 2"     -> "STALKER2"
+ *   "Yakuza: Like a Dragon"-> "YakuzaLikeaDragon"
+ *   "visual_novel"         -> "visualnovel"
+ *   "仁王 2"                -> "仁王2"
+ */
+export function sanitizeHashtag(name: string): string {
+  return name.normalize("NFC").replace(/[^\p{L}\p{N}]/gu, "");
+}
+
+/**
+ * Turn a snake_case identifier into a space-separated, human-readable form.
+ * Used for free-text tag strings where the id would otherwise leak as-is.
+ *
+ *   "visual_novel"    -> "visual novel"
+ *   "survival_craft"  -> "survival craft"
+ */
+export function humanizeId(id: string): string {
+  return id.replace(/_/g, " ");
+}

--- a/tests/engine/description-builder.test.ts
+++ b/tests/engine/description-builder.test.ts
@@ -31,6 +31,23 @@ describe("buildDescription", () => {
     expect(result).toContain("#EldenRing");
   });
 
+  it("sanitises hashtags for game names with special characters", () => {
+    const t = createMockT("en");
+    const result = buildDescription(
+      makeInput({ gameName: "S.T.A.L.K.E.R. 2" }),
+      t,
+    );
+    expect(result).toContain("#STALKER2");
+    expect(result).not.toMatch(/#\s?S\./);
+  });
+
+  it("sanitises hashtags for snake_case genre ids (fixes #visual_novel bug)", () => {
+    const t = createMockT("en");
+    const result = buildDescription(makeInput({ genre: "visual_novel" }), t);
+    expect(result).toContain("#visualnovel");
+    expect(result).not.toContain("#visual_novel");
+  });
+
   it("includes timestamps when provided", () => {
     const t = createMockT("en");
     const result = buildDescription(
@@ -154,6 +171,16 @@ describe("buildDescription", () => {
     expect(result).toContain("MY RIG");
     expect(result).toContain("CPU: i9-14900K");
     expect(result).toContain("GPU: RTX 4090");
+  });
+
+  it("humanises snake_case rig keys (e.g. video_editor → VIDEO EDITOR)", () => {
+    const t = createMockT("en");
+    const result = buildDescription(
+      makeInput({ rig: { video_editor: "davinci_resolve_studio|19.1" } }),
+      t,
+    );
+    expect(result).toContain("VIDEO EDITOR: DaVinci Resolve Studio 19.1");
+    expect(result).not.toContain("VIDEO_EDITOR");
   });
 
   it("includes spoiler warning when enabled", () => {

--- a/tests/engine/tag-generator.test.ts
+++ b/tests/engine/tag-generator.test.ts
@@ -47,6 +47,19 @@ describe("generateTags", () => {
     expect(tags.some((t) => t.toLowerCase().includes("boss"))).toBe(true);
   });
 
+  it("humanises snake_case genres in trending tags (fixes visual_novel leak)", () => {
+    const tags = generateTags(
+      makeInput({ genre: "visual_novel" }),
+      { includeTrendingTags: true },
+    );
+    // No tag should contain the raw underscore form
+    expect(tags.every((t) => !t.includes("visual_novel"))).toBe(true);
+    // The humanised form should be present in the trending tags
+    const year = new Date().getFullYear().toString();
+    expect(tags.some((t) => t === `best visual novel games ${year}`)).toBe(true);
+    expect(tags.some((t) => t === `visual novel gameplay ${year}`)).toBe(true);
+  });
+
   it("includes video type tags for speedrun", () => {
     const tags = generateTags(makeInput({ videoType: "speedrun" }));
     expect(tags.some((t) => t.toLowerCase().includes("speedrun"))).toBe(true);

--- a/tests/utils/sanitize.test.ts
+++ b/tests/utils/sanitize.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeHashtag, humanizeId } from "@utils/sanitize";
+
+describe("sanitizeHashtag", () => {
+  it("drops spaces", () => {
+    expect(sanitizeHashtag("Elden Ring")).toBe("EldenRing");
+  });
+
+  it("drops periods and colons", () => {
+    expect(sanitizeHashtag("S.T.A.L.K.E.R. 2")).toBe("STALKER2");
+    expect(sanitizeHashtag("Yakuza: Like a Dragon")).toBe("YakuzaLikeaDragon");
+  });
+
+  it("drops apostrophes, hyphens, ampersands, parentheses", () => {
+    expect(sanitizeHashtag("Assassin's Creed")).toBe("AssassinsCreed");
+    expect(sanitizeHashtag("Spider-Man")).toBe("SpiderMan");
+    expect(sanitizeHashtag("Sonic & Knuckles")).toBe("SonicKnuckles");
+    expect(sanitizeHashtag("Prey (2017)")).toBe("Prey2017");
+  });
+
+  it("drops underscores (fixes #visual_novel bug)", () => {
+    expect(sanitizeHashtag("visual_novel")).toBe("visualnovel");
+    expect(sanitizeHashtag("survival_craft")).toBe("survivalcraft");
+    expect(sanitizeHashtag("tower_defense")).toBe("towerdefense");
+  });
+
+  it("keeps digits and letters intact", () => {
+    expect(sanitizeHashtag("Cyberpunk 2077")).toBe("Cyberpunk2077");
+    expect(sanitizeHashtag("100% Orange Juice")).toBe("100OrangeJuice");
+  });
+
+  it("preserves non-Latin scripts", () => {
+    expect(sanitizeHashtag("仁王 2")).toBe("仁王2");
+    expect(sanitizeHashtag("プレイ動画")).toBe("プレイ動画");
+    expect(sanitizeHashtag("게임 플레이")).toBe("게임플레이");
+  });
+
+  it("preserves accented characters", () => {
+    expect(sanitizeHashtag("Pokémon Violet")).toBe("PokémonViolet");
+    expect(sanitizeHashtag("Café World")).toBe("CaféWorld");
+  });
+
+  it("handles empty input", () => {
+    expect(sanitizeHashtag("")).toBe("");
+    expect(sanitizeHashtag("   ")).toBe("");
+    expect(sanitizeHashtag("!!!")).toBe("");
+  });
+
+  it("drops emojis", () => {
+    expect(sanitizeHashtag("🎮 Elden Ring 🔥")).toBe("EldenRing");
+  });
+});
+
+describe("humanizeId", () => {
+  it("replaces underscores with spaces", () => {
+    expect(humanizeId("visual_novel")).toBe("visual novel");
+    expect(humanizeId("survival_craft")).toBe("survival craft");
+    expect(humanizeId("tower_defense")).toBe("tower defense");
+  });
+
+  it("leaves single-word ids untouched", () => {
+    expect(humanizeId("action")).toBe("action");
+    expect(humanizeId("rpg")).toBe("rpg");
+  });
+
+  it("handles multiple underscores", () => {
+    expect(humanizeId("a_b_c_d")).toBe("a b c d");
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of the v0.5 roadmap — three display/functionality bugs that a user flagged:

- **Bug 1** — Rig section printed raw snake_case keys (`VIDEO_EDITOR:` instead of `VIDEO EDITOR:`).
- **Bug 2** — Hashtags and trending tags leaked the raw genre id (`#visual_novel`, `best visual_novel games 2026`) and didn't cope with punctuation in game names (`#S.T.A.L.K.E.R.2`).
- **Bug 3** — _Settings → Open Folder_ always toast-failed with "Could not open settings folder" because the shell plugin's `open()` needs `shell:allow-open`, which isn't in `shell:default`.

## Changes

### Engine
- New `src/utils/sanitize.ts` with `sanitizeHashtag` (keeps only Unicode letters/digits) and `humanizeId` (snake_case → spaces).
- `description-builder.ts`: rig keys now go through `k.replace(/_/g, " ").toUpperCase()`, hashtags go through `sanitizeHashtag`.
- `tag-generator.ts`: trending tag template runs the genre through `humanizeId`.
- Also fixes a pre-existing ESLint error (`url!.trim()` non-null assertion) that has been failing CI on main since #19 — narrowed the store-links filter with a type predicate so the assertion isn't needed.

### Tauri
- Swapped `tauri-plugin-shell` → `tauri-plugin-opener` for the _Open Folder_ action. Opener is purpose-built for this in Tauri v2 and doesn't require the broader shell capability.
- `capabilities/default.json` grants `opener:default`, `opener:allow-open-path`, and `opener:allow-reveal-item-in-dir` scoped to `$APPDATA` / `$APPDATA/**`.
- `SettingsPage.tsx` now calls `openPath(dir)` from `@tauri-apps/plugin-opener`.

### Tests
- 97 passing (+16 new). New coverage:
  - `tests/utils/sanitize.test.ts` — 12 tests (special chars, emoji, non-Latin scripts, underscores).
  - `tests/engine/description-builder.test.ts` — 3 tests (snake_case rig humanisation, `S.T.A.L.K.E.R. 2` hashtag, `#visual_novel` → `#visualnovel`).
  - `tests/engine/tag-generator.test.ts` — 1 test (trending tag humanisation).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (was failing on `main`)
- [x] `npm run validate:locales` clean
- [x] `npm run test:run` — 97 passing
- [x] `npm run build` — production bundle builds
- [x] Manual Tauri verify — _Settings → Open Folder_ reveals `%APPDATA%\com.skullmute.ytdescgen\` in Explorer (user-confirmed)
- [x] Manual verify — rig with Video Editor field and `visual_novel` genre produce clean output

🤖 Generated with [Claude Code](https://claude.com/claude-code)