### PR TITLE
Phase 3: quality badge in title + mods/collectibles video types

### DIFF
--- a/src/components/editor/GameInfoForm.tsx
+++ b/src/components/editor/GameInfoForm.tsx
@@ -66,6 +66,14 @@ export function GameInfoForm() {
           onChange={(e) => store.set("challengeName", e.target.value)}
         />
       )}
+      {extraFields.includes("modName") && (
+        <Input
+          label={t("editor.modName")}
+          placeholder={t("editor.modNamePlaceholder")}
+          value={store.modName ?? ""}
+          onChange={(e) => store.set("modName", e.target.value)}
+        />
+      )}
     </div>
   );
 }

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -14,6 +14,7 @@ export interface EditorDefaults {
   bossName: string;
   dlcName: string;
   challengeName: string;
+  modName: string;
   resolution: string;
   fps: string;
   graphicsPreset: string;
@@ -47,6 +48,7 @@ export const DEFAULTS = {
     bossName: "",
     dlcName: "",
     challengeName: "",
+    modName: "",
     resolution: "1080p",
     fps: "60",
     graphicsPreset: "Ultra",

--- a/src/config/video-types.ts
+++ b/src/config/video-types.ts
@@ -15,6 +15,8 @@ export const VIDEO_TYPES = [
   { id: "secret", labelKey: "videoTypes.secret", icon: "🔍", extraFields: [] },
   { id: "comparison", labelKey: "videoTypes.comparison", icon: "⚖️", extraFields: [] },
   { id: "guide", labelKey: "videoTypes.guide", icon: "📘", extraFields: [] },
+  { id: "mods", labelKey: "videoTypes.mods", icon: "🧩", extraFields: ["modName"] },
+  { id: "collectibles", labelKey: "videoTypes.collectibles", icon: "⭐", extraFields: [] },
 ] as const;
 
 export type VideoTypeId = (typeof VIDEO_TYPES)[number]["id"];

--- a/src/engine/description-builder.ts
+++ b/src/engine/description-builder.ts
@@ -51,6 +51,7 @@ export function buildDescription(
     bossName: input.bossName ?? "",
     dlcName: input.dlcName ?? "",
     challengeName: input.challengeName ?? "",
+    modName: input.modName ?? "",
   });
   sections.push(intro);
 

--- a/src/engine/tag-generator.ts
+++ b/src/engine/tag-generator.ts
@@ -179,6 +179,18 @@ const VIDEO_TYPE_TAGS: Record<string, (gameName: string) => string[]> = {
   secret: (g) => [`${g} secret`, `${g} hidden`, "secret content no commentary"],
   comparison: (g) => [`${g} comparison`, `${g} graphics comparison`, "comparison no commentary"],
   guide: (g) => [`${g} guide`, `${g} silent guide`, "guide no commentary"],
+  mods: (g) => [
+    `${g} mods`,
+    `${g} modded gameplay`,
+    "modded gameplay no commentary",
+    `${g} mod showcase`,
+  ],
+  collectibles: (g) => [
+    `${g} all collectibles`,
+    `${g} 100% collectibles`,
+    `${g} completionist no commentary`,
+    `${g} achievement guide`,
+  ],
 };
 
 /**

--- a/src/engine/template-renderer.ts
+++ b/src/engine/template-renderer.ts
@@ -6,6 +6,13 @@ import { YT_LIMITS } from "./types";
 
 export interface RenderOptions extends TagOptions {
   hashtagCount?: number;
+  /**
+   * When true, buildTitle appends a `[2K 60FPS]`-style badge to the
+   * video-type segment whenever resolution/fps are above the defaults.
+   * Defaults to true at the engine level; callers override with the
+   * user's setting.
+   */
+  showQualityBadge?: boolean;
 }
 
 export function renderAll(
@@ -13,7 +20,7 @@ export function renderAll(
   t: TranslationFn,
   options?: RenderOptions,
 ): GeneratorOutput {
-  const title = buildTitle(input, t);
+  const title = buildTitle(input, t, options?.showQualityBadge ?? true);
   const description = buildDescription(input, t, options?.hashtagCount);
   const tags = generateTags(input, options);
   const tagString = formatTagString(tags);

--- a/src/engine/title-builder.ts
+++ b/src/engine/title-builder.ts
@@ -1,7 +1,32 @@
 import type { GeneratorInput, TranslationFn, CharLimitWarning } from "./types";
 import { YT_LIMITS } from "./types";
 
-export function buildTitle(input: GeneratorInput, t: TranslationFn): string {
+/**
+ * Compact "[2K 60FPS]" badge appended to the video-type segment when the
+ * recording quality is above the defaults (1080p / 60fps).
+ *
+ * Rules:
+ * - 1080p + 60fps → empty string (no badge, keeps the title short).
+ * - Resolution above 1080p → map 1440p to "2K"; 720p/4K pass through.
+ * - Non-default FPS → include the resolution alongside (e.g. "1080p 120FPS")
+ *   so a lonely FPS number isn't ambiguous.
+ */
+export function buildQualityBadge(resolution?: string, fps?: string): string {
+  const res = resolution || "1080p";
+  const fpsValue = fps || "60";
+  const resDefault = res === "1080p";
+  const fpsDefault = fpsValue === "60";
+  if (resDefault && fpsDefault) return "";
+
+  const resLabel = res === "1440p" ? "2K" : res;
+  return fpsDefault ? resLabel : `${resLabel} ${fpsValue}FPS`;
+}
+
+export function buildTitle(
+  input: GeneratorInput,
+  t: TranslationFn,
+  showQualityBadge = true,
+): string {
   const separator = t("title.separator");
   const suffix = t("title.suffix");
 
@@ -10,14 +35,21 @@ export function buildTitle(input: GeneratorInput, t: TranslationFn): string {
     bossName: input.bossName ?? "",
     dlcName: input.dlcName ?? "",
     challengeName: input.challengeName ?? "",
+    modName: input.modName ?? "",
   });
 
   const gameName =
     input.gameNameLocalized?.[input.language] ?? input.gameName;
 
+  const qualityBadge = showQualityBadge ? buildQualityBadge(input.resolution, input.fps) : "";
+
   const parts = [gameName];
   if (videoTypeLabel) {
-    parts.push(videoTypeLabel);
+    parts.push(qualityBadge ? `${videoTypeLabel} [${qualityBadge}]` : videoTypeLabel);
+  } else if (qualityBadge) {
+    // Edge case: some video types render to empty string (e.g. "full").
+    // Still surface the quality badge as its own segment so viewers see it.
+    parts.push(`[${qualityBadge}]`);
   }
   parts.push(suffix);
 

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -14,7 +14,9 @@ export type VideoType =
   | "side_quest"
   | "secret"
   | "comparison"
-  | "guide";
+  | "guide"
+  | "mods"
+  | "collectibles";
 
 export type Genre =
   | "action"
@@ -94,6 +96,7 @@ export interface GeneratorInput {
   bossName?: string;
   dlcName?: string;
   challengeName?: string;
+  modName?: string;
   resolution?: string;
   fps?: string;
   graphicsPreset?: string;

--- a/src/hooks/use-generated-output.ts
+++ b/src/hooks/use-generated-output.ts
@@ -7,7 +7,8 @@ import type { GeneratorOutput, GeneratorInput } from "@engine/types";
 
 export function useGeneratedOutput(): GeneratorOutput {
   const state = useEditorStore();
-  const { includeMultilingualTags, includeTrendingTags, hashtagCount } = useSettingsStore();
+  const { includeMultilingualTags, includeTrendingTags, hashtagCount, showQualityBadge } =
+    useSettingsStore();
 
   const input: GeneratorInput = useMemo(
     () => ({
@@ -70,7 +71,8 @@ export function useGeneratedOutput(): GeneratorOutput {
         includeMultilingualTags,
         includeTrendingTags,
         hashtagCount,
+        showQualityBadge,
       }),
-    [input, t, includeMultilingualTags, includeTrendingTags, hashtagCount],
+    [input, t, includeMultilingualTags, includeTrendingTags, hashtagCount, showQualityBadge],
   );
 }

--- a/src/hooks/use-multilang-output.ts
+++ b/src/hooks/use-multilang-output.ts
@@ -9,7 +9,8 @@ export function useMultilangOutput(
   languages: SupportedLanguage[],
 ): Record<string, GeneratorOutput> {
   const state = useEditorStore();
-  const { includeMultilingualTags, includeTrendingTags, hashtagCount } = useSettingsStore();
+  const { includeMultilingualTags, includeTrendingTags, hashtagCount, showQualityBadge } =
+    useSettingsStore();
 
   return useMemo(() => {
     const results: Record<string, GeneratorOutput> = {};
@@ -44,6 +45,7 @@ export function useMultilangOutput(
         includeMultilingualTags,
         includeTrendingTags,
         hashtagCount,
+        showQualityBadge,
       });
     }
     return results;
@@ -74,5 +76,6 @@ export function useMultilangOutput(
     includeMultilingualTags,
     includeTrendingTags,
     hashtagCount,
+    showQualityBadge,
   ]);
 }

--- a/src/i18n/locales/_schema.json
+++ b/src/i18n/locales/_schema.json
@@ -7,6 +7,7 @@
       "channelName", "channelNamePlaceholder", "platform",
       "partNumber", "partNumberPlaceholder", "bossName", "bossNamePlaceholder",
       "dlcName", "dlcNamePlaceholder", "challengeName", "challengeNamePlaceholder",
+      "modName", "modNamePlaceholder",
       "resolution", "fps", "graphicsPreset",
       "timestamps", "timestampsPlaceholder",
       "storeLinks", "storeLinkType", "rig", "social", "warnings",
@@ -23,7 +24,7 @@
       "copied", "charCount", "selectLanguages"
     ],
     "common": ["save", "cancel", "delete", "confirm", "export", "import", "reset", "search", "generate"],
-    "videoTypes": ["full", "part", "full_demo", "demo_part", "boss", "boss_nohit", "ending", "speedrun", "100percent", "dlc", "newgame_plus", "challenge", "side_quest", "secret", "comparison", "guide"],
+    "videoTypes": ["full", "part", "full_demo", "demo_part", "boss", "boss_nohit", "ending", "speedrun", "100percent", "dlc", "newgame_plus", "challenge", "side_quest", "secret", "comparison", "guide", "mods", "collectibles"],
     "genres": ["action", "hack_slash", "beatemup", "platformer", "horror", "survival_horror", "psychological_horror", "rpg", "jrpg", "action_rpg", "crpg", "fps", "arena_shooter", "tactical_fps", "boomer_shooter", "extraction_shooter", "shmup", "openworld", "indie", "soulslike", "racing", "story", "simulation", "city_builder", "fighting", "stealth", "survival_craft", "roguelike", "metroidvania", "mmo", "rhythm", "puzzle", "tower_defense", "card_game", "deck_builder", "auto_battler", "battle_royale", "tactical", "space", "farming", "fmv", "visual_novel"],
     "rig": ["cpu", "gpu", "ram", "storage", "monitor", "capture", "motherboard", "controller", "video_editor"],
     "social": ["kofi", "patreon", "buymeacoffee", "paypal", "github", "twitter", "discord", "website", "twitch", "tiktok", "instagram", "streamlabs", "bluesky", "mastodon", "facebook", "fb_page", "fb_group"],
@@ -32,7 +33,7 @@
     "profiles": ["title", "createNew", "editProfile", "profileName", "profileNamePlaceholder", "loadProfile", "deleteConfirm", "emptyState", "exportProfiles", "importProfiles"],
     "presets": ["title", "createNew", "editPreset", "loadPreset", "deleteConfirm", "emptyState", "selectPreset", "noPresets", "exportPresets", "importPresets"],
     "history": ["title", "emptyState", "clearAll", "clearConfirm", "searchPlaceholder"],
-    "settings": ["title", "appearance", "defaults", "editorSettings", "tagSettings", "historySettings", "theme", "appLanguage", "defaultOutputLanguage", "defaultGenre", "autoSaveDraft", "showCharCount", "compactTagDisplay", "historyLimit", "multilingualTags", "trendingTags", "hashtagCount"],
+    "settings": ["title", "appearance", "defaults", "editorSettings", "tagSettings", "historySettings", "theme", "appLanguage", "defaultOutputLanguage", "defaultGenre", "autoSaveDraft", "showCharCount", "compactTagDisplay", "historyLimit", "multilingualTags", "trendingTags", "hashtagCount", "showQualityBadge"],
     "batch": ["title", "startPart", "endPart", "generateBatch", "copyAllBatch", "emptyState"],
     "shortcuts": ["title", "generate", "copyAll", "saveDraft", "help", "close"],
     "validation": ["emailInvalid", "emailMaxExceeded", "urlInvalid", "urlPrefixMismatch"],
@@ -41,8 +42,8 @@
   },
   "templates": {
     "title": ["separator", "suffix"],
-    "title.videoType": ["full", "part", "full_demo", "demo_part", "boss", "boss_nohit", "ending", "speedrun", "100percent", "dlc", "newgame_plus", "challenge", "side_quest", "secret", "comparison", "guide"],
-    "description.intro": ["full", "part", "full_demo", "demo_part", "boss", "boss_nohit", "ending", "speedrun", "100percent", "dlc", "newgame_plus", "challenge", "side_quest", "secret", "comparison", "guide"],
+    "title.videoType": ["full", "part", "full_demo", "demo_part", "boss", "boss_nohit", "ending", "speedrun", "100percent", "dlc", "newgame_plus", "challenge", "side_quest", "secret", "comparison", "guide", "mods", "collectibles"],
+    "description.intro": ["full", "part", "full_demo", "demo_part", "boss", "boss_nohit", "ending", "speedrun", "100percent", "dlc", "newgame_plus", "challenge", "side_quest", "secret", "comparison", "guide", "mods", "collectibles"],
     "description": ["noCommentaryLine"],
     "description.sections": [
       "timestamps", "storeLinksBuy", "storeLinksDownload", "videoSettings", "rig",

--- a/src/i18n/locales/en/templates.json
+++ b/src/i18n/locales/en/templates.json
@@ -18,7 +18,9 @@
       "side_quest": "Side Quest",
       "secret": "Secret",
       "comparison": "Comparison",
-      "guide": "Guide"
+      "guide": "Guide",
+      "mods": "{{modName}} Mods",
+      "collectibles": "All Collectibles"
     }
   },
   "description": {
@@ -38,7 +40,9 @@
       "side_quest": "This video features side quests and optional content from {{gameName}} on {{channelName}}.",
       "secret": "This video features secrets and hidden content from {{gameName}} on {{channelName}}.",
       "comparison": "This video compares the graphics/performance of {{gameName}} on {{channelName}}.",
-      "guide": "This video is a silent guide for {{gameName}} on {{channelName}}."
+      "guide": "This video is a silent guide for {{gameName}} on {{channelName}}.",
+      "mods": "This video features the {{modName}} mod for {{gameName}} on {{channelName}}.",
+      "collectibles": "This video covers all collectibles and 100% completion of {{gameName}} on {{channelName}}."
     },
     "noCommentaryLine": "No Commentary — pure gameplay for your enjoyment.",
     "storeLinkSuffix": {

--- a/src/i18n/locales/en/ui.json
+++ b/src/i18n/locales/en/ui.json
@@ -30,6 +30,8 @@
     "dlcNamePlaceholder": "e.g. Shadow of the Erdtree",
     "challengeName": "Challenge Name",
     "challengeNamePlaceholder": "e.g. No Hit Run",
+    "modName": "Mod Name",
+    "modNamePlaceholder": "e.g. Requiem, NaturalVision Evolved",
     "resolution": "Resolution",
     "fps": "FPS",
     "graphicsPreset": "Graphics Preset",
@@ -93,7 +95,9 @@
     "side_quest": "Side Quests",
     "secret": "Secrets / Hidden",
     "comparison": "Graphics Comparison",
-    "guide": "Silent Guide"
+    "guide": "Silent Guide",
+    "mods": "Modded Gameplay",
+    "collectibles": "All Collectibles"
   },
   "genres": {
     "action": "Action / Adventure",
@@ -229,7 +233,8 @@
     "historyLimit": "History Limit",
     "multilingualTags": "Include Multilingual Tags",
     "trendingTags": "Include Trending Tags",
-    "hashtagCount": "Hashtag Count"
+    "hashtagCount": "Hashtag Count",
+    "showQualityBadge": "Show quality badge in title (e.g. [2K 60FPS])"
   },
   "batch": {
     "title": "Batch Mode",

--- a/src/i18n/locales/es/templates.json
+++ b/src/i18n/locales/es/templates.json
@@ -18,7 +18,9 @@
       "side_quest": "Misiones Secundarias",
       "secret": "Secretos",
       "comparison": "Comparación de Gráficos",
-      "guide": "Guía Silenciosa"
+      "guide": "Guía Silenciosa",
+      "mods": "Mod {{modName}}",
+      "collectibles": "Todos los Coleccionables"
     }
   },
   "description": {
@@ -38,7 +40,9 @@
       "side_quest": "Este video presenta misiones secundarias y contenido opcional de {{gameName}} en {{channelName}}.",
       "secret": "Este video presenta secretos y contenido oculto de {{gameName}} en {{channelName}}.",
       "comparison": "Este video presenta una comparación de gráficos de {{gameName}} en {{channelName}}.",
-      "guide": "Este video presenta una guía silenciosa de {{gameName}} en {{channelName}}."
+      "guide": "Este video presenta una guía silenciosa de {{gameName}} en {{channelName}}.",
+      "mods": "Este video presenta el mod {{modName}} para {{gameName}} en {{channelName}}.",
+      "collectibles": "Este video cubre todos los coleccionables y el 100% de {{gameName}} en {{channelName}}."
     },
     "noCommentaryLine": "Sin Comentarios — gameplay puro para tu disfrute.",
     "storeLinkSuffix": {

--- a/src/i18n/locales/es/ui.json
+++ b/src/i18n/locales/es/ui.json
@@ -30,6 +30,8 @@
     "dlcNamePlaceholder": "ej. Shadow of the Erdtree",
     "challengeName": "Nombre del Desafío",
     "challengeNamePlaceholder": "ej. Sin Golpes",
+    "modName": "Nombre del Mod",
+    "modNamePlaceholder": "ej. Requiem, NaturalVision Evolved",
     "resolution": "Resolución",
     "fps": "FPS",
     "graphicsPreset": "Calidad Gráfica",
@@ -93,7 +95,9 @@
     "side_quest": "Misiones Secundarias",
     "secret": "Secretos / Ocultos",
     "comparison": "Comparación de Gráficos",
-    "guide": "Guía Silenciosa"
+    "guide": "Guía Silenciosa",
+    "mods": "Gameplay con Mods",
+    "collectibles": "Todos los Coleccionables"
   },
   "genres": {
     "action": "Acción / Aventura",
@@ -229,7 +233,8 @@
     "historyLimit": "Límite de Historial",
     "multilingualTags": "Etiquetas Multilingües",
     "trendingTags": "Etiquetas Tendencia",
-    "hashtagCount": "Cantidad de Hashtags"
+    "hashtagCount": "Cantidad de Hashtags",
+    "showQualityBadge": "Mostrar insignia de calidad en el título (ej. [2K 60FPS])"
   },
   "batch": {
     "title": "Generación por Lote",

--- a/src/i18n/locales/ja/templates.json
+++ b/src/i18n/locales/ja/templates.json
@@ -18,7 +18,9 @@
       "side_quest": "サブクエスト",
       "secret": "隠し要素",
       "comparison": "グラフィック比較",
-      "guide": "攻略ガイド"
+      "guide": "攻略ガイド",
+      "mods": "{{modName}} MOD",
+      "collectibles": "全コレクション"
     }
   },
   "description": {
@@ -38,7 +40,9 @@
       "side_quest": "この動画は{{channelName}}による{{gameName}}のサブクエストです。",
       "secret": "この動画は{{channelName}}による{{gameName}}の隠し要素です。",
       "comparison": "この動画は{{channelName}}による{{gameName}}のグラフィック比較です。",
-      "guide": "この動画は{{channelName}}による{{gameName}}の攻略ガイドです。"
+      "guide": "この動画は{{channelName}}による{{gameName}}の攻略ガイドです。",
+      "mods": "この動画は{{channelName}}による{{gameName}}の{{modName}} MODプレイです。",
+      "collectibles": "この動画は{{channelName}}による{{gameName}}のコレクション完全攻略です。"
     },
     "noCommentaryLine": "実況なし — 純粋なゲームプレイをお楽しみください。",
     "storeLinkSuffix": {

--- a/src/i18n/locales/ja/ui.json
+++ b/src/i18n/locales/ja/ui.json
@@ -30,6 +30,8 @@
     "dlcNamePlaceholder": "例：Shadow of the Erdtree",
     "challengeName": "チャレンジ名",
     "challengeNamePlaceholder": "例：ノーヒットラン",
+    "modName": "MOD名",
+    "modNamePlaceholder": "例: Requiem, NaturalVision Evolved",
     "resolution": "解像度",
     "fps": "FPS",
     "graphicsPreset": "グラフィック設定",
@@ -93,7 +95,9 @@
     "side_quest": "サブクエスト",
     "secret": "隠し要素",
     "comparison": "グラフィック比較",
-    "guide": "攻略ガイド"
+    "guide": "攻略ガイド",
+    "mods": "MODプレイ",
+    "collectibles": "全コレクション"
   },
   "genres": {
     "action": "アクション / アドベンチャー",
@@ -229,7 +233,8 @@
     "historyLimit": "履歴上限",
     "multilingualTags": "多言語タグを含む",
     "trendingTags": "トレンドタグを含む",
-    "hashtagCount": "ハッシュタグ数"
+    "hashtagCount": "ハッシュタグ数",
+    "showQualityBadge": "タイトルに画質バッジを表示 (例: [2K 60FPS])"
   },
   "batch": {
     "title": "一括モード",

--- a/src/i18n/locales/ko/templates.json
+++ b/src/i18n/locales/ko/templates.json
@@ -18,7 +18,9 @@
       "side_quest": "서브 퀘스트",
       "secret": "비밀",
       "comparison": "그래픽 비교",
-      "guide": "무음 가이드"
+      "guide": "무음 가이드",
+      "mods": "{{modName}} 모드",
+      "collectibles": "모든 수집품"
     }
   },
   "description": {
@@ -38,7 +40,9 @@
       "side_quest": "이 영상은 {{channelName}}에서 {{gameName}}의 서브 퀘스트와 선택 콘텐츠를 담고 있습니다.",
       "secret": "이 영상은 {{channelName}}에서 {{gameName}}의 비밀과 숨겨진 요소를 담고 있습니다.",
       "comparison": "이 영상은 {{channelName}}에서 {{gameName}}의 그래픽 비교를 담고 있습니다.",
-      "guide": "이 영상은 {{channelName}}에서 {{gameName}}의 무음 가이드를 담고 있습니다."
+      "guide": "이 영상은 {{channelName}}에서 {{gameName}}의 무음 가이드를 담고 있습니다.",
+      "mods": "이 영상은 {{channelName}}에서 {{gameName}}의 {{modName}} 모드 플레이를 담고 있습니다.",
+      "collectibles": "이 영상은 {{channelName}}에서 {{gameName}}의 모든 수집 요소와 100% 완료 플레이를 담고 있습니다."
     },
     "noCommentaryLine": "무음 플레이 — 순수한 게임플레이를 즐겨보세요.",
     "storeLinkSuffix": {

--- a/src/i18n/locales/ko/ui.json
+++ b/src/i18n/locales/ko/ui.json
@@ -30,6 +30,8 @@
     "dlcNamePlaceholder": "예: Shadow of the Erdtree",
     "challengeName": "챌린지 이름",
     "challengeNamePlaceholder": "예: 노히트 런",
+    "modName": "모드 이름",
+    "modNamePlaceholder": "예: Requiem, NaturalVision Evolved",
     "resolution": "해상도",
     "fps": "FPS",
     "graphicsPreset": "그래픽 프리셋",
@@ -93,7 +95,9 @@
     "side_quest": "서브 퀘스트",
     "secret": "비밀 / 숨겨진 요소",
     "comparison": "그래픽 비교",
-    "guide": "무음 가이드"
+    "guide": "무음 가이드",
+    "mods": "모드 플레이",
+    "collectibles": "모든 수집품"
   },
   "genres": {
     "action": "액션 / 어드벤처",
@@ -229,7 +233,8 @@
     "historyLimit": "기록 제한",
     "multilingualTags": "다국어 태그",
     "trendingTags": "인기 태그",
-    "hashtagCount": "해시태그 수"
+    "hashtagCount": "해시태그 수",
+    "showQualityBadge": "제목에 화질 배지 표시 (예: [2K 60FPS])"
   },
   "batch": {
     "title": "일괄 생성",

--- a/src/i18n/locales/vi/templates.json
+++ b/src/i18n/locales/vi/templates.json
@@ -18,7 +18,9 @@
       "side_quest": "Nhiệm vụ phụ",
       "secret": "Bí mật",
       "comparison": "So sánh",
-      "guide": "Hướng dẫn"
+      "guide": "Hướng dẫn",
+      "mods": "Mod {{modName}}",
+      "collectibles": "Tất cả Sưu tầm"
     }
   },
   "description": {
@@ -38,7 +40,9 @@
       "side_quest": "Video này là các nhiệm vụ phụ trong {{gameName}} trên kênh {{channelName}}.",
       "secret": "Video này là nội dung bí mật và ẩn trong {{gameName}} trên kênh {{channelName}}.",
       "comparison": "Video này so sánh đồ họa/hiệu suất của {{gameName}} trên kênh {{channelName}}.",
-      "guide": "Video này là hướng dẫn không lời cho {{gameName}} trên kênh {{channelName}}."
+      "guide": "Video này là hướng dẫn không lời cho {{gameName}} trên kênh {{channelName}}.",
+      "mods": "Video này showcase mod {{modName}} cho {{gameName}} trên kênh {{channelName}}.",
+      "collectibles": "Video này gom đủ mọi vật phẩm sưu tầm và 100% completion trong {{gameName}} trên kênh {{channelName}}."
     },
     "noCommentaryLine": "Không bình luận — gameplay thuần túy để bạn thưởng thức.",
     "storeLinkSuffix": {

--- a/src/i18n/locales/vi/ui.json
+++ b/src/i18n/locales/vi/ui.json
@@ -30,6 +30,8 @@
     "dlcNamePlaceholder": "VD: Shadow of the Erdtree",
     "challengeName": "Tên Challenge",
     "challengeNamePlaceholder": "VD: No Hit Run",
+    "modName": "Tên Mod",
+    "modNamePlaceholder": "vd: Requiem, NaturalVision Evolved",
     "resolution": "Độ phân giải",
     "fps": "FPS",
     "graphicsPreset": "Cài đặt đồ họa",
@@ -93,7 +95,9 @@
     "side_quest": "Nhiệm vụ phụ",
     "secret": "Bí mật / Ẩn",
     "comparison": "So sánh đồ họa",
-    "guide": "Hướng dẫn"
+    "guide": "Hướng dẫn",
+    "mods": "Chơi với Mod",
+    "collectibles": "Full Sưu Tầm"
   },
   "genres": {
     "action": "Hành động / Phiêu lưu",
@@ -229,7 +233,8 @@
     "historyLimit": "Giới hạn lịch sử",
     "multilingualTags": "Tags đa ngôn ngữ",
     "trendingTags": "Tags xu hướng",
-    "hashtagCount": "Số hashtag"
+    "hashtagCount": "Số hashtag",
+    "showQualityBadge": "Hiện badge chất lượng trong tiêu đề (vd: [2K 60FPS])"
   },
   "batch": {
     "title": "Chế độ hàng loạt",

--- a/src/i18n/locales/zh/templates.json
+++ b/src/i18n/locales/zh/templates.json
@@ -18,7 +18,9 @@
       "side_quest": "支线任务",
       "secret": "秘密",
       "comparison": "画质对比",
-      "guide": "无声攻略"
+      "guide": "无声攻略",
+      "mods": "{{modName}} Mod",
+      "collectibles": "全收集要素"
     }
   },
   "description": {
@@ -38,7 +40,9 @@
       "side_quest": "本视频展示了{{channelName}}的{{gameName}}支线任务与可选内容。",
       "secret": "本视频展示了{{channelName}}的{{gameName}}秘密与隐藏内容。",
       "comparison": "本视频展示了{{channelName}}的{{gameName}}画质对比。",
-      "guide": "本视频展示了{{channelName}}的{{gameName}}无声攻略。"
+      "guide": "本视频展示了{{channelName}}的{{gameName}}无声攻略。",
+      "mods": "本视频展示了{{channelName}}的{{gameName}}之{{modName}} Mod游玩。",
+      "collectibles": "本视频展示了{{channelName}}的{{gameName}}全收集要素与100%完成度。"
     },
     "noCommentaryLine": "无解说 — 纯粹的游戏体验，尽情享受。",
     "storeLinkSuffix": {

--- a/src/i18n/locales/zh/ui.json
+++ b/src/i18n/locales/zh/ui.json
@@ -30,6 +30,8 @@
     "dlcNamePlaceholder": "例如：Shadow of the Erdtree",
     "challengeName": "挑战名称",
     "challengeNamePlaceholder": "例如：无伤通关",
+    "modName": "Mod 名称",
+    "modNamePlaceholder": "如：Requiem, NaturalVision Evolved",
     "resolution": "分辨率",
     "fps": "帧率",
     "graphicsPreset": "画质预设",
@@ -93,7 +95,9 @@
     "side_quest": "支线任务",
     "secret": "秘密 / 隐藏内容",
     "comparison": "画质对比",
-    "guide": "无声攻略"
+    "guide": "无声攻略",
+    "mods": "Mod 游玩",
+    "collectibles": "全收集要素"
   },
   "genres": {
     "action": "动作 / 冒险",
@@ -229,7 +233,8 @@
     "historyLimit": "历史记录上限",
     "multilingualTags": "多语言标签",
     "trendingTags": "热门标签",
-    "hashtagCount": "话题标签数量"
+    "hashtagCount": "话题标签数量",
+    "showQualityBadge": "在标题中显示画质标签 (如：[2K 60FPS])"
   },
   "batch": {
     "title": "批量生成",

--- a/src/pages/BatchPage.tsx
+++ b/src/pages/BatchPage.tsx
@@ -21,7 +21,8 @@ interface BatchResult {
 export function BatchPage() {
   const { t } = useTranslation("ui");
   const state = useEditorStore();
-  const { includeMultilingualTags, includeTrendingTags, hashtagCount } = useSettingsStore();
+  const { includeMultilingualTags, includeTrendingTags, hashtagCount, showQualityBadge } =
+    useSettingsStore();
   const [startPart, setStartPart] = useState("1");
   const [endPart, setEndPart] = useState("5");
   const [selectedLangs, setSelectedLangs] = useState<SupportedLanguage[]>([state.language]);
@@ -69,7 +70,15 @@ export function BatchPage() {
           social: state.social,
           rig: state.rig,
         };
-        return { language: lang, output: renderAll(input, tFn, { includeMultilingualTags, includeTrendingTags, hashtagCount }) };
+        return {
+          language: lang,
+          output: renderAll(input, tFn, {
+            includeMultilingualTags,
+            includeTrendingTags,
+            hashtagCount,
+            showQualityBadge,
+          }),
+        };
       });
       outputs.push({ partNumber: String(i), languages });
     }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -151,6 +151,11 @@ export function SettingsPage() {
             checked={settings.includeTrendingTags}
             onChange={(v) => settings.setSetting("includeTrendingTags", v)}
           />
+          <Toggle
+            label={t("settings.showQualityBadge")}
+            checked={settings.showQualityBadge}
+            onChange={(v) => settings.setSetting("showQualityBadge", v)}
+          />
           <Select
             label={t("settings.hashtagCount")}
             options={hashtagOptions}

--- a/src/store/editor-store.ts
+++ b/src/store/editor-store.ts
@@ -15,6 +15,7 @@ interface EditorData {
   bossName: string;
   dlcName: string;
   challengeName: string;
+  modName: string;
   resolution: string;
   fps: string;
   graphicsPreset: string;
@@ -56,6 +57,7 @@ const initialState: EditorData = {
   bossName: DEFAULTS.editor.bossName,
   dlcName: DEFAULTS.editor.dlcName,
   challengeName: DEFAULTS.editor.challengeName,
+  modName: DEFAULTS.editor.modName,
   resolution: DEFAULTS.editor.resolution,
   fps: DEFAULTS.editor.fps,
   graphicsPreset: DEFAULTS.editor.graphicsPreset,
@@ -121,6 +123,7 @@ export const useEditorStore = create<EditorState>()(
         bossName: state.bossName,
         dlcName: state.dlcName,
         challengeName: state.challengeName,
+        modName: state.modName,
         resolution: state.resolution,
         fps: state.fps,
         graphicsPreset: state.graphicsPreset,

--- a/src/store/settings-store.ts
+++ b/src/store/settings-store.ts
@@ -16,6 +16,7 @@ interface SettingsState {
   includeMultilingualTags: boolean;
   includeTrendingTags: boolean;
   hashtagCount: number;
+  showQualityBadge: boolean;
   setTheme: (theme: "dark" | "light") => void;
   setAppLanguage: (lang: SupportedLanguage) => void;
   setDefaultOutputLanguage: (lang: SupportedLanguage) => void;
@@ -35,6 +36,7 @@ interface SettingsData {
   includeMultilingualTags: boolean;
   includeTrendingTags: boolean;
   hashtagCount: number;
+  showQualityBadge: boolean;
 }
 
 const detectBrowserLanguage = (): SupportedLanguage => {
@@ -57,6 +59,7 @@ const initialSettings: SettingsData = {
   includeMultilingualTags: true,
   includeTrendingTags: true,
   hashtagCount: 3,
+  showQualityBadge: true,
 };
 
 const STORE_KEY = "ytdescgen-settings";
@@ -108,6 +111,7 @@ export const useSettingsStore = create<SettingsState>()(
         includeMultilingualTags: state.includeMultilingualTags,
         includeTrendingTags: state.includeTrendingTags,
         hashtagCount: state.hashtagCount,
+        showQualityBadge: state.showQualityBadge,
       }),
       onRehydrateStorage: () => {
         return () => {
@@ -143,6 +147,7 @@ useSettingsStore.subscribe((state) => {
     includeMultilingualTags: state.includeMultilingualTags,
     includeTrendingTags: state.includeTrendingTags,
     hashtagCount: state.hashtagCount,
+    showQualityBadge: state.showQualityBadge,
   };
   saveSettings(STORE_KEY, data);
 });

--- a/tests/engine/tag-generator.test.ts
+++ b/tests/engine/tag-generator.test.ts
@@ -47,6 +47,18 @@ describe("generateTags", () => {
     expect(tags.some((t) => t.toLowerCase().includes("boss"))).toBe(true);
   });
 
+  it("includes video type tags for mods", () => {
+    const tags = generateTags(makeInput({ videoType: "mods" }));
+    expect(tags.some((t) => t.toLowerCase().includes("mod"))).toBe(true);
+    expect(tags).toContain("modded gameplay no commentary");
+  });
+
+  it("includes video type tags for collectibles", () => {
+    const tags = generateTags(makeInput({ videoType: "collectibles" }));
+    expect(tags.some((t) => t.toLowerCase().includes("collectibles"))).toBe(true);
+    expect(tags).toContain("Elden Ring all collectibles");
+  });
+
   it("humanises snake_case genres in trending tags (fixes visual_novel leak)", () => {
     const tags = generateTags(
       makeInput({ genres: ["visual_novel"] }),

--- a/tests/engine/title-builder.test.ts
+++ b/tests/engine/title-builder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildTitle, checkTitleWarning } from "@engine/title-builder";
+import { buildTitle, buildQualityBadge, checkTitleWarning } from "@engine/title-builder";
 import { createMockT } from "../helpers/mock-t";
 import type { GeneratorInput } from "@engine/types";
 
@@ -99,6 +99,96 @@ describe("buildTitle", () => {
     });
     const result = buildTitle(input, t);
     expect(result).toBe("エルデンリング — Gameplay No Commentary");
+  });
+
+  it("appends quality badge after the video-type segment", () => {
+    const t = createMockT("en");
+    const result = buildTitle(
+      makeInput({ videoType: "part", partNumber: "5", resolution: "1440p", fps: "60" }),
+      t,
+    );
+    expect(result).toBe("Elden Ring — Part 5 [2K] — Gameplay No Commentary");
+  });
+
+  it("includes resolution alongside non-default FPS for clarity", () => {
+    const t = createMockT("en");
+    const result = buildTitle(
+      makeInput({ videoType: "part", partNumber: "1", resolution: "1080p", fps: "120" }),
+      t,
+    );
+    expect(result).toBe("Elden Ring — Part 1 [1080p 120FPS] — Gameplay No Commentary");
+  });
+
+  it("combines resolution and FPS when both are non-default", () => {
+    const t = createMockT("en");
+    const result = buildTitle(
+      makeInput({ resolution: "4K", fps: "120" }),
+      t,
+    );
+    // videoType "full" renders empty, so the badge becomes its own segment
+    expect(result).toBe("Elden Ring — [4K 120FPS] — Gameplay No Commentary");
+  });
+
+  it("omits the quality badge at defaults", () => {
+    const t = createMockT("en");
+    const result = buildTitle(
+      makeInput({ videoType: "part", partNumber: "2", resolution: "1080p", fps: "60" }),
+      t,
+    );
+    expect(result).toBe("Elden Ring — Part 2 — Gameplay No Commentary");
+  });
+
+  it("respects the showQualityBadge flag", () => {
+    const t = createMockT("en");
+    const result = buildTitle(
+      makeInput({ videoType: "boss", bossName: "Margit", resolution: "4K", fps: "60" }),
+      t,
+      false,
+    );
+    expect(result).toBe("Elden Ring — Margit Boss Fight — Gameplay No Commentary");
+  });
+
+  it("renders mods video type with mod name", () => {
+    const t = createMockT("en");
+    const result = buildTitle(
+      makeInput({ videoType: "mods", modName: "Requiem" }),
+      t,
+    );
+    expect(result).toBe("Elden Ring — Requiem Mods — Gameplay No Commentary");
+  });
+
+  it("renders collectibles video type", () => {
+    const t = createMockT("en");
+    const result = buildTitle(makeInput({ videoType: "collectibles" }), t);
+    expect(result).toBe("Elden Ring — All Collectibles — Gameplay No Commentary");
+  });
+});
+
+describe("buildQualityBadge", () => {
+  it("returns empty at defaults (1080p 60fps)", () => {
+    expect(buildQualityBadge("1080p", "60")).toBe("");
+  });
+
+  it("maps 1440p to 2K", () => {
+    expect(buildQualityBadge("1440p", "60")).toBe("2K");
+  });
+
+  it("keeps 720p and 4K as-is", () => {
+    expect(buildQualityBadge("720p", "60")).toBe("720p");
+    expect(buildQualityBadge("4K", "60")).toBe("4K");
+  });
+
+  it("joins resolution and non-default FPS", () => {
+    expect(buildQualityBadge("4K", "120")).toBe("4K 120FPS");
+    expect(buildQualityBadge("1440p", "144")).toBe("2K 144FPS");
+  });
+
+  it("includes default resolution when only FPS is non-default", () => {
+    expect(buildQualityBadge("1080p", "120")).toBe("1080p 120FPS");
+  });
+
+  it("falls back to defaults when inputs are undefined", () => {
+    expect(buildQualityBadge(undefined, undefined)).toBe("");
   });
 });
 


### PR DESCRIPTION
## Summary

Phase 3 of v0.5 — two title-surface upgrades that work together:

1. **Quality badge** `[2K 60FPS]` appended to the video-type segment whenever recording quality is above 1080p/60fps defaults.
2. **Two new video types**: `mods` (with optional `modName` field) and `collectibles`.

## Quality badge

New `buildQualityBadge(resolution, fps)` helper in [title-builder.ts](src/engine/title-builder.ts):

| Resolution | FPS  | Badge               |
| ---------- | ---- | ------------------- |
| 1080p      | 60   | _(none)_            |
| 1440p      | 60   | `[2K]`              |
| 4K         | 60   | `[4K]`              |
| 720p       | 60   | `[720p]`            |
| 1080p      | 120  | `[1080p 120FPS]`¹   |
| 1440p      | 120  | `[2K 120FPS]`       |
| 4K         | 120  | `[4K 120FPS]`       |

¹ Resolution stays attached to non-default FPS so viewers don't see a lonely `[120FPS]` that could mean 720p or 4K.

Example: `Elden Ring — Part 5 [2K] — Gameplay No Commentary`

**Settings toggle** `showQualityBadge` (default true) in the Tags section lets creators who don't care about specs opt out. Threads through `RenderOptions` → `renderAll` → both render hooks → BatchPage.

## New video types

- **`mods`** (🧩) — extra field `modName`. Title: `{{modName}} Mods` (e.g. "Requiem Mods"). Tag pool: _mods_, _modded gameplay_, _mod showcase_. GameInfoForm renders the modName input when this type is selected.
- **`collectibles`** (⭐) — no extra fields. Title: `All Collectibles`. Tag pool: _all collectibles_, _100% collectibles_, _completionist no commentary_, _achievement guide_.

## i18n

All six locales updated:

- `title.videoType.mods`/`.collectibles` + `description.intro.mods`/`.collectibles` (template strings)
- `videoTypes.mods`/`.collectibles` (chip labels)
- `editor.modName` + `.modNamePlaceholder`
- `settings.showQualityBadge`

`_schema.json` bumped. `validate:locales` shows 237/237 ui + 80/80 templates across 6 locales.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run validate:locales` — 237/237 × 6
- [x] `npm run test:run` — **113 passing** (+15 new; 6 buildQualityBadge unit tests cover every resolution/fps combo, 6 buildTitle tests cover badge placement + toggle override + both new types, 2 tag-generator tests hit the new registries)
- [x] `npm run build` — production bundle ~150KB gzipped
- [ ] Manual — pick 1440p/60 → `[2K]` in title; pick mods + type modName → title shows the mod name; toggle _Show quality badge_ off → badge disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)