### PR TITLE
fix(ci): skip macOS DMG bundling, drop macos-13, add workflow_dispatch

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -3,6 +3,16 @@ name: Release Desktop
 on:
   push:
     tags: ["v*"]
+  # Manual re-run hook — lets us rebuild a release without deleting +
+  # recreating the tag. Useful when a transient runner failure (e.g.
+  # the macOS DMG bundler hitting an AppleScript flake) costs us one
+  # arch's binary on an otherwise-shipped tag.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build (e.g. v0.9.0). The job still expects the manifests to already carry this version."
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -15,15 +25,34 @@ jobs:
         include:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-          - os: macos-13
-            target: x86_64-apple-darwin
+            # Default Windows bundles: MSI + NSIS (.exe). Both ship.
+            bundleArgs: ""
           - os: macos-14
             target: aarch64-apple-darwin
+            # macOS DMG bundling on hosted runners flakes inside
+            # `bundle_dmg.sh` (the AppleScript that sets icon
+            # positions in the DMG window times out on the headless
+            # runner). Build only the `.app` bundle; tauri-action
+            # tar.gzips it into a `.app.tar.gz` for upload. Users
+            # expand and drag-drop into /Applications.
+            #
+            # Intel macOS (x86_64) is NOT built — the `macos-13`
+            # free runner queue is functionally unavailable since
+            # GitHub started deprecating it. Revisit with a
+            # `universal-apple-darwin` build on this same runner if
+            # Intel support becomes a priority.
+            bundleArgs: "--bundles app"
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            # Default Linux bundles: AppImage + deb. Both ship.
+            bundleArgs: ""
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # On `workflow_dispatch` checkout the requested tag; on a
+          # tag push we already get the tag commit by default.
+          ref: ${{ github.event.inputs.tag || github.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -46,8 +75,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: v__VERSION__
-          releaseName: "YTDescGen v__VERSION__"
+          tagName: ${{ github.event.inputs.tag || 'v__VERSION__' }}
+          releaseName: "YTDescGen ${{ github.event.inputs.tag || 'v__VERSION__' }}"
           releaseBody: "See the assets to download the installer for your platform."
           releaseDraft: true
-          args: --target ${{ matrix.target }}
+          args: ${{ matrix.bundleArgs }} --target ${{ matrix.target }}

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -239,24 +239,29 @@ Output locations:
 
 ### GitHub Actions Release
 
-The live workflow lives at [.github/workflows/release-desktop.yml](../.github/workflows/release-desktop.yml). Pushing a `v*` tag (e.g. `v0.10.0`) triggers a four-platform matrix build (Windows, macOS Intel, macOS ARM, Linux) and uploads each installer to a single draft GitHub Release named `YTDescGen v__VERSION__`. Publish the draft manually after smoke-testing the binaries.
+The live workflow lives at [.github/workflows/release-desktop.yml](../.github/workflows/release-desktop.yml). Pushing a `v*` tag (e.g. `v0.10.0`) triggers a three-platform matrix build (Windows, macOS ARM, Linux) and uploads each installer to a single draft GitHub Release named `YTDescGen v__VERSION__`. Publish the draft manually after smoke-testing the binaries.
 
-Matrix entries (v0.9 phase 2):
+Matrix entries:
 
 | Runner | Target | Output |
 |---|---|---|
 | `windows-latest` | `x86_64-pc-windows-msvc` | `.msi`, `.exe` (NSIS) |
-| `macos-13` | `x86_64-apple-darwin` | `.dmg`, `.app.tar.gz` |
-| `macos-14` | `aarch64-apple-darwin` | `.dmg`, `.app.tar.gz` |
+| `macos-14` | `aarch64-apple-darwin` | `.app.tar.gz` |
 | `ubuntu-latest` | `x86_64-unknown-linux-gnu` | `.AppImage`, `.deb` |
 
 Linux runners install `libwebkit2gtk-4.1-dev`, `libgtk-3-dev`, `libayatana-appindicator3-dev`, `librsvg2-dev`, and `patchelf` before building — Tauri's webview + AppImage tooling needs these.
 
-`fail-fast: false` keeps the other platforms going if one breaks. `args: --target ${{ matrix.target }}` is passed through to `tauri build` so each runner uses its explicit target triple.
+`fail-fast: false` keeps the other platforms going if one breaks. The `bundleArgs` matrix field is concatenated with `--target ${{ matrix.target }}` and passed through to `tauri build`.
+
+**macOS notes (v0.9.1+):**
+- **DMG bundling is skipped** (`--bundles app`). Tauri's DMG bundler runs an AppleScript that flakes intermittently on hosted macOS runners (the headless display can't load Finder fast enough for `osascript` to position icons), so we ship a `.app.tar.gz` instead. Users expand the archive and drag the `.app` into `/Applications`.
+- **Intel macOS (`macos-13`) is NOT built.** GitHub started deprecating the `macos-13` free runner pool in 2025; jobs queue indefinitely. If Intel support becomes a priority, switch the macos-14 entry's target to `universal-apple-darwin` (Tauri builds both archs and lipos them into one universal binary) — the runner already has the toolchain capacity.
 
 **Code signing is intentionally skipped** for both Windows and macOS — this is an open-source personal tool, and signing certificates carry recurring cost. End users will see the standard "unverified publisher" / "unidentified developer" prompts on first launch. Document the bypass steps in the release notes if needed.
 
 **Auto-changelog** (`git-cliff`) is out of scope; release notes come from the tag's annotated message via the default `tauri-action` behaviour. CHANGELOG.md is hand-maintained.
+
+**Manual re-run:** the workflow accepts `workflow_dispatch` with a `tag` input — `gh workflow run release-desktop.yml -f tag=v0.9.0` rebuilds an existing release without deleting + recreating the tag. Useful when a transient runner failure costs a single arch's binary.
 
 **Backfill for pre-workflow tags:** `v0.8.0` and `v0.8.1` predate the multi-platform matrix and only have local Windows builds. To attach binaries retroactively, build manually then `gh release create v0.8.0 --notes-file CHANGELOG.md path/to/*.msi …`.
 


### PR DESCRIPTION
## Summary

Three CI release fixes from the v0.9.0 first run. Original run: [#25267515722](https://github.com/poli0981/youtube-generator/actions/runs/25267515722).

| Job | Result | Cause | Fix |
|---|---|---|---|
| `windows-latest` | ✅ success | — | unchanged |
| `ubuntu-latest` | ✅ success | — | unchanged |
| `macos-14` (ARM) | ❌ failure (3m11s) | `bundle_dmg.sh` AppleScript flake on hosted runner | drop DMG, ship `.app.tar.gz` only |
| `macos-13` (Intel) | ❌ cancelled (2h11m queue) | free `macos-13` runner pool depleted (deprecation) | drop the matrix entry |

### (1) macOS DMG bundler — `failed to run bundle_dmg.sh`

Tauri's DMG bundler runs an AppleScript via `osascript` to set icon positions in the mounted DMG window. Hosted macOS runners have a headless display + sandboxed Finder that causes the AppleScript to flake intermittently — a known tauri-action issue.

**Fix:** build only the `.app` bundle (`--bundles app`). `tauri-action` tar.gzips the `.app` into a `.app.tar.gz` upload. End user expands the archive and drags the `.app` into `/Applications`.

### (2) macos-13 queue 2h11m → cancelled

GitHub started progressively deprecating the `macos-13` free runner pool through 2025; jobs frequently never start. **Fix:** drop the matrix entry. Intel macOS users have no CI binary for now — revisit by switching the `macos-14` entry to `universal-apple-darwin` if Intel support becomes a priority. (Tauri builds both archs and lipos them into one universal binary; same runner does both arches.)

### (3) `workflow_dispatch` for manual re-runs

Adds a `workflow_dispatch` trigger with a `tag` input. `actions/checkout@v4` honours the input ref; `tauri-action` honours the `tagName` input. After merge, this recovers the v0.9.0 macOS binary without deleting + recreating the tag:

```
gh workflow run release-desktop.yml --ref main -f tag=v0.9.0
```

The workflow file from `main` (with this fix) runs against the v0.9.0 commit and uploads to the existing draft release.

## Matrix after this PR

| Runner | Target | Bundles |
|---|---|---|
| `windows-latest` | `x86_64-pc-windows-msvc` | `.msi` + `.exe` (NSIS) |
| `macos-14` | `aarch64-apple-darwin` | `.app.tar.gz` |
| `ubuntu-latest` | `x86_64-unknown-linux-gnu` | `.AppImage` + `.deb` |

## Test plan

- [ ] After merge, run `gh workflow run release-desktop.yml --ref main -f tag=v0.9.0` to rebuild v0.9.0 across the three platforms. Expect: macOS-14 produces `YTDescGen_0.9.0_aarch64.app.tar.gz` and uploads to the existing v0.9.0 draft release.
- [ ] Smoke-test the new macOS asset on a Mac (expand archive, drag-drop, right-click → Open to bypass Gatekeeper).
- [ ] If green, publish the draft release.