### PR TITLE
feat(v0.7-phase1): title-format settings + reorganized Settings page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yt-desc-gen",
-  "version": "0.6.0",
+  "version": "0.7.0-phase1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/engine/template-renderer.ts
+++ b/src/engine/template-renderer.ts
@@ -1,4 +1,10 @@
-import type { GeneratorInput, GeneratorOutput, TranslationFn, CharLimitWarning } from "./types";
+import type {
+  GeneratorInput,
+  GeneratorOutput,
+  TranslationFn,
+  CharLimitWarning,
+  TitleFormatConfig,
+} from "./types";
 import { buildTitle, checkTitleWarning } from "./title-builder";
 import { buildDescription, checkDescriptionWarning } from "./description-builder";
 import { generateTags, formatTagString, type TagOptions } from "./tag-generator";
@@ -13,6 +19,12 @@ export interface RenderOptions extends TagOptions {
    * user's setting.
    */
   showQualityBadge?: boolean;
+  /**
+   * Title formatting knobs (badge position, separator, badge case).
+   * Partial — any omitted sub-key falls back to the v0.6 default inside
+   * buildTitle. Flowed from the user's Settings.
+   */
+  titleFormat?: Partial<TitleFormatConfig>;
   /**
    * When true (and channelName is non-empty), the description ends with
    * an auto-generated `© <year> <channelName>. All rights reserved.` line.
@@ -36,7 +48,12 @@ export function renderAll(
   t: TranslationFn,
   options?: RenderOptions,
 ): GeneratorOutput {
-  const title = buildTitle(input, t, options?.showQualityBadge ?? true);
+  const title = buildTitle(input, t, {
+    showQualityBadge: options?.showQualityBadge ?? true,
+    badgePosition: options?.titleFormat?.badgePosition,
+    separator: options?.titleFormat?.separator,
+    badgeCase: options?.titleFormat?.badgeCase,
+  });
   const description = buildDescription(input, t, {
     hashtagCount: options?.hashtagCount,
     showCopyright: options?.showCopyright,

--- a/src/engine/title-builder.ts
+++ b/src/engine/title-builder.ts
@@ -1,4 +1,11 @@
-import type { GeneratorInput, TranslationFn, CharLimitWarning } from "./types";
+import type {
+  GeneratorInput,
+  TranslationFn,
+  CharLimitWarning,
+  TitleBadgePosition,
+  TitleSeparatorId,
+  TitleBadgeCase,
+} from "./types";
 import { YT_LIMITS } from "./types";
 
 /**
@@ -10,6 +17,9 @@ import { YT_LIMITS } from "./types";
  * - Resolution above 1080p → map 1440p to "2K"; 720p/4K pass through.
  * - Non-default FPS → include the resolution alongside (e.g. "1080p 120FPS")
  *   so a lonely FPS number isn't ambiguous.
+ *
+ * Always returns upper-case. Callers apply `badgeCase: "lower"` downstream
+ * — this function is a label producer, not a display formatter.
  */
 export function buildQualityBadge(resolution?: string, fps?: string): string {
   const res = resolution || "1080p";
@@ -22,12 +32,107 @@ export function buildQualityBadge(resolution?: string, fps?: string): string {
   return fpsDefault ? resLabel : `${resLabel} ${fpsValue}FPS`;
 }
 
+export interface BuildTitleOptions {
+  /** When true, a `[2K]`-style badge is appended/prefixed according to
+   *  `badgePosition`. When false, the badge is suppressed regardless of
+   *  resolution/fps. Default: true. */
+  showQualityBadge?: boolean;
+  /** Where the badge sits. Default: "middle" (v0.6 behavior). */
+  badgePosition?: TitleBadgePosition;
+  /** Separator ID, resolved via `templates.title.separators.<id>`.
+   *  Falls back to the legacy `templates.title.separator` when the
+   *  id-keyed form is missing. Default: "emDash". */
+  separator?: TitleSeparatorId;
+  /** Case of the badge label. Default: "upper" (v0.6 behavior). */
+  badgeCase?: TitleBadgeCase;
+}
+
+const DEFAULT_TITLE_OPTIONS: Required<BuildTitleOptions> = {
+  showQualityBadge: true,
+  badgePosition: "middle",
+  separator: "emDash",
+  badgeCase: "upper",
+};
+
+function normalizeOptions(
+  optsOrShow: BuildTitleOptions | boolean | undefined,
+): Required<BuildTitleOptions> {
+  if (typeof optsOrShow === "boolean") {
+    return { ...DEFAULT_TITLE_OPTIONS, showQualityBadge: optsOrShow };
+  }
+  return { ...DEFAULT_TITLE_OPTIONS, ...(optsOrShow ?? {}) };
+}
+
+interface ComposeArgs {
+  gameName: string;
+  videoTypeLabel: string;
+  suffix: string;
+  badge: string;
+  separator: string;
+  position: TitleBadgePosition;
+}
+
+/**
+ * Assembles the final title string. Three positions supported:
+ *
+ * - "middle": badge glues to the video-type segment. If that segment is
+ *   empty (e.g. `full` video type renders as ""), the badge becomes its
+ *   own segment between game name and suffix — preserves the v0.6 edge
+ *   case where a 4K full run still surfaces the quality label.
+ * - "prefix": `[badge] gameName <sep> videoTypeLabel? <sep> suffix`.
+ *   The badge attaches to the game-name segment with a literal space
+ *   (no separator between badge and game — matches the visual
+ *   convention of `qualityFirst` in title-variants.ts).
+ * - "suffix": `gameName <sep> videoTypeLabel? <sep> [badge] suffix`.
+ *   Badge prefixes the "Gameplay No Commentary" tail.
+ *
+ * When `badge` is empty, all three positions collapse to an identical
+ * string — tested explicitly in title-builder.test.ts.
+ */
+function composeTitle(args: ComposeArgs): string {
+  const { gameName, videoTypeLabel, suffix, badge, separator, position } = args;
+  const badgeTag = badge ? `[${badge}]` : "";
+
+  if (position === "prefix") {
+    const head = badgeTag ? `${badgeTag} ${gameName}` : gameName;
+    const parts = [head];
+    if (videoTypeLabel) parts.push(videoTypeLabel);
+    parts.push(suffix);
+    return parts.join(separator);
+  }
+
+  if (position === "suffix") {
+    const tail = badgeTag ? `${badgeTag} ${suffix}` : suffix;
+    const parts = [gameName];
+    if (videoTypeLabel) parts.push(videoTypeLabel);
+    parts.push(tail);
+    return parts.join(separator);
+  }
+
+  // position === "middle" (default / v0.6 behavior)
+  const parts = [gameName];
+  if (videoTypeLabel) {
+    parts.push(badgeTag ? `${videoTypeLabel} ${badgeTag}` : videoTypeLabel);
+  } else if (badgeTag) {
+    parts.push(badgeTag);
+  }
+  parts.push(suffix);
+  return parts.join(separator);
+}
+
 export function buildTitle(
   input: GeneratorInput,
   t: TranslationFn,
-  showQualityBadge = true,
+  optionsOrShowQualityBadge: BuildTitleOptions | boolean = true,
 ): string {
-  const separator = t("title.separator");
+  const opts = normalizeOptions(optionsOrShowQualityBadge);
+
+  // Resolve the separator: prefer the id-keyed form, fall back to the
+  // legacy single key so locales that haven't been migrated still work.
+  const separatorKey = `title.separators.${opts.separator}`;
+  const resolved = t(separatorKey);
+  const separator = resolved && resolved !== separatorKey ? resolved : t("title.separator");
+
   const suffix = t("title.suffix");
 
   const videoTypeLabel = t(`title.videoType.${input.videoType}`, {
@@ -41,19 +146,17 @@ export function buildTitle(
   const gameName =
     input.gameNameLocalized?.[input.language] ?? input.gameName;
 
-  const qualityBadge = showQualityBadge ? buildQualityBadge(input.resolution, input.fps) : "";
+  let badge = opts.showQualityBadge ? buildQualityBadge(input.resolution, input.fps) : "";
+  if (badge && opts.badgeCase === "lower") badge = badge.toLowerCase();
 
-  const parts = [gameName];
-  if (videoTypeLabel) {
-    parts.push(qualityBadge ? `${videoTypeLabel} [${qualityBadge}]` : videoTypeLabel);
-  } else if (qualityBadge) {
-    // Edge case: some video types render to empty string (e.g. "full").
-    // Still surface the quality badge as its own segment so viewers see it.
-    parts.push(`[${qualityBadge}]`);
-  }
-  parts.push(suffix);
-
-  return parts.join(separator);
+  return composeTitle({
+    gameName,
+    videoTypeLabel,
+    suffix,
+    badge,
+    separator,
+    position: opts.badgePosition,
+  });
 }
 
 export function checkTitleWarning(title: string): CharLimitWarning | null {

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -163,3 +163,31 @@ export const YT_LIMITS = {
 export interface TranslationFn {
   (key: string, options?: Record<string, string>): string;
 }
+
+/**
+ * Where the quality-badge ("[2K]") sits relative to the other title segments:
+ * - "middle"  → attached to the video-type segment (v0.6 behavior)
+ * - "prefix"  → before the game name, e.g. "[2K] Elden Ring — …"
+ * - "suffix"  → before the "Gameplay No Commentary" tail
+ */
+export type TitleBadgePosition = "prefix" | "middle" | "suffix";
+
+/**
+ * Stable IDs for the segment separator. The actual character is resolved
+ * per-locale via `templates.title.separators.<id>` so locales can pick
+ * their own punctuation conventions.
+ */
+export type TitleSeparatorId = "emDash" | "hyphen" | "colon" | "pipe";
+
+/** Case of the quality-badge label in the rendered title ("2K" vs "2k"). */
+export type TitleBadgeCase = "upper" | "lower";
+
+/**
+ * User-configurable title formatting. Defaults (middle / emDash / upper)
+ * reproduce v0.6 output byte-for-byte.
+ */
+export interface TitleFormatConfig {
+  badgePosition: TitleBadgePosition;
+  separator: TitleSeparatorId;
+  badgeCase: TitleBadgeCase;
+}

--- a/src/hooks/use-generated-output.ts
+++ b/src/hooks/use-generated-output.ts
@@ -15,6 +15,7 @@ export function useGeneratedOutput(): GeneratorOutput {
     showCopyright,
     showUsagePolicy,
     showSponsorCredit,
+    titleFormat,
   } = useSettingsStore();
 
   const input: GeneratorInput = useMemo(
@@ -88,6 +89,7 @@ export function useGeneratedOutput(): GeneratorOutput {
         showCopyright,
         showUsagePolicy,
         showSponsorCredit,
+        titleFormat,
       }),
     [
       input,
@@ -99,6 +101,7 @@ export function useGeneratedOutput(): GeneratorOutput {
       showCopyright,
       showUsagePolicy,
       showSponsorCredit,
+      titleFormat,
     ],
   );
 }

--- a/src/hooks/use-multilang-output.ts
+++ b/src/hooks/use-multilang-output.ts
@@ -16,6 +16,8 @@ export function useMultilangOutput(
     showQualityBadge,
     showCopyright,
     showUsagePolicy,
+    showSponsorCredit,
+    titleFormat,
   } = useSettingsStore();
 
   return useMemo(() => {
@@ -41,6 +43,8 @@ export function useMultilangOutput(
         playlistLink: state.playlistLink,
         contactEmail: state.contactEmail,
         musicAttribution: state.musicAttribution,
+        sponsorName: state.sponsorName,
+        sponsorPlatform: state.sponsorPlatform,
         spoilerWarning: state.spoilerWarning,
         matureWarning: state.matureWarning,
         storeLinks: state.storeLinks,
@@ -55,6 +59,8 @@ export function useMultilangOutput(
         showQualityBadge,
         showCopyright,
         showUsagePolicy,
+        showSponsorCredit,
+        titleFormat,
       });
     }
     return results;
@@ -77,6 +83,8 @@ export function useMultilangOutput(
     state.playlistLink,
     state.contactEmail,
     state.musicAttribution,
+    state.sponsorName,
+    state.sponsorPlatform,
     state.spoilerWarning,
     state.matureWarning,
     state.storeLinks,
@@ -89,5 +97,7 @@ export function useMultilangOutput(
     showQualityBadge,
     showCopyright,
     showUsagePolicy,
+    showSponsorCredit,
+    titleFormat,
   ]);
 }

--- a/src/i18n/locales/_schema.json
+++ b/src/i18n/locales/_schema.json
@@ -44,7 +44,7 @@
     "presets": ["title", "createNew", "editPreset", "loadPreset", "deleteConfirm", "emptyState", "selectPreset", "noPresets", "exportPresets", "importPresets"],
     "templates": ["title", "createNew", "saveAsTemplate", "templateName", "templateNamePlaceholder", "loadTemplate", "deleteConfirm", "emptyState", "saveHint", "savedAs", "appliedToast", "exportTemplates", "importTemplates"],
     "history": ["title", "emptyState", "clearAll", "clearConfirm", "searchPlaceholder"],
-    "settings": ["title", "appearance", "defaults", "editorSettings", "tagSettings", "historySettings", "theme", "appLanguage", "defaultOutputLanguage", "defaultGenre", "showCharCount", "compactTagDisplay", "historyLimit", "multilingualTags", "trendingTags", "hashtagCount", "showQualityBadge", "showCopyright", "showUsagePolicy", "showSponsorCredit"],
+    "settings": ["title", "appearance", "defaults", "editorSettings", "tagSettings", "historySettings", "theme", "appLanguage", "defaultOutputLanguage", "defaultGenre", "showCharCount", "compactTagDisplay", "historyLimit", "multilingualTags", "trendingTags", "hashtagCount", "showQualityBadge", "showCopyright", "showUsagePolicy", "showSponsorCredit", "titleFormatTitle", "descriptionSettingsTitle", "badgePosition", "badgePositionPrefix", "badgePositionMiddle", "badgePositionSuffix", "titleSeparator", "titleSeparatorEmDash", "titleSeparatorHyphen", "titleSeparatorColon", "titleSeparatorPipe", "badgeCase", "badgeCaseUpper", "badgeCaseLower"],
     "batch": ["title", "startPart", "endPart", "generateBatch", "copyAllBatch", "emptyState"],
     "shortcuts": ["title", "generate", "copyAll", "saveDraft", "help", "close"],
     "validation": ["emailInvalid", "emailMaxExceeded", "urlInvalid", "urlPrefixMismatch"],
@@ -53,6 +53,7 @@
   },
   "templates": {
     "title": ["separator", "suffix"],
+    "title.separators": ["emDash", "hyphen", "colon", "pipe"],
     "title.videoType": ["full", "part", "full_demo", "demo_part", "boss", "boss_nohit", "ending", "speedrun", "100percent", "dlc", "newgame_plus", "challenge", "side_quest", "secret", "comparison", "guide", "mods", "collectibles"],
     "description.intro": ["full", "part", "full_demo", "demo_part", "boss", "boss_nohit", "ending", "speedrun", "100percent", "dlc", "newgame_plus", "challenge", "side_quest", "secret", "comparison", "guide", "mods", "collectibles"],
     "description": ["noCommentaryLine"],

--- a/src/i18n/locales/en/templates.json
+++ b/src/i18n/locales/en/templates.json
@@ -1,6 +1,12 @@
 {
   "title": {
     "separator": " — ",
+    "separators": {
+      "emDash": " — ",
+      "hyphen": " - ",
+      "colon": ": ",
+      "pipe": " | "
+    },
     "suffix": "Gameplay No Commentary",
     "videoType": {
       "full": "",

--- a/src/i18n/locales/en/ui.json
+++ b/src/i18n/locales/en/ui.json
@@ -280,7 +280,21 @@
     "showQualityBadge": "Show quality badge in title (e.g. [2K 60FPS])",
     "showCopyright": "Append © copyright line to description",
     "showUsagePolicy": "Append usage policy block to description",
-    "showSponsorCredit": "Show sponsor credit line in description (thanks for the key)"
+    "showSponsorCredit": "Show sponsor credit line in description (thanks for the key)",
+    "titleFormatTitle": "Title Format",
+    "descriptionSettingsTitle": "Description",
+    "badgePosition": "Quality badge position",
+    "badgePositionPrefix": "Prefix (before game name)",
+    "badgePositionMiddle": "Middle (attached to video type)",
+    "badgePositionSuffix": "Suffix (before tail)",
+    "titleSeparator": "Segment separator",
+    "titleSeparatorEmDash": "Em dash ( — )",
+    "titleSeparatorHyphen": "Hyphen ( - )",
+    "titleSeparatorColon": "Colon ( : )",
+    "titleSeparatorPipe": "Pipe ( | )",
+    "badgeCase": "Badge case",
+    "badgeCaseUpper": "UPPERCASE (2K)",
+    "badgeCaseLower": "lowercase (2k)"
   },
   "batch": {
     "title": "Batch Mode",

--- a/src/i18n/locales/es/templates.json
+++ b/src/i18n/locales/es/templates.json
@@ -1,6 +1,12 @@
 {
   "title": {
     "separator": " — ",
+    "separators": {
+      "emDash": " — ",
+      "hyphen": " - ",
+      "colon": ": ",
+      "pipe": " | "
+    },
     "suffix": "Gameplay No Commentary",
     "videoType": {
       "full": "",

--- a/src/i18n/locales/es/ui.json
+++ b/src/i18n/locales/es/ui.json
@@ -280,7 +280,21 @@
     "showQualityBadge": "Mostrar insignia de calidad en el título (ej. [2K 60FPS])",
     "showCopyright": "Agregar línea de © copyright a la descripción",
     "showUsagePolicy": "Agregar bloque de política de uso a la descripción",
-    "showSponsorCredit": "Mostrar línea de agradecimiento al patrocinador (clave) en la descripción"
+    "showSponsorCredit": "Mostrar línea de agradecimiento al patrocinador (clave) en la descripción",
+    "titleFormatTitle": "Formato del título",
+    "descriptionSettingsTitle": "Descripción",
+    "badgePosition": "Posición de la insignia de calidad",
+    "badgePositionPrefix": "Prefijo (antes del nombre del juego)",
+    "badgePositionMiddle": "Medio (junto al tipo de vídeo)",
+    "badgePositionSuffix": "Sufijo (antes de la cola)",
+    "titleSeparator": "Separador de segmentos",
+    "titleSeparatorEmDash": "Raya ( — )",
+    "titleSeparatorHyphen": "Guion ( - )",
+    "titleSeparatorColon": "Dos puntos ( : )",
+    "titleSeparatorPipe": "Barra vertical ( | )",
+    "badgeCase": "Mayúsculas / minúsculas",
+    "badgeCaseUpper": "MAYÚSCULAS (2K)",
+    "badgeCaseLower": "minúsculas (2k)"
   },
   "batch": {
     "title": "Generación por Lote",

--- a/src/i18n/locales/ja/templates.json
+++ b/src/i18n/locales/ja/templates.json
@@ -1,6 +1,12 @@
 {
   "title": {
     "separator": " — ",
+    "separators": {
+      "emDash": " — ",
+      "hyphen": " - ",
+      "colon": ": ",
+      "pipe": " | "
+    },
     "suffix": "Gameplay No Commentary",
     "videoType": {
       "full": "",

--- a/src/i18n/locales/ja/ui.json
+++ b/src/i18n/locales/ja/ui.json
@@ -280,7 +280,21 @@
     "showQualityBadge": "タイトルに画質バッジを表示 (例: [2K 60FPS])",
     "showCopyright": "説明欄に © 著作権行を追加",
     "showUsagePolicy": "説明欄に動画利用ポリシーを追加",
-    "showSponsorCredit": "説明欄にスポンサーへの感謝行を追加 (キー提供)"
+    "showSponsorCredit": "説明欄にスポンサーへの感謝行を追加 (キー提供)",
+    "titleFormatTitle": "タイトル書式",
+    "descriptionSettingsTitle": "説明欄",
+    "badgePosition": "品質バッジの位置",
+    "badgePositionPrefix": "先頭 (ゲーム名の前)",
+    "badgePositionMiddle": "中央 (動画タイプに付随)",
+    "badgePositionSuffix": "末尾 (末尾の前)",
+    "titleSeparator": "区切り文字",
+    "titleSeparatorEmDash": "エムダッシュ ( — )",
+    "titleSeparatorHyphen": "ハイフン ( - )",
+    "titleSeparatorColon": "コロン ( : )",
+    "titleSeparatorPipe": "パイプ ( | )",
+    "badgeCase": "バッジの大文字小文字",
+    "badgeCaseUpper": "大文字 (2K)",
+    "badgeCaseLower": "小文字 (2k)"
   },
   "batch": {
     "title": "一括モード",

--- a/src/i18n/locales/ko/templates.json
+++ b/src/i18n/locales/ko/templates.json
@@ -1,6 +1,12 @@
 {
   "title": {
     "separator": " — ",
+    "separators": {
+      "emDash": " — ",
+      "hyphen": " - ",
+      "colon": ": ",
+      "pipe": " | "
+    },
     "suffix": "Gameplay No Commentary",
     "videoType": {
       "full": "",

--- a/src/i18n/locales/ko/ui.json
+++ b/src/i18n/locales/ko/ui.json
@@ -280,7 +280,21 @@
     "showQualityBadge": "제목에 화질 배지 표시 (예: [2K 60FPS])",
     "showCopyright": "설명란에 © 저작권 줄 추가",
     "showUsagePolicy": "설명란에 영상 사용 정책 블록 추가",
-    "showSponsorCredit": "설명란에 스폰서 감사 문구 추가 (키 제공)"
+    "showSponsorCredit": "설명란에 스폰서 감사 문구 추가 (키 제공)",
+    "titleFormatTitle": "제목 형식",
+    "descriptionSettingsTitle": "설명",
+    "badgePosition": "품질 배지 위치",
+    "badgePositionPrefix": "접두부 (게임명 앞)",
+    "badgePositionMiddle": "중간 (영상 유형에 부착)",
+    "badgePositionSuffix": "접미부 (끝 앞)",
+    "titleSeparator": "구분자",
+    "titleSeparatorEmDash": "엠 대시 ( — )",
+    "titleSeparatorHyphen": "하이픈 ( - )",
+    "titleSeparatorColon": "콜론 ( : )",
+    "titleSeparatorPipe": "파이프 ( | )",
+    "badgeCase": "배지 대소문자",
+    "badgeCaseUpper": "대문자 (2K)",
+    "badgeCaseLower": "소문자 (2k)"
   },
   "batch": {
     "title": "일괄 생성",

--- a/src/i18n/locales/vi/templates.json
+++ b/src/i18n/locales/vi/templates.json
@@ -1,6 +1,12 @@
 {
   "title": {
     "separator": " — ",
+    "separators": {
+      "emDash": " — ",
+      "hyphen": " - ",
+      "colon": ": ",
+      "pipe": " | "
+    },
     "suffix": "Gameplay No Commentary",
     "videoType": {
       "full": "",

--- a/src/i18n/locales/vi/ui.json
+++ b/src/i18n/locales/vi/ui.json
@@ -280,7 +280,21 @@
     "showQualityBadge": "Hiện badge chất lượng trong tiêu đề (vd: [2K 60FPS])",
     "showCopyright": "Gắn dòng © copyright vào description",
     "showUsagePolicy": "Gắn khối quy định sử dụng video vào description",
-    "showSponsorCredit": "Hiện dòng cảm ơn sponsor (tặng key) trong description"
+    "showSponsorCredit": "Hiện dòng cảm ơn sponsor (tặng key) trong description",
+    "titleFormatTitle": "Định dạng tiêu đề",
+    "descriptionSettingsTitle": "Mô tả",
+    "badgePosition": "Vị trí badge chất lượng",
+    "badgePositionPrefix": "Đầu (trước tên game)",
+    "badgePositionMiddle": "Giữa (gắn với loại video)",
+    "badgePositionSuffix": "Cuối (trước đuôi)",
+    "titleSeparator": "Dấu phân tách",
+    "titleSeparatorEmDash": "Gạch dài ( — )",
+    "titleSeparatorHyphen": "Gạch ngang ( - )",
+    "titleSeparatorColon": "Hai chấm ( : )",
+    "titleSeparatorPipe": "Sổ đứng ( | )",
+    "badgeCase": "Kiểu chữ badge",
+    "badgeCaseUpper": "VIẾT HOA (2K)",
+    "badgeCaseLower": "viết thường (2k)"
   },
   "batch": {
     "title": "Chế độ hàng loạt",

--- a/src/i18n/locales/zh/templates.json
+++ b/src/i18n/locales/zh/templates.json
@@ -1,6 +1,12 @@
 {
   "title": {
     "separator": " — ",
+    "separators": {
+      "emDash": " — ",
+      "hyphen": " - ",
+      "colon": ": ",
+      "pipe": " | "
+    },
     "suffix": "Gameplay No Commentary",
     "videoType": {
       "full": "",

--- a/src/i18n/locales/zh/ui.json
+++ b/src/i18n/locales/zh/ui.json
@@ -280,7 +280,21 @@
     "showQualityBadge": "在标题中显示画质标签 (如：[2K 60FPS])",
     "showCopyright": "在描述中添加 © 版权行",
     "showUsagePolicy": "在描述中添加视频使用规则块",
-    "showSponsorCredit": "在描述中添加赞助商感谢行（提供激活码）"
+    "showSponsorCredit": "在描述中添加赞助商感谢行（提供激活码）",
+    "titleFormatTitle": "标题格式",
+    "descriptionSettingsTitle": "描述",
+    "badgePosition": "画质徽章位置",
+    "badgePositionPrefix": "前缀 (游戏名前)",
+    "badgePositionMiddle": "中间 (与视频类型相连)",
+    "badgePositionSuffix": "后缀 (尾部前)",
+    "titleSeparator": "分隔符",
+    "titleSeparatorEmDash": "长破折号 ( — )",
+    "titleSeparatorHyphen": "连字符 ( - )",
+    "titleSeparatorColon": "冒号 ( : )",
+    "titleSeparatorPipe": "竖线 ( | )",
+    "badgeCase": "徽章大小写",
+    "badgeCaseUpper": "大写 (2K)",
+    "badgeCaseLower": "小写 (2k)"
   },
   "batch": {
     "title": "批量生成",

--- a/src/pages/BatchPage.tsx
+++ b/src/pages/BatchPage.tsx
@@ -28,6 +28,8 @@ export function BatchPage() {
     showQualityBadge,
     showCopyright,
     showUsagePolicy,
+    showSponsorCredit,
+    titleFormat,
   } = useSettingsStore();
   const [startPart, setStartPart] = useState("1");
   const [endPart, setEndPart] = useState("5");
@@ -70,6 +72,8 @@ export function BatchPage() {
           playlistLink: state.playlistLink,
           contactEmail: state.contactEmail,
           musicAttribution: state.musicAttribution,
+          sponsorName: state.sponsorName,
+          sponsorPlatform: state.sponsorPlatform,
           spoilerWarning: state.spoilerWarning,
           matureWarning: state.matureWarning,
           storeLinks: state.storeLinks,
@@ -86,6 +90,8 @@ export function BatchPage() {
             showQualityBadge,
             showCopyright,
             showUsagePolicy,
+            showSponsorCredit,
+            titleFormat,
           }),
         };
       });

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -9,7 +9,13 @@ import { SUPPORTED_LANGUAGES } from "@i18n/index";
 import { GENRES, type GenreId } from "@config/genres";
 import { useSettingsStore } from "@store/settings-store";
 import { IS_TAURI } from "@utils/platform";
-import { MAX_GENRES, type SupportedLanguage } from "@engine/types";
+import {
+  MAX_GENRES,
+  type SupportedLanguage,
+  type TitleBadgePosition,
+  type TitleSeparatorId,
+  type TitleBadgeCase,
+} from "@engine/types";
 import toast from "react-hot-toast";
 import { logger } from "@utils/logger";
 
@@ -65,6 +71,24 @@ export function SettingsPage() {
     { value: "3", label: "3" },
   ];
 
+  const badgePositionOptions = [
+    { value: "prefix", label: t("settings.badgePositionPrefix") },
+    { value: "middle", label: t("settings.badgePositionMiddle") },
+    { value: "suffix", label: t("settings.badgePositionSuffix") },
+  ];
+
+  const titleSeparatorOptions = [
+    { value: "emDash", label: t("settings.titleSeparatorEmDash") },
+    { value: "hyphen", label: t("settings.titleSeparatorHyphen") },
+    { value: "colon", label: t("settings.titleSeparatorColon") },
+    { value: "pipe", label: t("settings.titleSeparatorPipe") },
+  ];
+
+  const badgeCaseOptions = [
+    { value: "upper", label: t("settings.badgeCaseUpper") },
+    { value: "lower", label: t("settings.badgeCaseLower") },
+  ];
+
   return (
     <div className="mx-auto max-w-2xl p-6">
       <div className="mb-6 flex items-center justify-between">
@@ -84,6 +108,7 @@ export function SettingsPage() {
       </div>
 
       <div className="flex flex-col gap-8">
+        {/* 1. Appearance — theme toggle only. */}
         <section className="flex flex-col gap-3">
           <h2 className="text-sm font-semibold text-text-secondary">{t("settings.appearance")}</h2>
           <Toggle
@@ -93,6 +118,7 @@ export function SettingsPage() {
           />
         </section>
 
+        {/* 2. Language & Defaults — app + output language, default genres. */}
         <section className="flex flex-col gap-3">
           <h2 className="text-sm font-semibold text-text-secondary">{t("settings.defaults")}</h2>
           <Select
@@ -120,6 +146,7 @@ export function SettingsPage() {
           />
         </section>
 
+        {/* 3. Editor — UI knobs that affect the editor page itself. */}
         <section className="flex flex-col gap-3">
           <h2 className="text-sm font-semibold text-text-secondary">{t("settings.editorSettings")}</h2>
           <Toggle
@@ -134,23 +161,47 @@ export function SettingsPage() {
           />
         </section>
 
+        {/* 4. Title format — NEW in v0.7. Quality badge + format knobs. */}
         <section className="flex flex-col gap-3">
-          <h2 className="text-sm font-semibold text-text-secondary">{t("settings.tagSettings")}</h2>
-          <Toggle
-            label={t("settings.multilingualTags")}
-            checked={settings.includeMultilingualTags}
-            onChange={(v) => settings.setSetting("includeMultilingualTags", v)}
-          />
-          <Toggle
-            label={t("settings.trendingTags")}
-            checked={settings.includeTrendingTags}
-            onChange={(v) => settings.setSetting("includeTrendingTags", v)}
-          />
+          <h2 className="text-sm font-semibold text-text-secondary">
+            {t("settings.titleFormatTitle")}
+          </h2>
           <Toggle
             label={t("settings.showQualityBadge")}
             checked={settings.showQualityBadge}
             onChange={(v) => settings.setSetting("showQualityBadge", v)}
           />
+          <Select
+            label={t("settings.badgePosition")}
+            options={badgePositionOptions}
+            value={settings.titleFormat.badgePosition}
+            onChange={(v) =>
+              settings.setTitleFormat({ badgePosition: v as TitleBadgePosition })
+            }
+          />
+          <Select
+            label={t("settings.titleSeparator")}
+            options={titleSeparatorOptions}
+            value={settings.titleFormat.separator}
+            onChange={(v) =>
+              settings.setTitleFormat({ separator: v as TitleSeparatorId })
+            }
+          />
+          <Select
+            label={t("settings.badgeCase")}
+            options={badgeCaseOptions}
+            value={settings.titleFormat.badgeCase}
+            onChange={(v) =>
+              settings.setTitleFormat({ badgeCase: v as TitleBadgeCase })
+            }
+          />
+        </section>
+
+        {/* 5. Description — controls for auto-generated description blocks. */}
+        <section className="flex flex-col gap-3">
+          <h2 className="text-sm font-semibold text-text-secondary">
+            {t("settings.descriptionSettingsTitle")}
+          </h2>
           <Toggle
             label={t("settings.showCopyright")}
             checked={settings.showCopyright}
@@ -174,6 +225,22 @@ export function SettingsPage() {
           />
         </section>
 
+        {/* 6. Tags — tag-pool controls (narrowed from the old mixed section). */}
+        <section className="flex flex-col gap-3">
+          <h2 className="text-sm font-semibold text-text-secondary">{t("settings.tagSettings")}</h2>
+          <Toggle
+            label={t("settings.multilingualTags")}
+            checked={settings.includeMultilingualTags}
+            onChange={(v) => settings.setSetting("includeMultilingualTags", v)}
+          />
+          <Toggle
+            label={t("settings.trendingTags")}
+            checked={settings.includeTrendingTags}
+            onChange={(v) => settings.setSetting("includeTrendingTags", v)}
+          />
+        </section>
+
+        {/* 7. History. */}
         <section className="flex flex-col gap-3">
           <h2 className="text-sm font-semibold text-text-secondary">{t("settings.historySettings")}</h2>
           <Input

--- a/src/store/settings-heal.ts
+++ b/src/store/settings-heal.ts
@@ -1,5 +1,13 @@
 import type { GenreId } from "@config/genres";
-import type { SupportedLanguage } from "@engine/types";
+import type { SupportedLanguage, TitleFormatConfig } from "@engine/types";
+
+// Re-exported so UI + persist layers can import everything from one module.
+export type {
+  TitleBadgeCase,
+  TitleBadgePosition,
+  TitleFormatConfig,
+  TitleSeparatorId,
+} from "@engine/types";
 
 /**
  * Shape of the settings payload that is persisted to disk + localStorage.
@@ -23,6 +31,7 @@ export interface SettingsData {
   showCopyright: boolean;
   showUsagePolicy: boolean;
   showSponsorCredit: boolean;
+  titleFormat: TitleFormatConfig;
   editorAccordionState: Record<string, boolean>;
 }
 
@@ -52,6 +61,13 @@ export const initialSettings: SettingsData = {
   showCopyright: true,
   showUsagePolicy: false,
   showSponsorCredit: false,
+  titleFormat: {
+    // Defaults reproduce v0.6 output byte-for-byte: badge glued to the
+    // video-type segment, em-dash separator, upper-case badge label.
+    badgePosition: "middle",
+    separator: "emDash",
+    badgeCase: "upper",
+  },
   editorAccordionState: {
     gameInfo: true,
     videoSettings: true,
@@ -85,6 +101,15 @@ export function healSettings(raw: unknown): SettingsData {
   // v2 → v3: `autoSaveDraft` removed (the draft autosaves unconditionally
   // via the editor store's persist middleware, so the toggle was dead).
   delete incoming.autoSaveDraft;
+
+  // v4 → v5: `titleFormat` nested config added. Merge sub-keys defensively
+  // so a hand-edited / partial object doesn't drop defaults and leave
+  // downstream consumers with `undefined` badgePosition etc.
+  const incomingTf =
+    typeof incoming.titleFormat === "object" && incoming.titleFormat !== null
+      ? (incoming.titleFormat as Partial<TitleFormatConfig>)
+      : {};
+  incoming.titleFormat = { ...initialSettings.titleFormat, ...incomingTf };
 
   return { ...initialSettings, ...incoming } as SettingsData;
 }

--- a/src/store/settings-store.ts
+++ b/src/store/settings-store.ts
@@ -3,9 +3,20 @@ import { persist, createJSONStorage } from "zustand/middleware";
 import type { GenreId } from "@config/genres";
 import type { SupportedLanguage } from "@engine/types";
 import { saveSettings, loadSettings } from "@utils/storage-adapter";
-import { healSettings, initialSettings, type SettingsData } from "./settings-heal";
+import {
+  healSettings,
+  initialSettings,
+  type SettingsData,
+  type TitleFormatConfig,
+} from "./settings-heal";
 
-export type { SettingsData } from "./settings-heal";
+export type {
+  SettingsData,
+  TitleFormatConfig,
+  TitleBadgePosition,
+  TitleSeparatorId,
+  TitleBadgeCase,
+} from "./settings-heal";
 export { healSettings, initialSettings } from "./settings-heal";
 
 interface SettingsState extends SettingsData {
@@ -14,6 +25,7 @@ interface SettingsState extends SettingsData {
   setDefaultOutputLanguage: (lang: SupportedLanguage) => void;
   setDefaultGenres: (genres: GenreId[]) => void;
   setSetting: <K extends keyof SettingsData>(key: K, value: SettingsData[K]) => void;
+  setTitleFormat: (patch: Partial<TitleFormatConfig>) => void;
   toggleEditorAccordion: (id: string) => void;
 }
 
@@ -38,6 +50,9 @@ export const useSettingsStore = create<SettingsState>()(
 
       setSetting: (key, value) => set({ [key]: value }),
 
+      setTitleFormat: (patch) =>
+        set((state) => ({ titleFormat: { ...state.titleFormat, ...patch } })),
+
       toggleEditorAccordion: (id) =>
         set((state) => ({
           editorAccordionState: {
@@ -49,7 +64,7 @@ export const useSettingsStore = create<SettingsState>()(
     {
       name: STORE_KEY,
       storage: createJSONStorage(() => localStorage),
-      version: 4,
+      version: 5,
       migrate: (persistedState: unknown): SettingsData => healSettings(persistedState),
       partialize: (state) => extractData(state),
       onRehydrateStorage: () => {
@@ -84,6 +99,7 @@ function extractData(state: SettingsData): SettingsData {
     showCopyright: state.showCopyright,
     showUsagePolicy: state.showUsagePolicy,
     showSponsorCredit: state.showSponsorCredit,
+    titleFormat: { ...state.titleFormat },
     editorAccordionState: state.editorAccordionState,
   };
 }

--- a/tests/engine/title-builder.test.ts
+++ b/tests/engine/title-builder.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { buildTitle, buildQualityBadge, checkTitleWarning } from "@engine/title-builder";
 import { createMockT } from "../helpers/mock-t";
-import type { GeneratorInput } from "@engine/types";
+import type { GeneratorInput, TranslationFn } from "@engine/types";
 
 function makeInput(overrides: Partial<GeneratorInput> = {}): GeneratorInput {
   return {
@@ -161,6 +161,98 @@ describe("buildTitle", () => {
     const t = createMockT("en");
     const result = buildTitle(makeInput({ videoType: "collectibles" }), t);
     expect(result).toBe("Elden Ring — All Collectibles — Gameplay No Commentary");
+  });
+});
+
+describe("buildTitle with options bag (v0.7 title-format)", () => {
+  const baseInput = (): Parameters<typeof makeInput>[0] => ({
+    videoType: "part",
+    partNumber: "5",
+    resolution: "1440p",
+    fps: "60",
+  });
+
+  it("defaults (no opts) match v0.6 behaviour byte-for-byte", () => {
+    const t = createMockT("en");
+    const result = buildTitle(makeInput(baseInput()), t, {});
+    expect(result).toBe("Elden Ring — Part 5 [2K] — Gameplay No Commentary");
+  });
+
+  it("prefix position puts the badge before the game name", () => {
+    const t = createMockT("en");
+    const result = buildTitle(makeInput(baseInput()), t, { badgePosition: "prefix" });
+    expect(result).toBe("[2K] Elden Ring — Part 5 — Gameplay No Commentary");
+  });
+
+  it("suffix position puts the badge before the tail", () => {
+    const t = createMockT("en");
+    const result = buildTitle(makeInput(baseInput()), t, { badgePosition: "suffix" });
+    expect(result).toBe("Elden Ring — Part 5 — [2K] Gameplay No Commentary");
+  });
+
+  it("lower-case badge writes [2k] instead of [2K]", () => {
+    const t = createMockT("en");
+    const result = buildTitle(makeInput(baseInput()), t, {
+      badgePosition: "prefix",
+      badgeCase: "lower",
+    });
+    expect(result).toBe("[2k] Elden Ring — Part 5 — Gameplay No Commentary");
+  });
+
+  it("hyphen separator renders ` - ` between segments", () => {
+    const t = createMockT("en");
+    const result = buildTitle(makeInput(baseInput()), t, {
+      badgePosition: "prefix",
+      separator: "hyphen",
+      badgeCase: "lower",
+    });
+    expect(result).toBe("[2k] Elden Ring - Part 5 - Gameplay No Commentary");
+  });
+
+  it("colon separator survives multi-char joins", () => {
+    const t = createMockT("en");
+    const result = buildTitle(makeInput(baseInput()), t, { separator: "colon" });
+    expect(result).toBe("Elden Ring: Part 5 [2K]: Gameplay No Commentary");
+  });
+
+  it("pipe separator renders ` | `", () => {
+    const t = createMockT("en");
+    const result = buildTitle(makeInput(baseInput()), t, { separator: "pipe" });
+    expect(result).toBe("Elden Ring | Part 5 [2K] | Gameplay No Commentary");
+  });
+
+  it("empty badge collapses all three positions to identical output", () => {
+    const t = createMockT("en");
+    const input = makeInput({ videoType: "part", partNumber: "5", resolution: "1080p", fps: "60" });
+    const prefix = buildTitle(input, t, { badgePosition: "prefix" });
+    const middle = buildTitle(input, t, { badgePosition: "middle" });
+    const suffix = buildTitle(input, t, { badgePosition: "suffix" });
+    const expected = "Elden Ring — Part 5 — Gameplay No Commentary";
+    expect(prefix).toBe(expected);
+    expect(middle).toBe(expected);
+    expect(suffix).toBe(expected);
+  });
+
+  it("falls back to legacy title.separator when the id-keyed form is missing", () => {
+    // Mimic a locale that hasn't migrated to the new separators block:
+    // only expose `title.separator` and `title.suffix`, plus the minimum
+    // video-type keys needed for the assertion.
+    const legacyT: TranslationFn = (key, vars) => {
+      if (key === "title.separator") return " >>> ";
+      if (key === "title.suffix") return "Gameplay No Commentary";
+      if (key === "title.videoType.part") return `Part ${vars?.partNumber ?? ""}`;
+      // Everything else (including `title.separators.*`) returns the key
+      // itself, which the builder must detect and fall back on.
+      return key;
+    };
+    const result = buildTitle(makeInput(baseInput()), legacyT, { separator: "hyphen" });
+    expect(result).toBe("Elden Ring >>> Part 5 [2K] >>> Gameplay No Commentary");
+  });
+
+  it("legacy boolean third arg still suppresses the badge", () => {
+    const t = createMockT("en");
+    const result = buildTitle(makeInput(baseInput()), t, false);
+    expect(result).toBe("Elden Ring — Part 5 — Gameplay No Commentary");
   });
 });
 

--- a/tests/store/settings-heal.test.ts
+++ b/tests/store/settings-heal.test.ts
@@ -17,6 +17,11 @@ describe("healSettings", () => {
       expect(healed.showCopyright).toBe(true);
       expect(healed.showUsagePolicy).toBe(false);
       expect(healed.defaultGenres).toEqual(["action"]);
+      expect(healed.titleFormat).toEqual({
+        badgePosition: "middle",
+        separator: "emDash",
+        badgeCase: "upper",
+      });
       expect(healed.editorAccordionState).toEqual(
         expect.objectContaining({ gameInfo: true }),
       );
@@ -78,6 +83,11 @@ describe("healSettings", () => {
       showCopyright: false,
       showUsagePolicy: true,
       showSponsorCredit: true,
+      titleFormat: {
+        badgePosition: "prefix" as const,
+        separator: "hyphen" as const,
+        badgeCase: "lower" as const,
+      },
       editorAccordionState: { gameInfo: false, videoSettings: true },
     };
     const healed = healSettings(complete);
@@ -92,5 +102,43 @@ describe("healSettings", () => {
       showCopyright: true,
     });
     expect(healed.showSponsorCredit).toBe(false);
+  });
+
+  it("back-fills titleFormat default when the key is absent (v4 → v5 payload)", () => {
+    // Simulates a settings file written in v0.6 where titleFormat did
+    // not exist yet.
+    const healed = healSettings({
+      theme: "dark" as const,
+      showCopyright: true,
+    });
+    expect(healed.titleFormat).toEqual({
+      badgePosition: "middle",
+      separator: "emDash",
+      badgeCase: "upper",
+    });
+  });
+
+  it("merges partial titleFormat, filling missing sub-keys with defaults", () => {
+    const healed = healSettings({
+      titleFormat: { badgePosition: "prefix" },
+    });
+    // User-set value preserved:
+    expect(healed.titleFormat.badgePosition).toBe("prefix");
+    // Missing sub-keys back-filled from defaults:
+    expect(healed.titleFormat.separator).toBe("emDash");
+    expect(healed.titleFormat.badgeCase).toBe("upper");
+  });
+
+  it("replaces a non-object titleFormat value with defaults", () => {
+    // A corrupt on-disk file might have `titleFormat: null` or a string.
+    const healedFromNull = healSettings({ titleFormat: null });
+    const healedFromString = healSettings({ titleFormat: "bogus" });
+    for (const healed of [healedFromNull, healedFromString]) {
+      expect(healed.titleFormat).toEqual({
+        badgePosition: "middle",
+        separator: "emDash",
+        badgeCase: "upper",
+      });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Ship the first half of v0.7 — user-configurable title formatting + a Settings page reorganization. Phase 2 (pinned-comment template engine + Playthrough / Difficulty / Content-warning description fields) lands in a follow-up PR per the approved plan (`C:\Users\Anon\.claude\plans\toasty-tinkering-moonbeam.md`).

- **New `titleFormat` config** (`badgePosition` × `separator` × `badgeCase`) flows through `RenderOptions` → `buildTitle` so Batch + Editor + multi-lang all honour the setting. Defaults (`middle` / `emDash` / `upper`) reproduce v0.6 output byte-for-byte — upgrade is a no-op for anyone who doesn't touch these.
- **Settings page 5 → 7 sections**: Appearance / Language & Defaults / Editor / **Title** / **Description** / Tags / History. Every existing setting lands somewhere; the mixed-bag "Tag Settings" split into Description + Tags.
- **Engine purity preserved**: `TitleFormatConfig` + related types live in `src/engine/types.ts`; `src/store/settings-heal.ts` re-exports. No engine → store imports.
- **Backwards compat**: settings store v4 → v5 via `healSettings` defensive sub-key merge; `buildTitle` still accepts the legacy boolean third arg so `title-variants.ts` doesn't change.
- **Drive-by fix**: `useMultilangOutput` was missing `showSponsorCredit` and the sponsor fields — fixed while threading the new options.

## Test plan

- [x] `npm run validate:locales` — 291 UI + 89 template keys per locale × 6 locales all in sync
- [x] `npm run typecheck` — clean
- [x] `npm run test:run` — 156 / 156 pass (title-builder 25 → 35 cases, settings-heal 7 → 10 cases)
- [ ] `npm run dev` smoke: Settings → change badge position / separator / case → Editor title reflects immediately
- [ ] `npm run dev` smoke: Batch page → generate with `prefix` + `hyphen` + `lower` → titles read `[2k] - Game - Part 1 - Gameplay No Commentary`
- [ ] Reset to defaults → titles match v0.6 byte-for-byte
- [ ] Open Tauri `settings.json` after a save → contains the `titleFormat` block; remove it by hand, relaunch → `healSettings` back-fills defaults without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)