### PR TITLE
feat(v0.9-phase2): QoL trio + multi-platform release matrix

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -10,10 +10,17 @@ permissions:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
+          - os: macos-13
+            target: x86_64-apple-darwin
+          - os: macos-14
+            target: aarch64-apple-darwin
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -24,6 +31,16 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      - name: Install Linux dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf
       - run: npm ci
       - uses: tauri-apps/tauri-action@v0
         env:
@@ -33,3 +50,4 @@ jobs:
           releaseName: "YTDescGen v__VERSION__"
           releaseBody: "See the assets to download the installer for your platform."
           releaseDraft: true
+          args: --target ${{ matrix.target }}

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -239,48 +239,26 @@ Output locations:
 
 ### GitHub Actions Release
 
-```yaml
-# .github/workflows/release-desktop.yml
-name: Release Desktop
+The live workflow lives at [.github/workflows/release-desktop.yml](../.github/workflows/release-desktop.yml). Pushing a `v*` tag (e.g. `v0.10.0`) triggers a four-platform matrix build (Windows, macOS Intel, macOS ARM, Linux) and uploads each installer to a single draft GitHub Release named `YTDescGen v__VERSION__`. Publish the draft manually after smoke-testing the binaries.
 
-on:
-  push:
-    tags: ["v*"]
+Matrix entries (v0.9 phase 2):
 
-permissions:
-  contents: write
+| Runner | Target | Output |
+|---|---|---|
+| `windows-latest` | `x86_64-pc-windows-msvc` | `.msi`, `.exe` (NSIS) |
+| `macos-13` | `x86_64-apple-darwin` | `.dmg`, `.app.tar.gz` |
+| `macos-14` | `aarch64-apple-darwin` | `.dmg`, `.app.tar.gz` |
+| `ubuntu-latest` | `x86_64-unknown-linux-gnu` | `.AppImage`, `.deb` |
 
-jobs:
-  build:
-    strategy:
-      matrix:
-        include:
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-          - os: macos-latest
-            target: aarch64-apple-darwin
-          - os: macos-latest
-            target: x86_64-apple-darwin
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-      - run: npm ci
-      - uses: tauri-apps/tauri-action@v0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tagName: v__VERSION__
-          releaseName: "YTDescGen v__VERSION__"
-          releaseBody: "See CHANGELOG.md for details."
-          releaseDraft: true
-```
+Linux runners install `libwebkit2gtk-4.1-dev`, `libgtk-3-dev`, `libayatana-appindicator3-dev`, `librsvg2-dev`, and `patchelf` before building — Tauri's webview + AppImage tooling needs these.
+
+`fail-fast: false` keeps the other platforms going if one breaks. `args: --target ${{ matrix.target }}` is passed through to `tauri build` so each runner uses its explicit target triple.
+
+**Code signing is intentionally skipped** for both Windows and macOS — this is an open-source personal tool, and signing certificates carry recurring cost. End users will see the standard "unverified publisher" / "unidentified developer" prompts on first launch. Document the bypass steps in the release notes if needed.
+
+**Auto-changelog** (`git-cliff`) is out of scope; release notes come from the tag's annotated message via the default `tauri-action` behaviour. CHANGELOG.md is hand-maintained.
+
+**Backfill for pre-workflow tags:** `v0.8.0` and `v0.8.1` predate the multi-platform matrix and only have local Windows builds. To attach binaries retroactively, build manually then `gh release create v0.8.0 --notes-file CHANGELOG.md path/to/*.msi …`.
 
 ## Auto-Update Flow
 

--- a/src/components/editor/GenreSelector.tsx
+++ b/src/components/editor/GenreSelector.tsx
@@ -1,7 +1,12 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChipGroup } from "@components/ui/ChipGroup";
-import { GENRES } from "@config/genres";
+import {
+  GENRES,
+  GENRE_GROUPS,
+  GENRE_GROUP_IDS,
+  type GenreGroupId,
+} from "@config/genres";
 import { GENRES_WITHOUT_GRAPHICS_SETTINGS } from "@config/graphics-settings";
 import { useEditorStore } from "@store/editor-store";
 import { MAX_GENRES, type Genre } from "@engine/types";
@@ -16,28 +21,79 @@ export function GenreSelector() {
   // creator who flips back-and-forth between visual-novel and other genres
   // benefits from being reminded once per session.
   const [hintDismissed, setHintDismissed] = useState(false);
+  const [filter, setFilter] = useState("");
 
-  const options = GENRES.map((g) => ({
-    id: g.id,
-    label: t(g.labelKey),
-    icon: g.icon,
-  }));
+  const allOptions = useMemo(
+    () =>
+      GENRES.map((g) => ({
+        id: g.id,
+        label: t(g.labelKey),
+        icon: g.icon,
+      })),
+    [t],
+  );
+
+  const visibleOptions = useMemo(() => {
+    const trimmed = filter.trim().toLowerCase();
+    if (!trimmed) return allOptions;
+    return allOptions.filter((o) => o.label.toLowerCase().includes(trimmed));
+  }, [allOptions, filter]);
 
   const matchingGenre = genres.find((g) =>
     (GENRES_WITHOUT_GRAPHICS_SETTINGS as readonly string[]).includes(g),
   );
   const showHint = !!matchingGenre && !skipGraphicsSettings && !hintDismissed;
 
+  const applyGroup = (groupId: GenreGroupId) => {
+    const next = GENRE_GROUPS[groupId].slice(0, MAX_GENRES) as Genre[];
+    set("genres", next);
+    // Clear the filter so the user can see the newly-selected chips
+    // light up — otherwise a stale filter could hide them all.
+    setFilter("");
+  };
+
   return (
     <div className="flex flex-col gap-2">
-      <ChipGroup
-        label={t("editor.genre")}
-        multiple
-        max={MAX_GENRES}
-        options={options}
-        value={genres}
-        onChange={(next) => set("genres", next as Genre[])}
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className="text-sm font-medium text-text-secondary">
+          {t("editor.genre")}
+        </span>
+        <span className="text-xs text-text-muted">
+          {genres.length}/{MAX_GENRES}
+        </span>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {GENRE_GROUP_IDS.map((groupId) => (
+          <button
+            key={groupId}
+            type="button"
+            onClick={() => applyGroup(groupId)}
+            className="rounded-lg border border-border bg-surface-1 px-2.5 py-1 text-xs font-medium text-text-secondary transition-colors hover:border-accent hover:text-text-primary"
+          >
+            {t(`editor.genreGroups.${groupId}`)}
+          </button>
+        ))}
+      </div>
+      <input
+        type="text"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+        placeholder={t("editor.genreSearchPlaceholder")}
+        className="rounded-lg border border-border bg-surface-1 px-3 py-2 text-sm text-text-primary placeholder:text-text-muted transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/50"
       />
+      {visibleOptions.length === 0 ? (
+        <p className="py-2 text-sm text-text-muted">
+          {t("editor.genreSearchNoResults")}
+        </p>
+      ) : (
+        <ChipGroup
+          multiple
+          max={MAX_GENRES}
+          options={visibleOptions}
+          value={genres}
+          onChange={(next) => set("genres", next as Genre[])}
+        />
+      )}
       {showHint && (
         <div className="flex items-center justify-between gap-3 rounded-lg border border-accent/40 bg-accent/5 px-3 py-2 text-xs text-text-secondary">
           <span>{t("editor.skipGraphicsHintLabel")}</span>

--- a/src/components/ui/ShortcutHelpModal.tsx
+++ b/src/components/ui/ShortcutHelpModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Modal } from "./Modal";
 
@@ -6,29 +7,67 @@ interface ShortcutHelpModalProps {
   onClose: () => void;
 }
 
-const shortcuts = [
+const SHORTCUTS = [
   { keys: "Ctrl + G", labelKey: "shortcuts.generate" },
   { keys: "Ctrl + Enter", labelKey: "shortcuts.generate" },
   { keys: "Ctrl + Shift + C", labelKey: "shortcuts.copyAll" },
   { keys: "Ctrl + S", labelKey: "shortcuts.saveDraft" },
   { keys: "Ctrl + /", labelKey: "shortcuts.help" },
+  { keys: "?", labelKey: "shortcuts.help" },
   { keys: "Escape", labelKey: "shortcuts.close" },
 ] as const;
 
 export function ShortcutHelpModal({ open, onClose }: ShortcutHelpModalProps) {
   const { t } = useTranslation("ui");
+  const [query, setQuery] = useState("");
+
+  // Reset the filter every time the modal closes so a re-open starts
+  // fresh — otherwise the previous filter persists invisibly.
+  useEffect(() => {
+    if (!open) setQuery("");
+  }, [open]);
+
+  const filtered = useMemo(() => {
+    const trimmed = query.trim().toLowerCase();
+    if (!trimmed) return SHORTCUTS;
+    return SHORTCUTS.filter((s) => {
+      const label = t(s.labelKey).toLowerCase();
+      return label.includes(trimmed) || s.keys.toLowerCase().includes(trimmed);
+    });
+  }, [query, t]);
 
   return (
     <Modal open={open} onClose={onClose} title={t("shortcuts.title")}>
-      <div className="flex flex-col gap-2">
-        {shortcuts.map((s) => (
-          <div key={s.keys} className="flex items-center justify-between py-1">
-            <span className="text-sm text-text-secondary">{t(s.labelKey)}</span>
-            <kbd className="rounded bg-surface-2 px-2 py-0.5 font-mono text-xs text-text-primary">
-              {s.keys}
-            </kbd>
+      <div className="flex flex-col gap-3">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={t("shortcuts.searchPlaceholder")}
+          className="rounded-lg border border-border bg-surface-1 px-3 py-2 text-sm text-text-primary placeholder:text-text-muted transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/50"
+          autoFocus
+        />
+        {filtered.length === 0 ? (
+          <p className="py-2 text-sm text-text-muted">
+            {t("shortcuts.noResults")}
+          </p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {filtered.map((s) => (
+              <div
+                key={`${s.keys}-${s.labelKey}`}
+                className="flex items-center justify-between py-1"
+              >
+                <span className="text-sm text-text-secondary">
+                  {t(s.labelKey)}
+                </span>
+                <kbd className="rounded bg-surface-2 px-2 py-0.5 font-mono text-xs text-text-primary">
+                  {s.keys}
+                </kbd>
+              </div>
+            ))}
           </div>
-        ))}
+        )}
       </div>
     </Modal>
   );

--- a/src/config/genres.ts
+++ b/src/config/genres.ts
@@ -44,3 +44,32 @@ export const GENRES = [
 ] as const;
 
 export type GenreId = (typeof GENRES)[number]["id"];
+
+/**
+ * Ids for the bulk-select buttons rendered above the genre chip group.
+ * Each id maps to a curated set of genres in {@link GENRE_GROUPS} and
+ * an i18n label under `editor.genreGroups.<id>`.
+ */
+export type GenreGroupId = "rpg" | "shooter" | "horror";
+
+/**
+ * Bulk-toggle groups (v0.9 phase 2). Clicking the group's button
+ * REPLACES the current selection with the first {@link MAX_GENRES} ids
+ * from the list (so the selection stays under the cap regardless of
+ * how big the group is). Order in each list determines which ids get
+ * picked when the group exceeds the cap.
+ */
+export const GENRE_GROUPS: Record<GenreGroupId, readonly GenreId[]> = {
+  rpg: ["rpg", "jrpg", "action_rpg", "crpg"],
+  shooter: [
+    "fps",
+    "arena_shooter",
+    "tactical_fps",
+    "boomer_shooter",
+    "extraction_shooter",
+    "shmup",
+  ],
+  horror: ["horror", "survival_horror", "psychological_horror"],
+};
+
+export const GENRE_GROUP_IDS: readonly GenreGroupId[] = ["rpg", "shooter", "horror"];

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -29,10 +29,32 @@ export function useKeyboardShortcuts({ onToggleHelp }: ShortcutOptions) {
       } else if (ctrl && e.key === "/") {
         e.preventDefault();
         onToggleHelp();
+      } else if (
+        // Bare `?` (Shift+/) opens the cheatsheet too. Skip when the
+        // user is typing into a form field — `?` is a legitimate
+        // character in titles, descriptions, and other inputs.
+        e.key === "?" &&
+        !ctrl &&
+        !isEditableTarget(e.target)
+      ) {
+        e.preventDefault();
+        onToggleHelp();
       }
     };
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [navigate, output.title, output.description, copy, onToggleHelp]);
+}
+
+/**
+ * True when the keydown target is an input the user might be typing
+ * into. Used to gate bare-character shortcuts (e.g. `?`) so they don't
+ * hijack normal text entry.
+ */
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  return target.isContentEditable;
 }

--- a/src/i18n/locales/_schema.json
+++ b/src/i18n/locales/_schema.json
@@ -39,8 +39,10 @@
       "playthrough", "difficulty", "difficultyCustomLabel", "difficultyCustomPlaceholder",
       "contentWarnings",
       "videoSettings", "quickPreview", "version",
-      "clearDraft", "draftSaved", "clearDraftConfirm"
+      "clearDraft", "draftSaved", "clearDraftConfirm",
+      "genreSearchPlaceholder", "genreSearchNoResults"
     ],
+    "editor.genreGroups": ["rpg", "shooter", "horror"],
     "editor.graphicsPresetOptions": ["low", "medium", "high", "very_high", "cinematic", "ultra", "extreme", "custom"],
     "editor.rtOptions": ["ray_tracing", "full_rt", "path_tracing", "ray_reconstruction"],
     "editor.frameGenVendorOptions": ["none", "nvidia", "amd", "intel"],
@@ -84,7 +86,7 @@
     "history": ["title", "emptyState", "clearAll", "clearConfirm", "searchPlaceholder"],
     "settings": ["title", "appearance", "defaults", "editorSettings", "tagSettings", "historySettings", "theme", "appLanguage", "defaultOutputLanguage", "defaultGenre", "showCharCount", "compactTagDisplay", "historyLimit", "multilingualTags", "trendingTags", "hashtagCount", "showQualityBadge", "showCopyright", "showUsagePolicy", "showSponsorCredit", "titleFormatTitle", "descriptionSettingsTitle", "badgePosition", "badgePositionPrefix", "badgePositionMiddle", "badgePositionSuffix", "titleSeparator", "titleSeparatorEmDash", "titleSeparatorHyphen", "titleSeparatorColon", "titleSeparatorPipe", "badgeCase", "badgeCaseUpper", "badgeCaseLower", "showPinnedCommentTemplate", "pinnedCommentIncludeAskNextGame", "pinnedCommentIncludeGenrePlaylist", "genrePlaylistsTitle", "genrePlaylistsHelp", "genrePlaylistsEmptyHint"],
     "batch": ["title", "startPart", "endPart", "generateBatch", "copyAllBatch", "emptyState"],
-    "shortcuts": ["title", "generate", "copyAll", "saveDraft", "help", "close"],
+    "shortcuts": ["title", "generate", "copyAll", "saveDraft", "help", "close", "searchPlaceholder", "noResults"],
     "validation": ["emailInvalid", "emailMaxExceeded", "urlInvalid", "urlPrefixMismatch", "playlistUrlInvalid"],
     "logs": ["title", "emptyState", "clearAll", "clearConfirm", "searchPlaceholder"],
     "playlist": ["title", "status", "contentType", "totalVideos", "customNote", "generatePlaylist"]

--- a/src/i18n/locales/en/ui.json
+++ b/src/i18n/locales/en/ui.json
@@ -209,6 +209,13 @@
     "clearDraft": "Clear Draft",
     "draftSaved": "Draft saved",
     "clearDraftConfirm": "Are you sure you want to clear all form data?",
+    "genreSearchPlaceholder": "Search genres",
+    "genreSearchNoResults": "No matching genres",
+    "genreGroups": {
+      "rpg": "All RPGs",
+      "shooter": "All Shooters",
+      "horror": "All Horror"
+    },
     "contactEmailHelp": "Up to 3 emails, comma-separated",
     "toast": {
       "urlAutoFilled": "Auto-filled '{{name}}' from URL"
@@ -465,7 +472,9 @@
     "copyAll": "Copy All",
     "saveDraft": "Save Draft",
     "help": "Show Shortcuts",
-    "close": "Close Modal"
+    "close": "Close Modal",
+    "searchPlaceholder": "Search shortcuts",
+    "noResults": "No matching shortcuts"
   },
   "validation": {
     "emailInvalid": "Invalid email: {{email}}",

--- a/src/i18n/locales/es/ui.json
+++ b/src/i18n/locales/es/ui.json
@@ -209,6 +209,13 @@
     "clearDraft": "Limpiar Borrador",
     "draftSaved": "Borrador guardado",
     "clearDraftConfirm": "¿Estás seguro de que quieres borrar todos los datos del formulario?",
+    "genreSearchPlaceholder": "Buscar géneros",
+    "genreSearchNoResults": "No se encontraron géneros",
+    "genreGroups": {
+      "rpg": "Todos los RPG",
+      "shooter": "Todos los Shooter",
+      "horror": "Todo Horror"
+    },
     "contactEmailHelp": "Hasta 3 emails, separados por comas",
     "toast": {
       "urlAutoFilled": "'{{name}}' rellenado automáticamente desde URL"
@@ -465,7 +472,9 @@
     "copyAll": "Copiar Todo",
     "saveDraft": "Guardar Borrador",
     "help": "Ayuda",
-    "close": "Cerrar"
+    "close": "Cerrar",
+    "searchPlaceholder": "Buscar atajos",
+    "noResults": "No se encontraron atajos"
   },
   "validation": {
     "emailInvalid": "Email inválido: {{email}}",

--- a/src/i18n/locales/ja/ui.json
+++ b/src/i18n/locales/ja/ui.json
@@ -209,6 +209,13 @@
     "clearDraft": "下書きをクリア",
     "draftSaved": "下書き保存済み",
     "clearDraftConfirm": "フォームデータをすべてクリアしますか？",
+    "genreSearchPlaceholder": "ジャンルを検索",
+    "genreSearchNoResults": "該当するジャンルはありません",
+    "genreGroups": {
+      "rpg": "すべての RPG",
+      "shooter": "すべてのシューター",
+      "horror": "すべてのホラー"
+    },
     "contactEmailHelp": "最大3つのメール、カンマ区切り",
     "toast": {
       "urlAutoFilled": "URLから「{{name}}」を自動入力しました"
@@ -465,7 +472,9 @@
     "copyAll": "すべてコピー",
     "saveDraft": "下書き保存",
     "help": "ショートカット表示",
-    "close": "モーダルを閉じる"
+    "close": "モーダルを閉じる",
+    "searchPlaceholder": "ショートカットを検索",
+    "noResults": "該当するショートカットはありません"
   },
   "validation": {
     "emailInvalid": "無効なメール: {{email}}",

--- a/src/i18n/locales/ko/ui.json
+++ b/src/i18n/locales/ko/ui.json
@@ -209,6 +209,13 @@
     "clearDraft": "초안 지우기",
     "draftSaved": "초안 저장됨",
     "clearDraftConfirm": "모든 양식 데이터를 지우시겠습니까?",
+    "genreSearchPlaceholder": "장르 검색",
+    "genreSearchNoResults": "일치하는 장르 없음",
+    "genreGroups": {
+      "rpg": "모든 RPG",
+      "shooter": "모든 슈터",
+      "horror": "모든 호러"
+    },
     "contactEmailHelp": "최대 3개 이메일, 쉼표로 구분",
     "toast": {
       "urlAutoFilled": "URL에서 '{{name}}'을(를) 자동 채웠습니다"
@@ -465,7 +472,9 @@
     "copyAll": "전체 복사",
     "saveDraft": "초안 저장",
     "help": "도움말",
-    "close": "닫기"
+    "close": "닫기",
+    "searchPlaceholder": "단축키 검색",
+    "noResults": "일치하는 단축키 없음"
   },
   "validation": {
     "emailInvalid": "잘못된 이메일: {{email}}",

--- a/src/i18n/locales/vi/ui.json
+++ b/src/i18n/locales/vi/ui.json
@@ -209,6 +209,13 @@
     "clearDraft": "Xóa bản nháp",
     "draftSaved": "Đã lưu nháp",
     "clearDraftConfirm": "Bạn có chắc muốn xóa toàn bộ dữ liệu form?",
+    "genreSearchPlaceholder": "Tìm thể loại",
+    "genreSearchNoResults": "Không có thể loại phù hợp",
+    "genreGroups": {
+      "rpg": "Tất cả RPG",
+      "shooter": "Tất cả Shooter",
+      "horror": "Tất cả Horror"
+    },
     "contactEmailHelp": "Tối đa 3 email, cách nhau bằng dấu phẩy",
     "toast": {
       "urlAutoFilled": "Đã tự động điền '{{name}}' từ URL"
@@ -465,7 +472,9 @@
     "copyAll": "Sao chép tất cả",
     "saveDraft": "Lưu nháp",
     "help": "Hiện phím tắt",
-    "close": "Đóng"
+    "close": "Đóng",
+    "searchPlaceholder": "Tìm phím tắt",
+    "noResults": "Không có phím tắt phù hợp"
   },
   "validation": {
     "emailInvalid": "Email không hợp lệ: {{email}}",

--- a/src/i18n/locales/zh/ui.json
+++ b/src/i18n/locales/zh/ui.json
@@ -209,6 +209,13 @@
     "clearDraft": "清除草稿",
     "draftSaved": "草稿已保存",
     "clearDraftConfirm": "确定要清除所有表单数据吗？",
+    "genreSearchPlaceholder": "搜索类型",
+    "genreSearchNoResults": "未找到类型",
+    "genreGroups": {
+      "rpg": "所有 RPG",
+      "shooter": "所有射击",
+      "horror": "所有恐怖"
+    },
     "contactEmailHelp": "最多3个邮箱，用逗号分隔",
     "toast": {
       "urlAutoFilled": "已从URL自动填入「{{name}}」"
@@ -465,7 +472,9 @@
     "copyAll": "复制全部",
     "saveDraft": "保存草稿",
     "help": "帮助",
-    "close": "关闭"
+    "close": "关闭",
+    "searchPlaceholder": "搜索快捷键",
+    "noResults": "未找到快捷键"
   },
   "validation": {
     "emailInvalid": "无效邮箱: {{email}}",


### PR DESCRIPTION
## Summary

Closes out v0.9 with the four remaining items from the original spec — three QoL UI tweaks plus a multi-platform CI release.

## B3 — QoL trio

### (a) Cheatsheet modal — `?` shortcut + search

- Bare `?` key now opens the existing `ShortcutHelpModal` (Ctrl+/ still works). The `?` handler skips firing when the keydown target is an `INPUT` / `TEXTAREA` / `SELECT` / `contentEditable` element so it doesn't hijack normal text entry.
- The modal grows a search input that live-filters by translated label **or** by the literal key combo string (so typing `ctrl` finds every Ctrl-binding). Filter resets on close.
- Empty result set shows a localised "no matching shortcuts" line.

### (b) Genre search filter

- `GenreSelector` renders a search input above the chip group. Case-insensitive substring match on the translated chip label.
- Empty query renders all 41 genres; empty-result set shows "no matching genres" in place of the chip row.

### (c) Bulk-toggle — "All RPGs / Shooters / Horror"

- Three buttons above the chip group. Clicking **replaces** the current selection with the first `MAX_GENRES` (3) ids from the matching `GENRE_GROUPS` list — so the cap is preserved end-to-end without disabling buttons.
- Filter clears on bulk-toggle so the new chips are always visible.
- Group registry lives in [src/config/genres.ts](src/config/genres.ts) as a typed `Record<GenreGroupId, readonly GenreId[]>`:
  - `rpg` → `["rpg", "jrpg", "action_rpg", "crpg"]`
  - `shooter` → `["fps", "arena_shooter", "tactical_fps", "boomer_shooter", "extraction_shooter", "shmup"]`
  - `horror` → `["horror", "survival_horror", "psychological_horror"]`

**i18n:** 7 new keys per locale (`shortcuts.searchPlaceholder`, `shortcuts.noResults`, `editor.genreSearchPlaceholder`, `editor.genreSearchNoResults`, plus `editor.genreGroups.{rpg,shooter,horror}`). All 6 locales fully translated. 428 ui keys per locale (up from 421).

## B4 — Multi-platform release matrix

[`.github/workflows/release-desktop.yml`](.github/workflows/release-desktop.yml) grows from a Windows-only build to a 4-entry matrix:

| Runner | Target | Output |
|---|---|---|
| `windows-latest` | `x86_64-pc-windows-msvc` | `.msi`, `.exe` (NSIS) |
| `macos-13` | `x86_64-apple-darwin` | `.dmg`, `.app.tar.gz` |
| `macos-14` | `aarch64-apple-darwin` | `.dmg`, `.app.tar.gz` |
| `ubuntu-latest` | `x86_64-unknown-linux-gnu` | `.AppImage`, `.deb` |

- `fail-fast: false` so one platform breaking doesn't cancel the others.
- Each runner builds for its explicit `--target` triple.
- Linux runner installs `libwebkit2gtk-4.1-dev`, `libgtk-3-dev`, `libayatana-appindicator3-dev`, `librsvg2-dev`, and `patchelf` — Tauri's webview + AppImage tooling needs these.
- `tauri-action@v0` collects all artifacts onto a single draft GitHub Release named `YTDescGen v__VERSION__`. Smoke-test then publish manually.

**No code signing** for either Windows or macOS (open-source personal tool, recurring cert cost not justified) — users see the standard "unverified publisher" / "unidentified developer" prompts on first launch. Documented in [docs/PACKAGING.md](docs/PACKAGING.md).

**No git-cliff auto-changelog.** Release notes come from the tag's annotated message via the default `tauri-action` behaviour. CHANGELOG.md is hand-maintained.

**Pre-workflow backfill:** `v0.8.0` and `v0.8.1` predate this matrix and only have local Windows builds. To attach binaries retroactively, build manually then `gh release create v0.8.x ...`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test:run` — 297 passed
- [x] `npm run validate:locales` — 428/428 ui + 203/203 templates per locale
- [x] `npm run build` — main bundle 270 KB (≤500 KB gate)
- [ ] Manual UAT (browser):
  - Press `?` outside any input → ShortcutHelpModal opens.
  - Type into the Game Name field, press `?` → no modal (normal `?` typed into the input).
  - In the modal, type `ctrl` → list filters down to the Ctrl-* shortcuts.
  - GenreSelector: type `horror` in the search → only the 3 horror chips show.
  - Click "All RPGs" → chips for `rpg`, `jrpg`, `action_rpg` light up; previous selection cleared. Counter shows `3/3`.
  - Click "All Horror" → same flow with the 3 horror chips.
- [ ] CI smoke (next tag push, e.g. `v0.9.0`): release-desktop workflow runs the 4-platform matrix and uploads installers to a draft Release.