### PR TITLE
feat(v0.6 phase 1): self-heal settings + drop dead autoSaveDraft

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -254,9 +254,9 @@ Zustand Stores:
 │  SettingsStore                                 │
 │  - theme: "dark" | "light"                     │
 │  - defaultLanguage: SupportedLanguage          │
-│  - defaultGenre: Genre                         │
-│  - autoSaveDraft: boolean                      │
-│  Middleware: persist (localStorage)             │
+│  - defaultGenres: GenreId[]                    │
+│  - (flags: quality badge / copyright / ...)    │
+│  Middleware: persist (localStorage + file)     │
 └───────────────────────────────────────────────┘
 ```
 

--- a/src/i18n/locales/_schema.json
+++ b/src/i18n/locales/_schema.json
@@ -42,7 +42,7 @@
     "presets": ["title", "createNew", "editPreset", "loadPreset", "deleteConfirm", "emptyState", "selectPreset", "noPresets", "exportPresets", "importPresets"],
     "templates": ["title", "createNew", "saveAsTemplate", "templateName", "templateNamePlaceholder", "loadTemplate", "deleteConfirm", "emptyState", "saveHint", "savedAs", "appliedToast", "exportTemplates", "importTemplates"],
     "history": ["title", "emptyState", "clearAll", "clearConfirm", "searchPlaceholder"],
-    "settings": ["title", "appearance", "defaults", "editorSettings", "tagSettings", "historySettings", "theme", "appLanguage", "defaultOutputLanguage", "defaultGenre", "autoSaveDraft", "showCharCount", "compactTagDisplay", "historyLimit", "multilingualTags", "trendingTags", "hashtagCount", "showQualityBadge", "showCopyright", "showUsagePolicy"],
+    "settings": ["title", "appearance", "defaults", "editorSettings", "tagSettings", "historySettings", "theme", "appLanguage", "defaultOutputLanguage", "defaultGenre", "showCharCount", "compactTagDisplay", "historyLimit", "multilingualTags", "trendingTags", "hashtagCount", "showQualityBadge", "showCopyright", "showUsagePolicy"],
     "batch": ["title", "startPart", "endPart", "generateBatch", "copyAllBatch", "emptyState"],
     "shortcuts": ["title", "generate", "copyAll", "saveDraft", "help", "close"],
     "validation": ["emailInvalid", "emailMaxExceeded", "urlInvalid", "urlPrefixMismatch"],

--- a/src/i18n/locales/en/ui.json
+++ b/src/i18n/locales/en/ui.json
@@ -267,7 +267,6 @@
     "appLanguage": "App Language",
     "defaultOutputLanguage": "Default Output Language",
     "defaultGenre": "Default Genres",
-    "autoSaveDraft": "Auto-save Draft",
     "showCharCount": "Show Character Count",
     "compactTagDisplay": "Compact Tag Display",
     "historyLimit": "History Limit",

--- a/src/i18n/locales/es/ui.json
+++ b/src/i18n/locales/es/ui.json
@@ -267,7 +267,6 @@
     "appLanguage": "Idioma de la App",
     "defaultOutputLanguage": "Idioma de Salida Predeterminado",
     "defaultGenre": "Géneros Predeterminados",
-    "autoSaveDraft": "Guardar Borrador Automáticamente",
     "showCharCount": "Mostrar Contador de Caracteres",
     "compactTagDisplay": "Vista Compacta de Etiquetas",
     "historyLimit": "Límite de Historial",

--- a/src/i18n/locales/ja/ui.json
+++ b/src/i18n/locales/ja/ui.json
@@ -267,7 +267,6 @@
     "appLanguage": "アプリの言語",
     "defaultOutputLanguage": "デフォルト出力言語",
     "defaultGenre": "デフォルトジャンル",
-    "autoSaveDraft": "下書き自動保存",
     "showCharCount": "文字数を表示",
     "compactTagDisplay": "コンパクトタグ表示",
     "historyLimit": "履歴上限",

--- a/src/i18n/locales/ko/ui.json
+++ b/src/i18n/locales/ko/ui.json
@@ -267,7 +267,6 @@
     "appLanguage": "앱 언어",
     "defaultOutputLanguage": "기본 출력 언어",
     "defaultGenre": "기본 장르",
-    "autoSaveDraft": "초안 자동 저장",
     "showCharCount": "글자 수 표시",
     "compactTagDisplay": "태그 간략 표시",
     "historyLimit": "기록 제한",

--- a/src/i18n/locales/vi/ui.json
+++ b/src/i18n/locales/vi/ui.json
@@ -267,7 +267,6 @@
     "appLanguage": "Ngôn ngữ ứng dụng",
     "defaultOutputLanguage": "Ngôn ngữ đầu ra",
     "defaultGenre": "Thể loại mặc định",
-    "autoSaveDraft": "Tự động lưu nháp",
     "showCharCount": "Hiện số ký tự",
     "compactTagDisplay": "Hiển thị tags gọn",
     "historyLimit": "Giới hạn lịch sử",

--- a/src/i18n/locales/zh/ui.json
+++ b/src/i18n/locales/zh/ui.json
@@ -267,7 +267,6 @@
     "appLanguage": "应用语言",
     "defaultOutputLanguage": "默认输出语言",
     "defaultGenre": "默认类型",
-    "autoSaveDraft": "自动保存草稿",
     "showCharCount": "显示字数统计",
     "compactTagDisplay": "紧凑标签显示",
     "historyLimit": "历史记录上限",

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -123,11 +123,6 @@ export function SettingsPage() {
         <section className="flex flex-col gap-3">
           <h2 className="text-sm font-semibold text-text-secondary">{t("settings.editorSettings")}</h2>
           <Toggle
-            label={t("settings.autoSaveDraft")}
-            checked={settings.autoSaveDraft}
-            onChange={(v) => settings.setSetting("autoSaveDraft", v)}
-          />
-          <Toggle
             label={t("settings.showCharCount")}
             checked={settings.showCharCount}
             onChange={(v) => settings.setSetting("showCharCount", v)}

--- a/src/store/settings-heal.ts
+++ b/src/store/settings-heal.ts
@@ -1,0 +1,88 @@
+import type { GenreId } from "@config/genres";
+import type { SupportedLanguage } from "@engine/types";
+
+/**
+ * Shape of the settings payload that is persisted to disk + localStorage.
+ * Kept separate from the zustand store type so pure helpers (like
+ * {@link healSettings}) can run in any environment — the store itself
+ * pulls in browser-only modules (`window`, Tauri bridges) that break
+ * when imported from a Node-based test runner.
+ */
+export interface SettingsData {
+  appLanguage: SupportedLanguage;
+  defaultOutputLanguage: SupportedLanguage;
+  defaultGenres: GenreId[];
+  theme: "dark" | "light";
+  showCharCount: boolean;
+  compactTagDisplay: boolean;
+  historyLimit: number;
+  includeMultilingualTags: boolean;
+  includeTrendingTags: boolean;
+  hashtagCount: number;
+  showQualityBadge: boolean;
+  showCopyright: boolean;
+  showUsagePolicy: boolean;
+  editorAccordionState: Record<string, boolean>;
+}
+
+export function detectBrowserLanguage(): SupportedLanguage {
+  if (typeof navigator === "undefined") return "en";
+  const lang = navigator.language.split("-")[0];
+  const supported: SupportedLanguage[] = ["en", "vi", "ja", "es", "ko", "zh"];
+  return (supported.find((s) => s === lang) ?? "en") as SupportedLanguage;
+}
+
+/**
+ * Single source of truth for settings defaults. Evaluated once at module
+ * load so detection (e.g. browser language) happens before any rehydrate.
+ */
+export const initialSettings: SettingsData = {
+  appLanguage: detectBrowserLanguage(),
+  defaultOutputLanguage: detectBrowserLanguage(),
+  defaultGenres: ["action"],
+  theme: "dark",
+  showCharCount: true,
+  compactTagDisplay: false,
+  historyLimit: 100,
+  includeMultilingualTags: true,
+  includeTrendingTags: true,
+  hashtagCount: 3,
+  showQualityBadge: true,
+  showCopyright: true,
+  showUsagePolicy: false,
+  editorAccordionState: {
+    gameInfo: true,
+    videoSettings: true,
+    contentDetails: false,
+    attribution: false,
+    rig: false,
+    storeAndSocial: false,
+  },
+};
+
+/**
+ * Normalise persisted settings so missing keys are back-filled with the
+ * current defaults, legacy shapes are upgraded, and removed keys are
+ * stripped. Runs on every rehydrate so a hand-edited or partially-written
+ * `settings.json` can never leave the store in an incomplete state.
+ *
+ * Pure — safe to call from unit tests.
+ */
+export function healSettings(raw: unknown): SettingsData {
+  if (!raw || typeof raw !== "object") return { ...initialSettings };
+
+  const incoming = { ...(raw as Record<string, unknown>) };
+
+  // v1 → v2 shape upgrade: `defaultGenre: GenreId` became
+  // `defaultGenres: GenreId[]`.
+  if (typeof incoming.defaultGenre === "string" && !Array.isArray(incoming.defaultGenres)) {
+    incoming.defaultGenres = [incoming.defaultGenre];
+  }
+  delete incoming.defaultGenre;
+
+  // v2 → v3: `autoSaveDraft` removed (the draft autosaves unconditionally
+  // via the editor store's persist middleware, so the toggle was dead).
+  delete incoming.autoSaveDraft;
+
+  return { ...initialSettings, ...incoming } as SettingsData;
+}

--- a/src/store/settings-store.ts
+++ b/src/store/settings-store.ts
@@ -3,23 +3,12 @@ import { persist, createJSONStorage } from "zustand/middleware";
 import type { GenreId } from "@config/genres";
 import type { SupportedLanguage } from "@engine/types";
 import { saveSettings, loadSettings } from "@utils/storage-adapter";
+import { healSettings, initialSettings, type SettingsData } from "./settings-heal";
 
-interface SettingsState {
-  appLanguage: SupportedLanguage;
-  defaultOutputLanguage: SupportedLanguage;
-  defaultGenres: GenreId[];
-  theme: "dark" | "light";
-  autoSaveDraft: boolean;
-  showCharCount: boolean;
-  compactTagDisplay: boolean;
-  historyLimit: number;
-  includeMultilingualTags: boolean;
-  includeTrendingTags: boolean;
-  hashtagCount: number;
-  showQualityBadge: boolean;
-  showCopyright: boolean;
-  showUsagePolicy: boolean;
-  editorAccordionState: Record<string, boolean>;
+export type { SettingsData } from "./settings-heal";
+export { healSettings, initialSettings } from "./settings-heal";
+
+interface SettingsState extends SettingsData {
   setTheme: (theme: "dark" | "light") => void;
   setAppLanguage: (lang: SupportedLanguage) => void;
   setDefaultOutputLanguage: (lang: SupportedLanguage) => void;
@@ -27,57 +16,6 @@ interface SettingsState {
   setSetting: <K extends keyof SettingsData>(key: K, value: SettingsData[K]) => void;
   toggleEditorAccordion: (id: string) => void;
 }
-
-interface SettingsData {
-  appLanguage: SupportedLanguage;
-  defaultOutputLanguage: SupportedLanguage;
-  defaultGenres: GenreId[];
-  theme: "dark" | "light";
-  autoSaveDraft: boolean;
-  showCharCount: boolean;
-  compactTagDisplay: boolean;
-  historyLimit: number;
-  includeMultilingualTags: boolean;
-  includeTrendingTags: boolean;
-  hashtagCount: number;
-  showQualityBadge: boolean;
-  showCopyright: boolean;
-  showUsagePolicy: boolean;
-  editorAccordionState: Record<string, boolean>;
-}
-
-const detectBrowserLanguage = (): SupportedLanguage => {
-  const lang = navigator.language.split("-")[0];
-  const supported: SupportedLanguage[] = ["en", "vi", "ja", "es", "ko", "zh"];
-  return (supported.find((s) => s === lang) ?? "en") as SupportedLanguage;
-};
-
-const detectedLang = detectBrowserLanguage();
-
-const initialSettings: SettingsData = {
-  appLanguage: detectedLang,
-  defaultOutputLanguage: detectedLang,
-  defaultGenres: ["action"],
-  theme: "dark",
-  autoSaveDraft: true,
-  showCharCount: true,
-  compactTagDisplay: false,
-  historyLimit: 100,
-  includeMultilingualTags: true,
-  includeTrendingTags: true,
-  hashtagCount: 3,
-  showQualityBadge: true,
-  showCopyright: true,
-  showUsagePolicy: false,
-  editorAccordionState: {
-    gameInfo: true,
-    videoSettings: true,
-    contentDetails: false,
-    attribution: false,
-    rig: false,
-    storeAndSocial: false,
-  },
-};
 
 const STORE_KEY = "ytdescgen-settings";
 
@@ -111,48 +49,17 @@ export const useSettingsStore = create<SettingsState>()(
     {
       name: STORE_KEY,
       storage: createJSONStorage(() => localStorage),
-      // v1 → v2 upgrade: `defaultGenre: GenreId` became
-      // `defaultGenres: GenreId[]` in v0.5.
-      version: 2,
-      migrate: (persistedState: unknown, version: number): SettingsData => {
-        if (version < 2 && persistedState && typeof persistedState === "object") {
-          const state = persistedState as Record<string, unknown> & { defaultGenre?: unknown };
-          if (typeof state.defaultGenre === "string" && !Array.isArray(state.defaultGenres)) {
-            state.defaultGenres = [state.defaultGenre];
-            delete state.defaultGenre;
-          }
-        }
-        return persistedState as SettingsData;
-      },
-      partialize: (state) => ({
-        appLanguage: state.appLanguage,
-        defaultOutputLanguage: state.defaultOutputLanguage,
-        defaultGenres: state.defaultGenres,
-        theme: state.theme,
-        autoSaveDraft: state.autoSaveDraft,
-        showCharCount: state.showCharCount,
-        compactTagDisplay: state.compactTagDisplay,
-        historyLimit: state.historyLimit,
-        includeMultilingualTags: state.includeMultilingualTags,
-        includeTrendingTags: state.includeTrendingTags,
-        hashtagCount: state.hashtagCount,
-        showQualityBadge: state.showQualityBadge,
-        showCopyright: state.showCopyright,
-        showUsagePolicy: state.showUsagePolicy,
-        editorAccordionState: state.editorAccordionState,
-      }),
+      version: 3,
+      migrate: (persistedState: unknown): SettingsData => healSettings(persistedState),
+      partialize: (state) => extractData(state),
       onRehydrateStorage: () => {
         return () => {
-          loadSettings<SettingsData>(STORE_KEY, initialSettings).then((data) => {
+          // Fall back to the (already-healed) zustand state so the file read
+          // never downgrades the store if the on-disk copy is missing keys.
+          const fallback = extractData(useSettingsStore.getState());
+          loadSettings<Partial<SettingsData>>(STORE_KEY, fallback).then((data) => {
             if (data) {
-              // The file-backed copy may still be v1-shaped; normalise
-              // before piping into the store.
-              const maybeOld = data as SettingsData & { defaultGenre?: GenreId };
-              if (typeof maybeOld.defaultGenre === "string" && !Array.isArray(maybeOld.defaultGenres)) {
-                maybeOld.defaultGenres = [maybeOld.defaultGenre];
-                delete maybeOld.defaultGenre;
-              }
-              useSettingsStore.setState(data);
+              useSettingsStore.setState(healSettings(data));
             }
           });
         };
@@ -161,14 +68,12 @@ export const useSettingsStore = create<SettingsState>()(
   ),
 );
 
-// Dual-write: also save to file on every change
-useSettingsStore.subscribe((state) => {
-  const data: SettingsData = {
+function extractData(state: SettingsData): SettingsData {
+  return {
     appLanguage: state.appLanguage,
     defaultOutputLanguage: state.defaultOutputLanguage,
     defaultGenres: state.defaultGenres,
     theme: state.theme,
-    autoSaveDraft: state.autoSaveDraft,
     showCharCount: state.showCharCount,
     compactTagDisplay: state.compactTagDisplay,
     historyLimit: state.historyLimit,
@@ -180,5 +85,11 @@ useSettingsStore.subscribe((state) => {
     showUsagePolicy: state.showUsagePolicy,
     editorAccordionState: state.editorAccordionState,
   };
-  saveSettings(STORE_KEY, data);
+}
+
+// Dual-write: also save to file on every change. Guarantees the
+// `settings.json` on disk always contains the full schema after the first
+// rehydrate, even on a fresh install with no prior localStorage.
+useSettingsStore.subscribe((state) => {
+  saveSettings(STORE_KEY, extractData(state));
 });

--- a/tests/store/settings-heal.test.ts
+++ b/tests/store/settings-heal.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { healSettings } from "@store/settings-heal";
+
+describe("healSettings", () => {
+  it("returns a full defaults object when given null / undefined / non-object input", () => {
+    const fromNull = healSettings(null);
+    const fromUndefined = healSettings(undefined);
+    const fromString = healSettings("not an object");
+
+    // All three should have the full required shape with default-ish values.
+    for (const healed of [fromNull, fromUndefined, fromString]) {
+      expect(healed.theme).toBe("dark");
+      expect(healed.showCharCount).toBe(true);
+      expect(healed.compactTagDisplay).toBe(false);
+      expect(healed.hashtagCount).toBe(3);
+      expect(healed.showQualityBadge).toBe(true);
+      expect(healed.showCopyright).toBe(true);
+      expect(healed.showUsagePolicy).toBe(false);
+      expect(healed.defaultGenres).toEqual(["action"]);
+      expect(healed.editorAccordionState).toEqual(
+        expect.objectContaining({ gameInfo: true }),
+      );
+    }
+  });
+
+  it("back-fills missing keys with defaults but keeps user-set values", () => {
+    const healed = healSettings({
+      theme: "light",
+      hashtagCount: 1,
+      // showCharCount, compactTagDisplay, etc. all missing
+    });
+
+    expect(healed.theme).toBe("light");
+    expect(healed.hashtagCount).toBe(1);
+    // Back-filled:
+    expect(healed.showCharCount).toBe(true);
+    expect(healed.compactTagDisplay).toBe(false);
+    expect(healed.showQualityBadge).toBe(true);
+    expect(healed.editorAccordionState).toBeDefined();
+  });
+
+  it("strips the removed `autoSaveDraft` key even if persisted", () => {
+    const healed = healSettings({ autoSaveDraft: true, theme: "dark" }) as Record<
+      string,
+      unknown
+    >;
+    expect(healed.autoSaveDraft).toBeUndefined();
+  });
+
+  it("upgrades the legacy `defaultGenre: string` shape to `defaultGenres: string[]`", () => {
+    const healed = healSettings({ defaultGenre: "rpg" }) as Record<string, unknown>;
+    expect(healed.defaultGenre).toBeUndefined();
+    expect(healed.defaultGenres).toEqual(["rpg"]);
+  });
+
+  it("keeps explicit `defaultGenres` when both legacy and new keys are present", () => {
+    const healed = healSettings({
+      defaultGenre: "rpg",
+      defaultGenres: ["horror", "action"],
+    }) as Record<string, unknown>;
+    expect(healed.defaultGenre).toBeUndefined();
+    expect(healed.defaultGenres).toEqual(["horror", "action"]);
+  });
+
+  it("preserves all keys when given a complete payload", () => {
+    const complete = {
+      appLanguage: "vi" as const,
+      defaultOutputLanguage: "en" as const,
+      defaultGenres: ["rpg" as const],
+      theme: "light" as const,
+      showCharCount: false,
+      compactTagDisplay: true,
+      historyLimit: 50,
+      includeMultilingualTags: false,
+      includeTrendingTags: false,
+      hashtagCount: 2,
+      showQualityBadge: false,
+      showCopyright: false,
+      showUsagePolicy: true,
+      editorAccordionState: { gameInfo: false, videoSettings: true },
+    };
+    const healed = healSettings(complete);
+    expect(healed).toEqual(complete);
+  });
+});


### PR DESCRIPTION
## Summary
- Settings store now self-heals on every rehydrate — missing keys are back-filled with defaults, legacy shapes (`defaultGenre: string`) are upgraded, and removed keys (`autoSaveDraft`) are stripped. Bumps persist version 2 → 3.
- Guarantees `settings.json` always contains the full schema after first boot, even on a fresh install with no prior localStorage.
- Removes the dead `autoSaveDraft` toggle (the editor draft autosaves unconditionally via zustand persist middleware — the flag had no effect). Cleaned up across the UI, all 6 locales, and `_schema.json`.
- `healSettings` extracted to a pure module (`src/store/settings-heal.ts`) so it can be unit-tested without pulling in browser-only globals.

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] `npm run test:run` — 135 tests pass (6 new for `healSettings`)
- [x] `npm run validate:locales` — all 6 locales at 272/272 keys
- [ ] Manual: delete `%APPDATA%/com.ytdescgen.app/settings.json`, reopen app, confirm it regenerates with full defaults
- [ ] Manual: hand-edit the settings file to remove random keys, reopen, confirm missing keys are back-filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)