### PR TITLE
Phase 5: accordion editor layout + CharCounter polish + Ctrl+G

### DIFF
--- a/src/components/editor/ExtraFieldsInput.tsx
+++ b/src/components/editor/ExtraFieldsInput.tsx
@@ -1,0 +1,64 @@
+import { useTranslation } from "react-i18next";
+import { Input } from "@components/ui/Input";
+import { VIDEO_TYPES } from "@config/video-types";
+import { useEditorStore } from "@store/editor-store";
+
+/**
+ * Renders inputs for the extra fields required by the currently selected
+ * video type — e.g. "Part Number" for `part`, "Boss Name" for `boss`,
+ * "Mod Name" for `mods`. Returns null when the video type has no extras,
+ * so the caller doesn't have to conditionally render.
+ */
+export function ExtraFieldsInput() {
+  const { t } = useTranslation("ui");
+  const store = useEditorStore();
+
+  const currentVideoType = VIDEO_TYPES.find((vt) => vt.id === store.videoType);
+  const extraFields: readonly string[] = currentVideoType?.extraFields ?? [];
+  if (extraFields.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-3">
+      {extraFields.includes("partNumber") && (
+        <Input
+          label={t("editor.partNumber")}
+          placeholder={t("editor.partNumberPlaceholder")}
+          value={store.partNumber ?? ""}
+          onChange={(e) => store.set("partNumber", e.target.value)}
+        />
+      )}
+      {extraFields.includes("bossName") && (
+        <Input
+          label={t("editor.bossName")}
+          placeholder={t("editor.bossNamePlaceholder")}
+          value={store.bossName ?? ""}
+          onChange={(e) => store.set("bossName", e.target.value)}
+        />
+      )}
+      {extraFields.includes("dlcName") && (
+        <Input
+          label={t("editor.dlcName")}
+          placeholder={t("editor.dlcNamePlaceholder")}
+          value={store.dlcName ?? ""}
+          onChange={(e) => store.set("dlcName", e.target.value)}
+        />
+      )}
+      {extraFields.includes("challengeName") && (
+        <Input
+          label={t("editor.challengeName")}
+          placeholder={t("editor.challengeNamePlaceholder")}
+          value={store.challengeName ?? ""}
+          onChange={(e) => store.set("challengeName", e.target.value)}
+        />
+      )}
+      {extraFields.includes("modName") && (
+        <Input
+          label={t("editor.modName")}
+          placeholder={t("editor.modNamePlaceholder")}
+          value={store.modName ?? ""}
+          onChange={(e) => store.set("modName", e.target.value)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/editor/GameInfoForm.tsx
+++ b/src/components/editor/GameInfoForm.tsx
@@ -2,15 +2,16 @@ import { useTranslation } from "react-i18next";
 import { Input } from "@components/ui/Input";
 import { Select } from "@components/ui/Select";
 import { PLATFORMS } from "@config/platforms";
-import { VIDEO_TYPES } from "@config/video-types";
 import { useEditorStore } from "@store/editor-store";
 
+/**
+ * Core identity fields for the video (game name, channel, platform).
+ * Video-type-specific extra fields (partNumber, bossName, …) live in
+ * ExtraFieldsInput so they group with the video-type picker.
+ */
 export function GameInfoForm() {
   const { t } = useTranslation("ui");
   const store = useEditorStore();
-
-  const currentVideoType = VIDEO_TYPES.find((vt) => vt.id === store.videoType);
-  const extraFields: readonly string[] = currentVideoType?.extraFields ?? [];
 
   const platformOptions = PLATFORMS.map((p) => ({ value: p.id, label: p.label }));
 
@@ -34,46 +35,6 @@ export function GameInfoForm() {
         value={store.platform}
         onChange={(v) => store.set("platform", v)}
       />
-      {extraFields.includes("partNumber") && (
-        <Input
-          label={t("editor.partNumber")}
-          placeholder={t("editor.partNumberPlaceholder")}
-          value={store.partNumber ?? ""}
-          onChange={(e) => store.set("partNumber", e.target.value)}
-        />
-      )}
-      {extraFields.includes("bossName") && (
-        <Input
-          label={t("editor.bossName")}
-          placeholder={t("editor.bossNamePlaceholder")}
-          value={store.bossName ?? ""}
-          onChange={(e) => store.set("bossName", e.target.value)}
-        />
-      )}
-      {extraFields.includes("dlcName") && (
-        <Input
-          label={t("editor.dlcName")}
-          placeholder={t("editor.dlcNamePlaceholder")}
-          value={store.dlcName ?? ""}
-          onChange={(e) => store.set("dlcName", e.target.value)}
-        />
-      )}
-      {extraFields.includes("challengeName") && (
-        <Input
-          label={t("editor.challengeName")}
-          placeholder={t("editor.challengeNamePlaceholder")}
-          value={store.challengeName ?? ""}
-          onChange={(e) => store.set("challengeName", e.target.value)}
-        />
-      )}
-      {extraFields.includes("modName") && (
-        <Input
-          label={t("editor.modName")}
-          placeholder={t("editor.modNamePlaceholder")}
-          value={store.modName ?? ""}
-          onChange={(e) => store.set("modName", e.target.value)}
-        />
-      )}
     </div>
   );
 }

--- a/src/components/output/CharCounter.tsx
+++ b/src/components/output/CharCounter.tsx
@@ -6,14 +6,23 @@ interface CharCounterProps {
   limit: number;
 }
 
+/**
+ * Thresholds follow the v0.5 spec:
+ * - ≥100 %: red (over limit — YouTube will refuse the string).
+ * - ≥80 %: yellow (close enough that the user should glance).
+ * - else:  muted grey.
+ */
 export function CharCounter({ text, limit }: CharCounterProps) {
   const { count, isOver, percentage } = useCharCount(text, limit);
+  const isWarning = !isOver && percentage >= 80;
 
   return (
     <span
       className={clsx(
-        "text-xs font-mono",
-        isOver ? "text-danger" : percentage > 80 ? "text-warning" : "text-text-muted",
+        "text-xs font-mono font-semibold transition-colors",
+        isOver && "text-danger",
+        isWarning && "text-warning",
+        !isOver && !isWarning && "text-text-muted font-normal",
       )}
     >
       {count}/{limit}

--- a/src/components/ui/Accordion.tsx
+++ b/src/components/ui/Accordion.tsx
@@ -1,0 +1,72 @@
+import { ChevronDown } from "lucide-react";
+import type { ReactNode } from "react";
+import clsx from "clsx";
+
+interface AccordionProps {
+  /** Unique id for the section — used as React key in lists. */
+  id: string;
+  /** Header label. */
+  title: string;
+  /** Optional leading icon (emoji or single-char string). */
+  icon?: string;
+  /** Optional trailing badge — e.g. a count or status chip. */
+  badge?: ReactNode;
+  /** Controlled open state. */
+  open: boolean;
+  /** Called when the user clicks the header to toggle. */
+  onToggle: () => void;
+  children: ReactNode;
+}
+
+/**
+ * Single-section accordion. Controlled only — the parent decides which
+ * sections are open and persists that choice. Height animates via a
+ * grid-rows trick so content can be any height without measurement.
+ */
+export function Accordion({
+  id,
+  title,
+  icon,
+  badge,
+  open,
+  onToggle,
+  children,
+}: AccordionProps) {
+  return (
+    <section
+      data-accordion-id={id}
+      className="overflow-hidden rounded-lg border border-border bg-surface-1"
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={open}
+        className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-surface-2"
+      >
+        <div className="flex items-center gap-2">
+          {icon && <span className="text-base leading-none">{icon}</span>}
+          <span className="text-sm font-semibold text-text-primary">{title}</span>
+          {badge}
+        </div>
+        <ChevronDown
+          className={clsx(
+            "h-4 w-4 text-text-muted transition-transform duration-200",
+            open && "rotate-180",
+          )}
+        />
+      </button>
+      <div
+        className={clsx(
+          "grid transition-[grid-template-rows] duration-200 ease-out",
+          open ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+        )}
+      >
+        <div className="overflow-hidden">
+          <div className="flex flex-col gap-3 border-t border-border px-4 py-4">
+            {children}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ui/ShortcutHelpModal.tsx
+++ b/src/components/ui/ShortcutHelpModal.tsx
@@ -7,6 +7,7 @@ interface ShortcutHelpModalProps {
 }
 
 const shortcuts = [
+  { keys: "Ctrl + G", labelKey: "shortcuts.generate" },
   { keys: "Ctrl + Enter", labelKey: "shortcuts.generate" },
   { keys: "Ctrl + Shift + C", labelKey: "shortcuts.copyAll" },
   { keys: "Ctrl + S", labelKey: "shortcuts.saveDraft" },

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -17,7 +17,7 @@ export function useKeyboardShortcuts({ onToggleHelp }: ShortcutOptions) {
     const handleKeyDown = (e: KeyboardEvent) => {
       const ctrl = e.ctrlKey || e.metaKey;
 
-      if (ctrl && e.key === "Enter") {
+      if (ctrl && (e.key === "Enter" || e.key === "g" || e.key === "G")) {
         e.preventDefault();
         navigate("/output");
       } else if (ctrl && e.shiftKey && e.key === "C") {

--- a/src/i18n/locales/_schema.json
+++ b/src/i18n/locales/_schema.json
@@ -2,6 +2,7 @@
   "ui": {
     "app": ["title", "subtitle"],
     "tabs": ["editor", "output", "profiles", "history", "settings", "batch", "playlist", "logs"],
+    "editor.sections": ["gameInfo", "videoSettings", "contentDetails", "attribution", "rig", "storeAndSocial"],
     "editor": [
       "videoType", "language", "genre", "gameName", "gameNamePlaceholder",
       "channelName", "channelNamePlaceholder", "platform",

--- a/src/i18n/locales/en/ui.json
+++ b/src/i18n/locales/en/ui.json
@@ -14,6 +14,14 @@
     "logs": "Logs"
   },
   "editor": {
+    "sections": {
+      "gameInfo": "Game Info",
+      "videoSettings": "Video Settings",
+      "contentDetails": "Content Details",
+      "attribution": "Attribution",
+      "rig": "My Rig",
+      "storeAndSocial": "Store & Social"
+    },
     "videoType": "Video Type",
     "language": "Output Language",
     "genre": "Game Genre",

--- a/src/i18n/locales/es/ui.json
+++ b/src/i18n/locales/es/ui.json
@@ -14,6 +14,14 @@
     "logs": "Registros"
   },
   "editor": {
+    "sections": {
+      "gameInfo": "Info del Juego",
+      "videoSettings": "Ajustes de Video",
+      "contentDetails": "Detalles del Contenido",
+      "attribution": "Créditos",
+      "rig": "Mi Equipo",
+      "storeAndSocial": "Tiendas y Social"
+    },
     "videoType": "Tipo de Video",
     "language": "Idioma de Salida",
     "genre": "Género del Juego",

--- a/src/i18n/locales/ja/ui.json
+++ b/src/i18n/locales/ja/ui.json
@@ -14,6 +14,14 @@
     "logs": "ログ"
   },
   "editor": {
+    "sections": {
+      "gameInfo": "ゲーム情報",
+      "videoSettings": "動画設定",
+      "contentDetails": "コンテンツ詳細",
+      "attribution": "クレジット",
+      "rig": "PCスペック",
+      "storeAndSocial": "ストア・SNS"
+    },
     "videoType": "動画タイプ",
     "language": "出力言語",
     "genre": "ゲームジャンル",

--- a/src/i18n/locales/ko/ui.json
+++ b/src/i18n/locales/ko/ui.json
@@ -14,6 +14,14 @@
     "logs": "로그"
   },
   "editor": {
+    "sections": {
+      "gameInfo": "게임 정보",
+      "videoSettings": "비디오 설정",
+      "contentDetails": "콘텐츠 상세",
+      "attribution": "크레딧",
+      "rig": "내 장비",
+      "storeAndSocial": "스토어 & 소셜"
+    },
     "videoType": "영상 유형",
     "language": "출력 언어",
     "genre": "게임 장르",

--- a/src/i18n/locales/vi/ui.json
+++ b/src/i18n/locales/vi/ui.json
@@ -14,6 +14,14 @@
     "logs": "Nhật ký"
   },
   "editor": {
+    "sections": {
+      "gameInfo": "Thông tin game",
+      "videoSettings": "Cài đặt video",
+      "contentDetails": "Nội dung video",
+      "attribution": "Credit / Ghi chú",
+      "rig": "Cấu hình máy",
+      "storeAndSocial": "Store & Mạng xã hội"
+    },
     "videoType": "Loại Video",
     "language": "Ngôn ngữ đầu ra",
     "genre": "Thể loại Game",

--- a/src/i18n/locales/zh/ui.json
+++ b/src/i18n/locales/zh/ui.json
@@ -14,6 +14,14 @@
     "logs": "日志"
   },
   "editor": {
+    "sections": {
+      "gameInfo": "游戏信息",
+      "videoSettings": "视频设置",
+      "contentDetails": "内容详情",
+      "attribution": "署名",
+      "rig": "我的配置",
+      "storeAndSocial": "商店与社交"
+    },
     "videoType": "视频类型",
     "language": "输出语言",
     "genre": "游戏类型",

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -2,6 +2,7 @@ import { VideoTypeSelector } from "@components/editor/VideoTypeSelector";
 import { LanguageSelector } from "@components/editor/LanguageSelector";
 import { GenreSelector } from "@components/editor/GenreSelector";
 import { GameInfoForm } from "@components/editor/GameInfoForm";
+import { ExtraFieldsInput } from "@components/editor/ExtraFieldsInput";
 import { VideoSettingsForm } from "@components/editor/VideoSettingsForm";
 import { TimestampEditor } from "@components/editor/TimestampEditor";
 import { StoreLinkEditor } from "@components/editor/StoreLinkEditor";
@@ -17,7 +18,9 @@ import { PresetSelector } from "@components/presets/PresetSelector";
 import { ValidatedInput } from "@components/ui/ValidatedInput";
 import { Button } from "@components/ui/Button";
 import { ConfirmDialog } from "@components/ui/ConfirmDialog";
+import { Accordion } from "@components/ui/Accordion";
 import { useEditorStore } from "@store/editor-store";
+import { useSettingsStore } from "@store/settings-store";
 import { useTranslation } from "react-i18next";
 import { validateEmails, validateUrl } from "@utils/validation";
 import { RotateCcw } from "lucide-react";
@@ -26,12 +29,16 @@ import { useState } from "react";
 export function EditorPage() {
   const { t } = useTranslation("ui");
   const store = useEditorStore();
+  const accordion = useSettingsStore((s) => s.editorAccordionState);
+  const toggleAccordion = useSettingsStore((s) => s.toggleEditorAccordion);
   const [showClearDraft, setShowClearDraft] = useState(false);
+
+  const isOpen = (id: string): boolean => accordion[id] ?? false;
 
   return (
     <div className="mx-auto flex max-w-6xl flex-col gap-6 p-6 lg:flex-row">
       {/* Form */}
-      <div className="flex flex-1 flex-col gap-6">
+      <div className="flex flex-1 flex-col gap-4">
         <div className="flex items-center justify-between">
           <DraftIndicator />
           <Button variant="ghost" size="sm" onClick={() => setShowClearDraft(true)}>
@@ -50,40 +57,90 @@ export function EditorPage() {
           message={t("editor.clearDraftConfirm")}
           variant="danger"
         />
-        <VideoTypeSelector />
-        <div className="grid grid-cols-2 gap-4">
+
+        <Accordion
+          id="gameInfo"
+          title={t("editor.sections.gameInfo")}
+          icon="🎮"
+          open={isOpen("gameInfo")}
+          onToggle={() => toggleAccordion("gameInfo")}
+        >
           <LanguageSelector />
-          <div />
-        </div>
-        <GenreSelector />
-        <PresetSelector />
-        <GameInfoForm />
-        <VideoSettingsForm />
-        <TimestampEditor />
+          <GenreSelector />
+          <PresetSelector />
+          <GameInfoForm />
+        </Accordion>
 
-        <ValidatedInput
-          label={t("editor.playlistLink")}
-          placeholder={t("editor.playlistLinkPlaceholder")}
-          value={store.playlistLink ?? ""}
-          onChange={(v) => store.set("playlistLink", v)}
-          validate={validateUrl}
-        />
-        <ValidatedInput
-          label={t("editor.contactEmail")}
-          placeholder={t("editor.contactEmailPlaceholder")}
-          value={store.contactEmail ?? ""}
-          onChange={(v) => store.set("contactEmail", v)}
-          validate={validateEmails}
-          helpText={t("editor.contactEmailHelp")}
-        />
+        <Accordion
+          id="videoSettings"
+          title={t("editor.sections.videoSettings")}
+          icon="🎬"
+          open={isOpen("videoSettings")}
+          onToggle={() => toggleAccordion("videoSettings")}
+        >
+          <VideoTypeSelector />
+          <ExtraFieldsInput />
+          <VideoSettingsForm />
+        </Accordion>
 
-        <WarningToggles />
-        <MusicAttributionEditor />
-        <ThumbnailHelper />
-        <PinnedCommentEditor />
-        <StoreLinkEditor />
-        <RigEditor />
-        <SocialEditor />
+        <Accordion
+          id="contentDetails"
+          title={t("editor.sections.contentDetails")}
+          icon="⏱"
+          open={isOpen("contentDetails")}
+          onToggle={() => toggleAccordion("contentDetails")}
+        >
+          <TimestampEditor />
+          <WarningToggles />
+          <ValidatedInput
+            label={t("editor.playlistLink")}
+            placeholder={t("editor.playlistLinkPlaceholder")}
+            value={store.playlistLink ?? ""}
+            onChange={(v) => store.set("playlistLink", v)}
+            validate={validateUrl}
+          />
+          <ValidatedInput
+            label={t("editor.contactEmail")}
+            placeholder={t("editor.contactEmailPlaceholder")}
+            value={store.contactEmail ?? ""}
+            onChange={(v) => store.set("contactEmail", v)}
+            validate={validateEmails}
+            helpText={t("editor.contactEmailHelp")}
+          />
+        </Accordion>
+
+        <Accordion
+          id="attribution"
+          title={t("editor.sections.attribution")}
+          icon="🎵"
+          open={isOpen("attribution")}
+          onToggle={() => toggleAccordion("attribution")}
+        >
+          <MusicAttributionEditor />
+          <ThumbnailHelper />
+          <PinnedCommentEditor />
+        </Accordion>
+
+        <Accordion
+          id="rig"
+          title={t("editor.sections.rig")}
+          icon="💻"
+          open={isOpen("rig")}
+          onToggle={() => toggleAccordion("rig")}
+        >
+          <RigEditor />
+        </Accordion>
+
+        <Accordion
+          id="storeAndSocial"
+          title={t("editor.sections.storeAndSocial")}
+          icon="🔗"
+          open={isOpen("storeAndSocial")}
+          onToggle={() => toggleAccordion("storeAndSocial")}
+        >
+          <StoreLinkEditor />
+          <SocialEditor />
+        </Accordion>
       </div>
 
       {/* Sidebar: Quick Preview */}

--- a/src/store/settings-store.ts
+++ b/src/store/settings-store.ts
@@ -17,11 +17,13 @@ interface SettingsState {
   includeTrendingTags: boolean;
   hashtagCount: number;
   showQualityBadge: boolean;
+  editorAccordionState: Record<string, boolean>;
   setTheme: (theme: "dark" | "light") => void;
   setAppLanguage: (lang: SupportedLanguage) => void;
   setDefaultOutputLanguage: (lang: SupportedLanguage) => void;
   setDefaultGenres: (genres: GenreId[]) => void;
   setSetting: <K extends keyof SettingsData>(key: K, value: SettingsData[K]) => void;
+  toggleEditorAccordion: (id: string) => void;
 }
 
 interface SettingsData {
@@ -37,6 +39,7 @@ interface SettingsData {
   includeTrendingTags: boolean;
   hashtagCount: number;
   showQualityBadge: boolean;
+  editorAccordionState: Record<string, boolean>;
 }
 
 const detectBrowserLanguage = (): SupportedLanguage => {
@@ -60,6 +63,14 @@ const initialSettings: SettingsData = {
   includeTrendingTags: true,
   hashtagCount: 3,
   showQualityBadge: true,
+  editorAccordionState: {
+    gameInfo: true,
+    videoSettings: true,
+    contentDetails: false,
+    attribution: false,
+    rig: false,
+    storeAndSocial: false,
+  },
 };
 
 const STORE_KEY = "ytdescgen-settings";
@@ -82,6 +93,14 @@ export const useSettingsStore = create<SettingsState>()(
       setDefaultGenres: (genres) => set({ defaultGenres: genres }),
 
       setSetting: (key, value) => set({ [key]: value }),
+
+      toggleEditorAccordion: (id) =>
+        set((state) => ({
+          editorAccordionState: {
+            ...state.editorAccordionState,
+            [id]: !state.editorAccordionState[id],
+          },
+        })),
     }),
     {
       name: STORE_KEY,
@@ -112,6 +131,7 @@ export const useSettingsStore = create<SettingsState>()(
         includeTrendingTags: state.includeTrendingTags,
         hashtagCount: state.hashtagCount,
         showQualityBadge: state.showQualityBadge,
+        editorAccordionState: state.editorAccordionState,
       }),
       onRehydrateStorage: () => {
         return () => {
@@ -148,6 +168,7 @@ useSettingsStore.subscribe((state) => {
     includeTrendingTags: state.includeTrendingTags,
     hashtagCount: state.hashtagCount,
     showQualityBadge: state.showQualityBadge,
+    editorAccordionState: state.editorAccordionState,
   };
   saveSettings(STORE_KEY, data);
 });


### PR DESCRIPTION
## Summary

Phase 5 of v0.5. Regroups the editor's 12+ flat sections into **6 collapsible accordions** so the form doesn't require 40-row scrolling to reach rarely-edited fields. Plus two small polish items that came with the plan.

## Accordion layout

New controlled `Accordion` component in [src/components/ui/Accordion.tsx](src/components/ui/Accordion.tsx). Uses a `grid-template-rows: 0fr ↔ 1fr` transition so any child height animates cleanly without measuring.

EditorPage now reads:

| Section          | Contents                                                  |
| ---------------- | --------------------------------------------------------- |
| Game Info        | language, genres, preset loader, GameInfoForm             |
| Video Settings   | video-type picker + ExtraFieldsInput + resolution/fps     |
| Content Details  | timestamps, warnings, playlist link, contact email        |
| Attribution      | music attribution, thumbnail text, pinned comment         |
| My Rig           | hardware fields                                           |
| Store & Social   | store links + social links                                |

Open state persists via `settings-store.editorAccordionState` (Record<string, boolean>). Default has _Game Info_ and _Video Settings_ open; the other four start collapsed to cut visible scroll for first-time users.

## GameInfoForm split

The video-type-specific inputs (`partNumber`, `bossName`, `dlcName`, `challengeName`, `modName`) used to live in GameInfoForm, which put them in the wrong accordion. They now live in a new **`ExtraFieldsInput`** rendered in Video Settings alongside the video-type picker. `GameInfoForm` stays lean (name, channel, platform).

## CharCounter polish

- Threshold bumped from strict `> 80%` to `>= 80%` — the plan's cutoff.
- Warning and over-limit states switch to `font-semibold` for emphasis. (Tried `bg-warning/15` backgrounds first but the app's CSS-var colours don't expose RGB channels, so Tailwind opacity modifiers silently no-op.)

## Ctrl+G generate

Added alongside existing Ctrl+Enter. Both navigate to `/output`. `ShortcutHelpModal` lists Ctrl+G first (matching the v0.5 spec) and keeps Ctrl+Enter as an alternative.

## i18n

All six locales gain `editor.sections.{gameInfo, videoSettings, contentDetails, attribution, rig, storeAndSocial}`. Schema bumped. `validate:locales` shows **253/253 ui + 81/81 templates** × 6 locales.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run validate:locales` clean
- [x] `npm run test:run` — 116 passing (no engine change; accordion is pure UI)
- [x] `npm run build` — ~161 KB gzipped
- [ ] Manual:
  - Expand each accordion, collapse it — state survives reload
  - Pick video type `mods` → `Mod Name` field shows in Video Settings (not Game Info)
  - Type long description → counter goes yellow at ≥80% (4000/5000), red when over 5000
  - Hit Ctrl+G from editor → jumps to Output page

🤖 Generated with [Claude Code](https://claude.com/claude-code)