### PR TITLE
feat(v0.9-phase1-b2): Epic / Nintendo / Humble URL extractors + name-mismatch banner

### DIFF
--- a/src/components/editor/StoreLinkEditor.tsx
+++ b/src/components/editor/StoreLinkEditor.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useState } from "react";
 import type { ClipboardEvent } from "react";
 import { useTranslation } from "react-i18next";
 import toast from "react-hot-toast";
@@ -6,10 +7,19 @@ import { Select } from "@components/ui/Select";
 import { PLATFORMS } from "@config/platforms";
 import { useEditorStore } from "@store/editor-store";
 import { validateUrlWithPattern } from "@utils/validation";
-import { extractGameNameFromUrl } from "@utils/url-extractors";
+import {
+  extractGameNameFromUrl,
+  isLinkNameMismatch,
+} from "@utils/url-extractors";
 import type { StoreLinkType } from "@engine/types";
 
 const STORE_LINK_TYPE_VALUES: readonly StoreLinkType[] = ["paid", "free", "demo"];
+
+interface MismatchInfo {
+  host: string;
+  suggestedName: string;
+  fingerprint: string;
+}
 
 export function StoreLinkEditor() {
   const { t } = useTranslation("ui");
@@ -20,10 +30,40 @@ export function StoreLinkEditor() {
   const setNested = useEditorStore((s) => s.setNested);
   const setStoreLinkType = useEditorStore((s) => s.setStoreLinkType);
 
+  const [dismissedFingerprints, setDismissedFingerprints] = useState<
+    ReadonlySet<string>
+  >(new Set());
+
   const typeOptions = STORE_LINK_TYPE_VALUES.map((value) => ({
     value,
     label: t(`storeLinkTypes.${value}`),
   }));
+
+  // Find the first store link whose extracted name doesn't fit the
+  // typed Game Name (subset-tolerant check). Iteration order is
+  // PLATFORMS order. Dismissed fingerprints are skipped so a chain of
+  // mismatches surfaces one at a time.
+  const mismatch = useMemo<MismatchInfo | null>(() => {
+    const trimmed = gameName.trim();
+    if (!trimmed) return null;
+    for (const platform of PLATFORMS) {
+      const url = (storeLinks[platform.id] ?? "").trim();
+      if (!url) continue;
+      if (!isLinkNameMismatch(trimmed, url)) continue;
+      const suggestedName = extractGameNameFromUrl(url);
+      if (!suggestedName) continue;
+      const fingerprint = `${trimmed}|${url}`;
+      if (dismissedFingerprints.has(fingerprint)) continue;
+      let host: string;
+      try {
+        host = new URL(url).host;
+      } catch {
+        continue;
+      }
+      return { host, suggestedName, fingerprint };
+    }
+    return null;
+  }, [gameName, storeLinks, dismissedFingerprints]);
 
   // When a recognised store URL is pasted into any link input AND the
   // Game Name field is still empty, auto-fill it from the URL slug. The
@@ -60,6 +100,31 @@ export function StoreLinkEditor() {
   return (
     <div className="flex flex-col gap-3">
       <span className="text-sm font-medium text-text-secondary">{t("editor.storeLinks")}</span>
+      {mismatch && (
+        <div className="flex items-start gap-2 rounded-lg border border-warning bg-surface-2 px-3 py-2 text-sm">
+          <span className="flex-1 text-text-primary">
+            {t("editor.warning.linkNameMismatch", {
+              host: mismatch.host,
+              suggestedName: mismatch.suggestedName,
+              gameName: gameName.trim(),
+            })}
+          </span>
+          <button
+            type="button"
+            aria-label={t("common.dismiss")}
+            className="shrink-0 rounded px-2 py-0.5 text-base leading-none text-text-secondary hover:bg-surface-1"
+            onClick={() =>
+              setDismissedFingerprints((prev) => {
+                const next = new Set(prev);
+                next.add(mismatch.fingerprint);
+                return next;
+              })
+            }
+          >
+            ×
+          </button>
+        </div>
+      )}
       <div className="flex flex-col gap-2">
         {PLATFORMS.map((platform) => {
           const currentType = storeLinkTypes[platform.id] ?? "paid";

--- a/src/i18n/locales/_schema.json
+++ b/src/i18n/locales/_schema.json
@@ -45,6 +45,7 @@
     "editor.upscaleQualityOptions": ["none", "native_aa", "quality", "balanced", "performance", "ultra_performance"],
     "editor.artStyleOptions": ["none", "realistic", "stylized", "anime", "cel_shaded", "low_poly", "voxel", "pixel_art", "hand_drawn", "comic", "photorealistic"],
     "editor.toast": ["urlAutoFilled"],
+    "editor.warning": ["linkNameMismatch"],
     "editor.playthroughOptions": ["none", "blind", "replay", "newgame_plus", "postgame"],
     "editor.difficultyOptions": ["none", "easy", "normal", "hard", "nightmare", "custom"],
     "editor.contentWarningOptions": ["flashing_lights", "loud_noises", "jump_scares"],
@@ -59,7 +60,7 @@
       "generateAlternatives", "saveAsTemplate"
     ],
     "output.variants": ["default", "typeFirst", "qualityFirst"],
-    "common": ["save", "cancel", "delete", "confirm", "export", "import", "reset", "search", "generate", "undo"],
+    "common": ["save", "cancel", "delete", "confirm", "export", "import", "reset", "search", "generate", "undo", "dismiss"],
     "videoTypes": ["full", "part", "full_demo", "demo_part", "boss", "boss_nohit", "ending", "speedrun", "100percent", "dlc", "newgame_plus", "challenge", "side_quest", "secret", "comparison", "guide", "mods", "collectibles", "livestream"],
     "genres": ["action", "hack_slash", "beatemup", "platformer", "horror", "survival_horror", "psychological_horror", "rpg", "jrpg", "action_rpg", "crpg", "fps", "arena_shooter", "tactical_fps", "boomer_shooter", "extraction_shooter", "shmup", "openworld", "indie", "soulslike", "racing", "story", "simulation", "city_builder", "fighting", "stealth", "survival_craft", "roguelike", "metroidvania", "mmo", "rhythm", "puzzle", "tower_defense", "card_game", "deck_builder", "auto_battler", "battle_royale", "tactical", "space", "farming", "fmv", "visual_novel"],
     "rig": ["cpu", "gpu", "ram", "storage", "monitor", "capture", "motherboard", "controller", "video_editor"],

--- a/src/i18n/locales/en/ui.json
+++ b/src/i18n/locales/en/ui.json
@@ -181,6 +181,9 @@
     "contactEmailHelp": "Up to 3 emails, comma-separated",
     "toast": {
       "urlAutoFilled": "Auto-filled '{{name}}' from URL"
+    },
+    "warning": {
+      "linkNameMismatch": "Check link and add again — '{{host}}' suggests '{{suggestedName}}', but Game Name is '{{gameName}}'."
     }
   },
   "output": {
@@ -218,7 +221,8 @@
     "reset": "Reset",
     "search": "Search",
     "generate": "Generate",
-    "undo": "Undo"
+    "undo": "Undo",
+    "dismiss": "Dismiss"
   },
   "videoTypes": {
     "full": "Full Gameplay",

--- a/src/i18n/locales/es/ui.json
+++ b/src/i18n/locales/es/ui.json
@@ -181,6 +181,9 @@
     "contactEmailHelp": "Hasta 3 emails, separados por comas",
     "toast": {
       "urlAutoFilled": "'{{name}}' rellenado automáticamente desde URL"
+    },
+    "warning": {
+      "linkNameMismatch": "Comprueba el enlace y vuelve a añadirlo — '{{host}}' sugiere '{{suggestedName}}', pero el Nombre del juego es '{{gameName}}'."
     }
   },
   "output": {
@@ -218,7 +221,8 @@
     "reset": "Restablecer",
     "search": "Buscar",
     "generate": "Generar",
-    "undo": "Deshacer"
+    "undo": "Deshacer",
+    "dismiss": "Descartar"
   },
   "videoTypes": {
     "full": "Gameplay Completo",

--- a/src/i18n/locales/ja/ui.json
+++ b/src/i18n/locales/ja/ui.json
@@ -181,6 +181,9 @@
     "contactEmailHelp": "最大3つのメール、カンマ区切り",
     "toast": {
       "urlAutoFilled": "URLから「{{name}}」を自動入力しました"
+    },
+    "warning": {
+      "linkNameMismatch": "リンクを確認して再追加してください — 「{{host}}」は「{{suggestedName}}」を指していますが、ゲーム名は「{{gameName}}」です。"
     }
   },
   "output": {
@@ -218,7 +221,8 @@
     "reset": "リセット",
     "search": "検索",
     "generate": "生成",
-    "undo": "元に戻す"
+    "undo": "元に戻す",
+    "dismiss": "閉じる"
   },
   "videoTypes": {
     "full": "フルゲームプレイ",

--- a/src/i18n/locales/ko/ui.json
+++ b/src/i18n/locales/ko/ui.json
@@ -181,6 +181,9 @@
     "contactEmailHelp": "최대 3개 이메일, 쉼표로 구분",
     "toast": {
       "urlAutoFilled": "URL에서 '{{name}}'을(를) 자동 채웠습니다"
+    },
+    "warning": {
+      "linkNameMismatch": "링크를 확인하고 다시 추가하세요 — '{{host}}'은(는) '{{suggestedName}}'을(를) 가리키지만, 게임 이름은 '{{gameName}}'입니다."
     }
   },
   "output": {
@@ -218,7 +221,8 @@
     "reset": "초기화",
     "search": "검색",
     "generate": "생성",
-    "undo": "되돌리기"
+    "undo": "되돌리기",
+    "dismiss": "닫기"
   },
   "videoTypes": {
     "full": "전체 게임플레이",

--- a/src/i18n/locales/vi/ui.json
+++ b/src/i18n/locales/vi/ui.json
@@ -181,6 +181,9 @@
     "contactEmailHelp": "Tối đa 3 email, cách nhau bằng dấu phẩy",
     "toast": {
       "urlAutoFilled": "Đã tự động điền '{{name}}' từ URL"
+    },
+    "warning": {
+      "linkNameMismatch": "Kiểm tra link và thêm lại — '{{host}}' gợi ý '{{suggestedName}}', nhưng Tên Game đang là '{{gameName}}'."
     }
   },
   "output": {
@@ -218,7 +221,8 @@
     "reset": "Đặt lại",
     "search": "Tìm kiếm",
     "generate": "Tạo",
-    "undo": "Hoàn tác"
+    "undo": "Hoàn tác",
+    "dismiss": "Bỏ qua"
   },
   "videoTypes": {
     "full": "Full Gameplay",

--- a/src/i18n/locales/zh/ui.json
+++ b/src/i18n/locales/zh/ui.json
@@ -181,6 +181,9 @@
     "contactEmailHelp": "最多3个邮箱，用逗号分隔",
     "toast": {
       "urlAutoFilled": "已从URL自动填入「{{name}}」"
+    },
+    "warning": {
+      "linkNameMismatch": "请检查链接并重新添加 — 「{{host}}」 看起来是「{{suggestedName}}」，但游戏名称是「{{gameName}}」。"
     }
   },
   "output": {
@@ -218,7 +221,8 @@
     "reset": "重置",
     "search": "搜索",
     "generate": "生成",
-    "undo": "撤销"
+    "undo": "撤销",
+    "dismiss": "关闭"
   },
   "videoTypes": {
     "full": "完整游戏实况",

--- a/src/utils/url-extractors.ts
+++ b/src/utils/url-extractors.ts
@@ -3,14 +3,17 @@
  *
  * Supported storefronts (those whose URL paths carry stable, parseable
  * name slugs):
- *   • Steam     — `https://store.steampowered.com/app/<id>/<Slug>/`
- *   • itch.io   — `https://<dev>.itch.io/<slug>`
- *   • GOG       — `https://www.gog.com/[<lang>/]game/<slug>`
+ *   • Steam        — `https://store.steampowered.com/app/<id>/<Slug>/`
+ *   • itch.io      — `https://<dev>.itch.io/<slug>`
+ *   • GOG          — `https://www.gog.com/[<lang>/]game/<slug>`
+ *   • Epic         — `https://store.epicgames.com/<locale>/p/<slug>[-<hash>]`
+ *   • Nintendo US  — `https://www.nintendo.com/us/store/products/<slug>[-switch[-2]]/`
+ *   • Nintendo EU  — `https://www.nintendo.com/<locale>/Games/<segment>/<slug>[-<id>].html`
+ *   • Humble       — `https://www.humblebundle.com/store/<slug>`
  *
- * Returns `null` for every other URL shape. Epic / PlayStation / Xbox /
- * Nintendo / Humble / Amazon Luna do not expose stable name slugs in
- * their canonical URLs (most use product IDs or URL-encoded blobs), so
- * we deliberately skip them rather than emit garbled names.
+ * Returns `null` for every other URL shape — including PlayStation /
+ * Xbox / Amazon Luna URLs, which rely on opaque product IDs rather than
+ * stable name slugs and would emit garbled names.
  */
 
 interface NameExtractor {
@@ -59,6 +62,36 @@ const PLATFORM_NAME_EXTRACTORS: readonly NameExtractor[] = [
     pattern: /^https:\/\/www\.gog\.com\/(?:[a-z]{2}\/)?game\/([^/?#\s]+)/i,
     humanize: (s) => titleCase(s.replace(/_+/g, " ")),
   },
+  {
+    // Epic Games Store. Path is locale-prefixed (`en-US`, `de`, `fr`,
+    // …) and ends with `/p/<slug>` where the slug carries a 6+-char
+    // hex product hash like `-aa04de` we strip before display.
+    pattern:
+      /^https:\/\/store\.epicgames\.com\/[a-z]{2}(?:-[a-z]{2})?\/p\/([a-z0-9-]+)/i,
+    humanize: (s) =>
+      titleCase(s.replace(/-[a-f0-9]{6,}$/i, "").replace(/-+/g, " ")),
+  },
+  {
+    // Nintendo US store (`/us/store/products/<slug>`). Slugs frequently
+    // carry a `-switch` or `-switch-2` platform suffix that we strip
+    // for a cleaner display name.
+    pattern:
+      /^https:\/\/www\.nintendo\.com\/us\/store\/products\/([^/?#\s]+)/i,
+    humanize: (s) =>
+      titleCase(s.replace(/-switch(?:-2)?$/i, "").replace(/-+/g, " ")),
+  },
+  {
+    // Nintendo EU store (`/<locale>/Games/<segment>/<slug>-<id>.html`).
+    // The slug ends with a numeric product id we strip before display.
+    pattern:
+      /^https:\/\/www\.nintendo\.com\/[a-z]{2}-[a-z]{2}\/Games\/[^/]+\/([^/?#]+?)(?:-\d+)?\.html/i,
+    humanize: (s) => titleCase(s.replace(/-+/g, " ")),
+  },
+  {
+    // Humble Bundle store. Slugs are simple hyphen-cased names.
+    pattern: /^https:\/\/www\.humblebundle\.com\/store\/([^/?#\s]+)/i,
+    humanize: (s) => titleCase(s.replace(/-+/g, " ")),
+  },
 ] as const;
 
 export function extractGameNameFromUrl(url: string): string | null {
@@ -72,4 +105,48 @@ export function extractGameNameFromUrl(url: string): string | null {
     }
   }
   return null;
+}
+
+/**
+ * Lowercase + alphanumeric token set. Apostrophes are removed (not
+ * spaced) so `Marvel's` tokenises to `marvels`, matching Steam slugs
+ * like `Marvels_Spider-Man_Remastered` exactly.
+ */
+function tokenize(s: string): Set<string> {
+  return new Set(
+    s
+      .toLowerCase()
+      .replace(/['’]/g, "")
+      .replace(/[^a-z0-9 ]+/g, " ")
+      .split(/\s+/)
+      .filter(Boolean),
+  );
+}
+
+/**
+ * Subset-tolerant comparison: returns true when the URL extracts to a
+ * name whose tokens are NOT all present in the typed Game Name.
+ *
+ * Examples:
+ *   • Game `Marvel's Spider-Man Remastered` + Steam link `Spider-Man`
+ *     → no mismatch (link tokens ⊆ game tokens).
+ *   • Game `Pragmata Pro` + Humble link `Pragmata`
+ *     → no mismatch (link tokens ⊆ game tokens).
+ *   • Game `Pragmata` + Humble link `Lucky Tower Ultimate`
+ *     → mismatch (link has tokens absent from game name).
+ *
+ * Returns false when either side is empty or the URL is not a
+ * recognised storefront.
+ */
+export function isLinkNameMismatch(gameName: string, url: string): boolean {
+  if (!gameName.trim()) return false;
+  const extracted = extractGameNameFromUrl(url);
+  if (!extracted) return false;
+  const gameTokens = tokenize(gameName);
+  const linkTokens = tokenize(extracted);
+  if (gameTokens.size === 0 || linkTokens.size === 0) return false;
+  for (const t of linkTokens) {
+    if (!gameTokens.has(t)) return true;
+  }
+  return false;
 }

--- a/tests/utils/url-extractors.test.ts
+++ b/tests/utils/url-extractors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { extractGameNameFromUrl } from "@utils/url-extractors";
+import { extractGameNameFromUrl, isLinkNameMismatch } from "@utils/url-extractors";
 
 describe("extractGameNameFromUrl — Steam", () => {
   it("extracts and humanises an ALL_CAPS slug", () => {
@@ -81,11 +81,147 @@ describe("extractGameNameFromUrl — GOG", () => {
   });
 });
 
-describe("extractGameNameFromUrl — unsupported storefronts", () => {
-  it("returns null for Epic Games Store", () => {
+describe("extractGameNameFromUrl — Epic Games Store", () => {
+  it("extracts a slug from a 5-char locale prefix and strips the product hash", () => {
     expect(
       extractGameNameFromUrl(
-        "https://store.epicgames.com/p/some-game-name",
+        "https://store.epicgames.com/en-US/p/lucky-tower-ultimate-aa04de",
+      ),
+    ).toBe("Lucky Tower Ultimate");
+  });
+
+  it("supports a 2-char locale prefix", () => {
+    expect(
+      extractGameNameFromUrl(
+        "https://store.epicgames.com/de/p/alan-wake-2-49e0d3",
+      ),
+    ).toBe("Alan Wake 2");
+  });
+
+  it("works without a trailing product hash", () => {
+    expect(
+      extractGameNameFromUrl("https://store.epicgames.com/en-US/p/fortnite"),
+    ).toBe("Fortnite");
+  });
+
+  it("ignores trailing path segments and query strings", () => {
+    expect(
+      extractGameNameFromUrl(
+        "https://store.epicgames.com/en-US/p/control-c14ed6/home?lang=en",
+      ),
+    ).toBe("Control");
+  });
+
+  it("returns null when the locale prefix is missing (bare /p/)", () => {
+    expect(
+      extractGameNameFromUrl("https://store.epicgames.com/p/some-game-name"),
+    ).toBeNull();
+  });
+});
+
+describe("extractGameNameFromUrl — Nintendo US", () => {
+  it("strips the -switch-2 platform suffix", () => {
+    expect(
+      extractGameNameFromUrl(
+        "https://www.nintendo.com/us/store/products/mario-tennis-fever-switch-2/",
+      ),
+    ).toBe("Mario Tennis Fever");
+  });
+
+  it("strips a single -switch suffix", () => {
+    expect(
+      extractGameNameFromUrl(
+        "https://www.nintendo.com/us/store/products/the-legend-of-zelda-tears-of-the-kingdom-switch",
+      ),
+    ).toBe("The Legend Of Zelda Tears Of The Kingdom");
+  });
+
+  it("works with no platform suffix", () => {
+    expect(
+      extractGameNameFromUrl(
+        "https://www.nintendo.com/us/store/products/pikmin-4",
+      ),
+    ).toBe("Pikmin 4");
+  });
+
+  it("ignores trailing query strings", () => {
+    expect(
+      extractGameNameFromUrl(
+        "https://www.nintendo.com/us/store/products/animal-crossing-new-horizons-switch?source=share",
+      ),
+    ).toBe("Animal Crossing New Horizons");
+  });
+});
+
+describe("extractGameNameFromUrl — Nintendo EU", () => {
+  it("strips the trailing numeric id and .html suffix", () => {
+    expect(
+      extractGameNameFromUrl(
+        "https://www.nintendo.com/en-gb/Games/Nintendo-Switch-download-software/Teenage-Mutant-Ninja-Turtles-Splintered-Fate-2557953.html",
+      ),
+    ).toBe("Teenage Mutant Ninja Turtles Splintered Fate");
+  });
+
+  it("supports other locale prefixes", () => {
+    expect(
+      extractGameNameFromUrl(
+        "https://www.nintendo.com/de-de/Games/Nintendo-Switch/Hollow-Knight-1234567.html",
+      ),
+    ).toBe("Hollow Knight");
+  });
+
+  it("works when the slug carries no numeric id", () => {
+    expect(
+      extractGameNameFromUrl(
+        "https://www.nintendo.com/en-gb/Games/Nintendo-Switch/Stardew-Valley.html",
+      ),
+    ).toBe("Stardew Valley");
+  });
+
+  it("returns null for non-Games paths", () => {
+    expect(
+      extractGameNameFromUrl(
+        "https://www.nintendo.com/en-gb/News/2024/December/Update.html",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("extractGameNameFromUrl — Humble Bundle", () => {
+  it("extracts a single-word slug", () => {
+    expect(
+      extractGameNameFromUrl("https://www.humblebundle.com/store/pragmata"),
+    ).toBe("Pragmata");
+  });
+
+  it("extracts a hyphenated multi-word slug", () => {
+    expect(
+      extractGameNameFromUrl(
+        "https://www.humblebundle.com/store/baldurs-gate-3",
+      ),
+    ).toBe("Baldurs Gate 3");
+  });
+
+  it("ignores trailing query strings", () => {
+    expect(
+      extractGameNameFromUrl(
+        "https://www.humblebundle.com/store/dredge?ref=hp",
+      ),
+    ).toBe("Dredge");
+  });
+
+  it("returns null for non-store Humble paths", () => {
+    expect(
+      extractGameNameFromUrl("https://www.humblebundle.com/games"),
+    ).toBeNull();
+  });
+});
+
+describe("extractGameNameFromUrl — unsupported storefronts", () => {
+  it("returns null for PlayStation Store", () => {
+    expect(
+      extractGameNameFromUrl(
+        "https://store.playstation.com/en-us/product/UP9000-CUSA00000_00-XXXXXXXX",
       ),
     ).toBeNull();
   });
@@ -96,6 +232,12 @@ describe("extractGameNameFromUrl — unsupported storefronts", () => {
     ).toBeNull();
   });
 
+  it("returns null for Amazon Luna", () => {
+    expect(
+      extractGameNameFromUrl("https://www.amazon.com/luna/landing"),
+    ).toBeNull();
+  });
+
   it("returns null for empty or whitespace input", () => {
     expect(extractGameNameFromUrl("")).toBeNull();
     expect(extractGameNameFromUrl("   ")).toBeNull();
@@ -103,5 +245,80 @@ describe("extractGameNameFromUrl — unsupported storefronts", () => {
 
   it("returns null for non-store URLs", () => {
     expect(extractGameNameFromUrl("https://example.com/whatever")).toBeNull();
+  });
+});
+
+describe("isLinkNameMismatch", () => {
+  it("returns false when the link's tokens are a subset of the game name's tokens", () => {
+    expect(
+      isLinkNameMismatch(
+        "Marvel's Spider-Man Remastered",
+        "https://store.steampowered.com/app/1817070/Marvels_Spider-Man_Remastered/",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when the game name has extra editorial words around the link slug", () => {
+    expect(
+      isLinkNameMismatch(
+        "Pragmata Pro",
+        "https://www.humblebundle.com/store/pragmata",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false on an exact match", () => {
+    expect(
+      isLinkNameMismatch(
+        "Hollow Knight",
+        "https://team-cherry.itch.io/hollow-knight",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true when the link points at a completely different game", () => {
+    expect(
+      isLinkNameMismatch(
+        "Pragmata",
+        "https://store.epicgames.com/en-US/p/lucky-tower-ultimate-aa04de",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when the link adds tokens missing from the game name", () => {
+    expect(
+      isLinkNameMismatch(
+        "Spider-Man",
+        "https://www.humblebundle.com/store/marvels-spider-man-remastered",
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores apostrophes and punctuation when tokenising", () => {
+    expect(
+      isLinkNameMismatch(
+        "Marvel's Spider-Man",
+        "https://www.humblebundle.com/store/marvels-spider-man",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when the URL is not a recognised storefront", () => {
+    expect(
+      isLinkNameMismatch("Pragmata", "https://example.com/whatever"),
+    ).toBe(false);
+  });
+
+  it("returns false when the game name is empty", () => {
+    expect(
+      isLinkNameMismatch(
+        "",
+        "https://www.humblebundle.com/store/pragmata",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when the URL is empty", () => {
+    expect(isLinkNameMismatch("Pragmata", "")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

First slice of v0.9 phase 1: adds 4 new storefront URL extractors and a reactive name-mismatch banner above the store-link grid.

**New extractors** (`PLATFORM_NAME_EXTRACTORS` in `src/utils/url-extractors.ts`):
- **Epic** — `store.epicgames.com/<locale>/p/<slug>[-<6+-hex hash>]`. Locale prefix is required (`en-US`, `de`, …); the trailing product hash like `-aa04de` is stripped before display.
- **Nintendo US** — `nintendo.com/us/store/products/<slug>`. Trailing `-switch` / `-switch-2` platform suffix is stripped.
- **Nintendo EU** — `nintendo.com/<locale>/Games/<segment>/<slug>[-<id>].html`. Trailing numeric product id is stripped.
- **Humble** — `humblebundle.com/store/<slug>`. Simplest: hyphen → space + title-case.

PlayStation, Xbox, and Amazon Luna stay unsupported — their canonical URLs use opaque product IDs rather than name slugs and would emit garbled names. Existing Steam / itch.io / GOG extractors are unchanged.

**Name-mismatch helper** — new `isLinkNameMismatch(gameName, url)` applies a subset-tolerant token comparison. The link's tokens must all appear in the typed Game Name. Apostrophes are stripped (not spaced) so `Marvel's` tokenises to `marvels` and matches Steam slugs like `Marvels_Spider-Man_Remastered` verbatim. Returns false when the URL is unsupported or either side is empty.

**Banner UI** — `StoreLinkEditor` renders a warning banner above the platform grid when any filled store link mismatches the typed Game Name. Iteration order follows `PLATFORMS`; dismissed fingerprints (`gameName|url` pairs) are skipped so a chain of mismatches surfaces one at a time. Banner reappears automatically when either Game Name or the link changes.

**i18n** — 2 new keys per locale: `editor.warning.linkNameMismatch` (banner copy with `{{host}}`, `{{suggestedName}}`, `{{gameName}}` placeholders) and `common.dismiss` (× button aria-label). All 6 locales fully translated. 393 ui keys per locale (was 391).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test:run` — 280 passed (+27 from baseline 253)
- [x] `npm run validate:locales` — 393/393 ui + 164/164 templates per locale
- [x] `npm run build` — main bundle 242 KB (≤500 KB gate)
- [ ] Manual UAT (browser):
  - Paste an Epic URL with locale prefix (e.g. `https://store.epicgames.com/en-US/p/lucky-tower-ultimate-aa04de`) into any store-link input with empty Game Name → autofills `Lucky Tower Ultimate`.
  - Paste a Nintendo US URL (e.g. `https://www.nintendo.com/us/store/products/mario-tennis-fever-switch-2/`) → autofills `Mario Tennis Fever`.
  - Paste a Nintendo EU URL ending in `-NNNNNN.html` → autofills clean name.
  - Paste a Humble URL → autofills clean name.
  - Type `Pragmata` as Game Name, then paste an Epic URL for a different game → warning banner appears below the storeLinks label, above the platform grid, with the specific link host + suggested name + current Game Name.
  - Click the × on the banner → banner hides for that exact `(gameName, url)` pair. Editing either side re-shows.
  - Banner does NOT appear for Steam slug `Marvels_Spider-Man_Remastered` when Game Name is `Marvel's Spider-Man Remastered` (apostrophe-stripping subset match).