### PR TITLE
feat(v0.13.1): workflows + donate/dev surfaces + SEO + horror warnings

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,6 @@
+github: poli0981
+ko_fi: skullmute
+buy_me_a_coffee: skullmute
+patreon: skullmute
+custom:
+  - paypal.me/DungDang212

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,99 @@
+name: Bug report
+description: Something is broken or behaving unexpectedly.
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill in as much detail as you can —
+        a clear reproduction is the difference between a fix today and a fix in 3 weeks.
+  - type: input
+    id: version
+    attributes:
+      label: App version
+      description: From the About page or the title bar. Example `v0.13.0`.
+      placeholder: v0.13.0
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Where are you running YTDescGen?
+      options:
+        - Web (GitHub Pages)
+        - Desktop — Windows (Tauri)
+        - Desktop — macOS (Tauri)
+        - Desktop — Linux (Tauri)
+        - Local dev (npm run dev)
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      description: e.g. Windows 11 25H2, macOS 14.6, Ubuntu 24.04
+    validations:
+      required: true
+  - type: input
+    id: browser
+    attributes:
+      label: Browser (web only)
+      description: e.g. Chrome 131, Brave 1.70, Safari 17. Leave blank for desktop.
+  - type: dropdown
+    id: language
+    attributes:
+      label: App language at the time of the bug
+      options:
+        - English (en)
+        - Tiếng Việt (vi)
+        - 日本語 (ja)
+        - Español (es)
+        - 한국어 (ko)
+        - 中文 (zh)
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps. Include the exact inputs that triggered the bug.
+      placeholder: |
+        1. Open Editor
+        2. Pick genre "Survival Horror"
+        3. Toggle "eye_horror" warning
+        4. Click Generate
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: console
+    attributes:
+      label: Console / log output
+      description: Open DevTools (web) or the log panel (desktop) and paste any errors. Rendered as code.
+      render: shell
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / screen recording (optional)
+      description: Drag and drop images or videos here.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: I'm on the latest released version (or noted my older version above).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discord — General chat
+    url: https://discord.gg/2aNR3aVt
+    about: For casual questions, gameplay chat, or quick help. Use a bug report or feature request for anything actionable.
+  - name: GitHub Discussions
+    url: https://github.com/poli0981/youtube-generator/discussions
+    about: Ideas, Q&A, and release announcements live here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: Feature request
+description: Suggest a new feature or improvement.
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What pain point or workflow gap are you running into today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should YTDescGen do? Be concrete — UI sketch, example output, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about and why you ruled them out.
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: Which surfaces does this affect?
+      multiple: true
+      options:
+        - Editor
+        - Output / preview
+        - Profiles / presets
+        - Templates (description, title, tags)
+        - i18n / locales
+        - Settings
+        - Desktop (Tauri)
+        - Documentation
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true

--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -10,13 +10,31 @@ on:
         required: true
         type: string
 
-# Reusable announce-release.yml only needs `contents: read` to fetch
-# release metadata via the gh CLI.
+# `link-discussion` needs `contents: write` (to edit the release) and
+# `discussions: write` (so GitHub auto-creates the linked Discussion under
+# the configured category). The reusable announce job only needs read.
 permissions:
-  contents: read
+  contents: write
+  discussions: write
 
 jobs:
+  link-discussion:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Link release to Announcements discussion
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Setting --discussion-category on a published release causes
+        # GitHub to auto-create the linked Discussion. Requires the
+        # repo to have Discussions enabled with an "Announcements"
+        # category (configured manually under repo Settings).
+        run: |
+          gh release edit "${{ github.event.release.tag_name || inputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --discussion-category "Announcements"
+
   announce:
+    needs: link-discussion
     uses: poli0981/.github/.github/workflows/announce-release.yml@main
     with:
       tag_override: ${{ inputs.tag || '' }}

--- a/.github/workflows/notify-ci-failure.yml
+++ b/.github/workflows/notify-ci-failure.yml
@@ -2,7 +2,9 @@ name: Notify CI Failures
 
 on:
   workflow_run:
-    workflows: ["*"]
+    # Match the exact `name:` of the CI workflow (.github/workflows/ci.yml).
+    # Renaming CI silently breaks this filter — keep them in sync.
+    workflows: ["CI"]
     types: [completed]
 
 # REQUIRED: declare permissions matching the reusable workflow's needs.

--- a/.github/workflows/notify-deploy.yml
+++ b/.github/workflows/notify-deploy.yml
@@ -2,7 +2,10 @@ name: Notify Deploy Status
 
 on:
   workflow_run:
-    workflows: ["*"]
+    # Match the exact `name:` of the deploy workflow
+    # (.github/workflows/deploy-web.yml). Renaming it silently breaks this
+    # filter — keep them in sync.
+    workflows: ["Deploy to GitHub Pages"]
     types: [completed]
 
 permissions:

--- a/.github/workflows/notify-release-pipeline.yml
+++ b/.github/workflows/notify-release-pipeline.yml
@@ -2,7 +2,10 @@ name: Notify Release Pipeline
 
 on:
   workflow_run:
-    workflows: ["*"]
+    # Match the exact `name:` of the release-pipeline producers
+    # (release-desktop.yml + announce-release.yml). Renaming either silently
+    # breaks this filter — keep them in sync.
+    workflows: ["Release Desktop", "Announce Release to Discord"]
     types: [completed]
 
 permissions:

--- a/docs/dev_env.md
+++ b/docs/dev_env.md
@@ -1,0 +1,46 @@
+# Development environment
+
+What we install on a fresh box to be productive on YTDescGen. Hardware spec
+lives in [`pc_spec.md`](pc_spec.md); this file is the toolchain side.
+
+## Editors
+
+- **JetBrains 2026.x** (paid lineup) — PyCharm, WebStorm, RustRover, Rider.
+- **VS Code** — for quick edits, markdown preview, and shared remote sessions.
+
+Pick whichever feels right for the file; both share the project's ESLint /
+Prettier / TypeScript config out of the box.
+
+## Toolchains
+
+| Tool   | Version           | Notes |
+|--------|-------------------|-------|
+| Node.js | ≥ 25.8.1         | Required for Vite 5 + Vitest 2. Use `nvm` / `volta` if pinning. |
+| Python  | 3.12             | Used by tooling scripts under `scripts/`. |
+| Rust    | stable (`rustup`) | Required for Tauri 2 desktop builds. |
+| Git     | recent           | Any version with SSH + Sparse Checkout support. |
+
+## Git hygiene
+
+- `commit.gpgsign = true` — all commits are GPG-signed.
+- Branch model: `main` (stable) ← `dev` (integration) ← `feat/*`.
+- Commit message format: `type(scope): message` — see [`../CLAUDE.md`](../CLAUDE.md).
+
+## Common commands
+
+See [`../CLAUDE.md`](../CLAUDE.md) for the full list. Day-to-day:
+
+```bash
+npm install         # first time
+npm run dev         # Vite dev server
+npm run typecheck   # tsc --noEmit
+npm run test        # Vitest watch
+npm run validate:locales
+npm run tauri dev   # desktop shell against the dev server
+```
+
+## Companion docs
+
+- [`pc_spec.md`](pc_spec.md) — hardware reference.
+- [`../webapp/TAURI.md`](../webapp/TAURI.md) — Tauri 2 build prerequisites per platform.
+- [`i18n/vi/dev_env.md`](i18n/vi/dev_env.md) — Vietnamese mirror.

--- a/docs/i18n/vi/dev_env.md
+++ b/docs/i18n/vi/dev_env.md
@@ -1,0 +1,46 @@
+# Môi trường phát triển
+
+Những thứ cần cài trên máy mới để làm việc với YTDescGen. Phần phần cứng
+ở [`pc_spec.md`](pc_spec.md); file này tập trung vào toolchain.
+
+## Editor
+
+- **JetBrains 2026.x** (bản trả phí) — PyCharm, WebStorm, RustRover, Rider.
+- **VS Code** — cho chỉnh sửa nhanh, xem trước markdown, và pair session.
+
+Chọn editor phù hợp với từng file; cả hai đều dùng chung cấu hình
+ESLint / Prettier / TypeScript của project.
+
+## Toolchain
+
+| Công cụ | Phiên bản          | Ghi chú |
+|---------|--------------------|---------|
+| Node.js | ≥ 25.8.1           | Cần cho Vite 5 + Vitest 2. Nên dùng `nvm` / `volta` để pin version. |
+| Python  | 3.12               | Phục vụ các script trong `scripts/`. |
+| Rust    | stable (`rustup`)  | Cần cho build desktop Tauri 2. |
+| Git     | bản mới            | Phiên bản nào hỗ trợ SSH + Sparse Checkout đều dùng được. |
+
+## Quy ước Git
+
+- `commit.gpgsign = true` — mọi commit đều được GPG-sign.
+- Mô hình branch: `main` (stable) ← `dev` (integration) ← `feat/*`.
+- Format commit message: `type(scope): message` — xem [`../../../CLAUDE.md`](../../../CLAUDE.md).
+
+## Lệnh hay dùng
+
+Xem [`../../../CLAUDE.md`](../../../CLAUDE.md) để có danh sách đầy đủ. Hàng ngày:
+
+```bash
+npm install         # lần đầu
+npm run dev         # Vite dev server
+npm run typecheck   # tsc --noEmit
+npm run test        # Vitest watch
+npm run validate:locales
+npm run tauri dev   # shell desktop chạy đè lên dev server
+```
+
+## Tài liệu liên quan
+
+- [`pc_spec.md`](pc_spec.md) — phần cứng (tiếng Việt).
+- [`../../../webapp/TAURI.md`](../../../webapp/TAURI.md) — yêu cầu build Tauri 2 theo nền tảng.
+- [`../../dev_env.md`](../../dev_env.md) — bản gốc tiếng Anh.

--- a/docs/i18n/vi/pc_spec.md
+++ b/docs/i18n/vi/pc_spec.md
@@ -1,0 +1,39 @@
+# Máy phát triển
+
+Cấu hình tham chiếu cho máy dev chính của YTDescGen — bản web public, các
+binary Tauri desktop, và video demo ghi hình đều đến từ máy này. Xem
+[`dev_env.md`](dev_env.md) cho phần IDE + toolchain, và
+[`../../pc_spec.md`](../../pc_spec.md) cho bản gốc tiếng Anh.
+
+## Máy chính
+
+| Thành phần | Chi tiết |
+|------------|----------|
+| OS         | Windows 11 Pro 25H2 Insider Preview (Dev Channel) |
+| Build      | 26300.8376 |
+| CPU        | Intel Core i7-14700KF |
+| GPU        | NVIDIA GeForce RTX 5080 (16 GB VRAM) |
+| RAM        | 32 GB DDR5 |
+| Lưu trữ    | 1 TB SSD |
+| IDE        | JetBrains bản trả phí, 2026.x — PyCharm, WebStorm, RustRover, Rider — cộng thêm VS Code |
+
+## Điện thoại kiểm thử bản web
+
+Bản web được smoke-test trên Safari và các trình duyệt Chromium trên các
+máy sau:
+
+- iPhone 14 Pro (iOS 26.x)
+- iPhone 13 Pro Max (iOS 26.x)
+- Trình duyệt: Chrome, Brave
+
+## Vì sao cần ghi rõ
+
+Hiệu năng render, style scrollbar, và sidebar `position: sticky` của editor
+hoạt động hơi khác giữa Safari mobile và Chromium desktop. Mọi thay đổi UI
+được smoke-test trên các điện thoại liệt kê ở trên trước khi ship.
+
+## Tài liệu liên quan
+
+- [`dev_env.md`](dev_env.md) — bảng IDE + toolchain (tiếng Việt).
+- [`../../../webapp/TAURI.md`](../../../webapp/TAURI.md) — yêu cầu build Tauri desktop.
+- [`../../pc_spec.md`](../../pc_spec.md) — bản gốc tiếng Anh.

--- a/docs/pc_spec.md
+++ b/docs/pc_spec.md
@@ -1,0 +1,40 @@
+# Developer Machine
+
+Reference hardware spec for the primary YTDescGen developer workstation. This
+is the box the public web build, the desktop Tauri binaries, and the recorded
+demo videos all come off of. See [`dev_env.md`](dev_env.md) for the IDE +
+language toolchain side of the same setup, and [`i18n/vi/pc_spec.md`](i18n/vi/pc_spec.md)
+for the Vietnamese mirror.
+
+## Primary workstation
+
+| Component | Details |
+|-----------|---------|
+| OS        | Windows 11 Pro 25H2 Insider Preview (Dev Channel) |
+| Build     | 26300.8376 |
+| CPU       | Intel Core i7-14700KF |
+| GPU       | NVIDIA GeForce RTX 5080 (16 GB VRAM) |
+| RAM       | 32 GB DDR5 |
+| Storage   | 1 TB SSD |
+| IDE       | JetBrains paid lineup, 2026.x — PyCharm, WebStorm, RustRover, Rider — plus VS Code |
+
+## Mobile devices used for web QA
+
+We check the web build on Safari and Chromium browsers on these phones:
+
+- iPhone 14 Pro (iOS 26.x)
+- iPhone 13 Pro Max (iOS 26.x)
+- Browsers: Chrome, Brave
+
+## Why this matters
+
+Render performance, scrollbar styling, and the `position: sticky` editor
+sidebar all behave subtly differently on mobile Safari than on desktop
+Chromium. Anything UI-heavy gets smoke-tested on the listed phones before it
+ships.
+
+## Companion docs
+
+- [`dev_env.md`](dev_env.md) — IDE + toolchain table.
+- [`../webapp/TAURI.md`](../webapp/TAURI.md) — desktop build prerequisites.
+- [`i18n/vi/pc_spec.md`](i18n/vi/pc_spec.md) — Vietnamese mirror.

--- a/index.html
+++ b/index.html
@@ -3,7 +3,70 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>YTDescGen</title>
+    <meta name="color-scheme" content="dark light" />
+    <meta name="theme-color" content="#0a0a0a" />
+
+    <title>YTDescGen — YouTube Title, Description & Tag Generator for Gameplay Channels</title>
+    <meta name="description" content="Generate YouTube titles, descriptions, and tags for Gameplay No Commentary channels — multilingual templates, profile presets, and a Tauri-based desktop build." />
+    <meta name="keywords" content="youtube, gameplay, no commentary, description generator, tags generator, video title, vietnamese, japanese, korean, spanish, chinese, multilingual, tauri, desktop" />
+    <meta name="author" content="SkullMute (poli0981)" />
+    <meta name="robots" content="index, follow" />
+    <meta name="generator" content="Vite + React" />
+
+    <link rel="canonical" href="https://poli0981.github.io/youtube-generator/" />
+    <link rel="icon" type="image/svg+xml" href="/youtube-generator/favicon.svg" />
+    <link rel="apple-touch-icon" href="/youtube-generator/apple-touch-icon.png" />
+    <link rel="manifest" href="/youtube-generator/manifest.webmanifest" />
+
+    <!-- OpenGraph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="YTDescGen" />
+    <meta property="og:title" content="YTDescGen — YouTube Title, Description & Tag Generator" />
+    <meta property="og:description" content="Multilingual title, description, and tag generator for Gameplay No Commentary channels." />
+    <meta property="og:url" content="https://poli0981.github.io/youtube-generator/" />
+    <meta property="og:image" content="https://poli0981.github.io/youtube-generator/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="vi_VN" />
+    <meta property="og:locale:alternate" content="ja_JP" />
+    <meta property="og:locale:alternate" content="es_ES" />
+    <meta property="og:locale:alternate" content="ko_KR" />
+    <meta property="og:locale:alternate" content="zh_CN" />
+
+    <!-- Twitter / X card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@SkullMute0011" />
+    <meta name="twitter:creator" content="@SkullMute0011" />
+    <meta name="twitter:title" content="YTDescGen — YouTube Title, Description & Tag Generator" />
+    <meta name="twitter:description" content="Multilingual title, description, and tag generator for Gameplay No Commentary channels." />
+    <meta name="twitter:image" content="https://poli0981.github.io/youtube-generator/og-image.png" />
+
+    <!-- Structured data -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebApplication",
+        "name": "YTDescGen",
+        "alternateName": "YouTube Description Generator",
+        "url": "https://poli0981.github.io/youtube-generator/",
+        "applicationCategory": "MultimediaApplication",
+        "operatingSystem": "Web, Windows, macOS, Linux",
+        "description": "Generate YouTube titles, descriptions, and tags for Gameplay No Commentary channels — multilingual templates, profile presets, and a Tauri-based desktop build.",
+        "inLanguage": ["en", "vi", "ja", "es", "ko", "zh"],
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        },
+        "author": {
+          "@type": "Person",
+          "name": "SkullMute",
+          "url": "https://github.com/poli0981"
+        },
+        "license": "https://github.com/poli0981/youtube-generator/blob/main/LICENSE"
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yt-desc-gen",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#0a0a0a"/>
+  <rect x="14" y="14" width="36" height="36" rx="6" fill="none" stroke="#ec4899" stroke-width="3"/>
+  <path d="M22 22h20M22 30h20M22 38h12" stroke="#ec4899" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,32 @@
+{
+  "name": "YTDescGen",
+  "short_name": "YTDescGen",
+  "description": "YouTube title, description, and tag generator for Gameplay No Commentary channels.",
+  "start_url": "/youtube-generator/",
+  "scope": "/youtube-generator/",
+  "display": "standalone",
+  "background_color": "#0a0a0a",
+  "theme_color": "#0a0a0a",
+  "lang": "en",
+  "categories": ["productivity", "utilities", "multimedia"],
+  "icons": [
+    {
+      "src": "favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://poli0981.github.io/youtube-generator/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://poli0981.github.io/youtube-generator/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/src/components/editor/ContentWarningChecklist.tsx
+++ b/src/components/editor/ContentWarningChecklist.tsx
@@ -32,6 +32,7 @@ export function ContentWarningChecklist() {
     phobias: false,
     mental_health: false,
     sensitive: false,
+    horror_specific: false,
   }));
 
   const trimmedQuery = query.trim().toLowerCase();

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,8 +1,9 @@
 import { useState, useRef, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Heart } from "lucide-react";
 import { SUPPORTED_LANGUAGES } from "@i18n/index";
 import { useSettingsStore } from "@store/settings-store";
+import { PRIMARY_DONATE_URL } from "@config/donate";
 import type { SupportedLanguage } from "@engine/types";
 import clsx from "clsx";
 
@@ -37,7 +38,18 @@ export function Header() {
         <h1 className="text-lg font-bold text-text-primary">{t("app.title")}</h1>
         <p className="text-xs text-text-muted">{t("app.subtitle")}</p>
       </div>
-      <div className="relative" ref={dropdownRef}>
+      <div className="flex items-center gap-2">
+        <a
+          href={PRIMARY_DONATE_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1.5 rounded-lg border border-pink-500/30 bg-pink-500/10 px-3 py-1.5 text-sm text-pink-300 transition-colors hover:border-pink-400/60 hover:bg-pink-500/20 hover:text-pink-200"
+          title={t("header.donate")}
+        >
+          <Heart className="h-3.5 w-3.5" />
+          <span className="hidden md:inline">{t("header.donate")}</span>
+        </a>
+        <div className="relative" ref={dropdownRef}>
         <button
           onClick={() => setOpen(!open)}
           className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm transition-colors hover:bg-surface-2"
@@ -63,6 +75,7 @@ export function Header() {
             ))}
           </div>
         )}
+        </div>
       </div>
     </header>
   );

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -10,13 +10,23 @@ import {
   ListVideo,
   ScrollText,
   Info,
+  Bug,
   PanelLeftClose,
   PanelLeftOpen,
+  type LucideIcon,
 } from "lucide-react";
 import clsx from "clsx";
 import { useSettingsStore } from "@store/settings-store";
+import { ABOUT } from "@config/about";
 
-const tabs = [
+interface TabItem {
+  to: string;
+  labelKey: string;
+  icon: LucideIcon;
+  external?: boolean;
+}
+
+const tabs: readonly TabItem[] = [
   { to: "/", labelKey: "tabs.editor", icon: Pencil },
   { to: "/output", labelKey: "tabs.output", icon: FileText },
   { to: "/batch", labelKey: "tabs.batch", icon: Layers },
@@ -26,6 +36,7 @@ const tabs = [
   { to: "/logs", labelKey: "tabs.logs", icon: ScrollText },
   { to: "/settings", labelKey: "tabs.settings", icon: Settings },
   { to: "/about", labelKey: "tabs.about", icon: Info },
+  { to: ABOUT.bugReportUrl, labelKey: "tabs.reportBug", icon: Bug, external: true },
 ] as const;
 
 export function Sidebar() {
@@ -56,26 +67,49 @@ export function Sidebar() {
         )}
       </button>
       <nav className="flex flex-1 flex-col gap-0.5 overflow-y-auto p-2">
-        {tabs.map((tab) => (
-          <NavLink
-            key={tab.to}
-            to={tab.to}
-            end={tab.to === "/"}
-            title={collapsed ? t(tab.labelKey) : undefined}
-            className={({ isActive }) =>
-              clsx(
-                "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
-                collapsed && "justify-center px-0",
-                isActive
-                  ? "bg-accent-muted text-accent"
-                  : "text-text-secondary hover:bg-surface-2 hover:text-text-primary",
-              )
-            }
-          >
-            <tab.icon className="h-4 w-4 shrink-0" />
-            {!collapsed && <span className="truncate">{t(tab.labelKey)}</span>}
-          </NavLink>
-        ))}
+        {tabs.map((tab) => {
+          const baseClass = clsx(
+            "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+            collapsed && "justify-center px-0",
+          );
+          if (tab.external) {
+            return (
+              <a
+                key={tab.to}
+                href={tab.to}
+                target="_blank"
+                rel="noopener noreferrer"
+                title={collapsed ? t(tab.labelKey) : undefined}
+                className={clsx(
+                  baseClass,
+                  "text-text-secondary hover:bg-surface-2 hover:text-text-primary",
+                )}
+              >
+                <tab.icon className="h-4 w-4 shrink-0" />
+                {!collapsed && <span className="truncate">{t(tab.labelKey)}</span>}
+              </a>
+            );
+          }
+          return (
+            <NavLink
+              key={tab.to}
+              to={tab.to}
+              end={tab.to === "/"}
+              title={collapsed ? t(tab.labelKey) : undefined}
+              className={({ isActive }) =>
+                clsx(
+                  baseClass,
+                  isActive
+                    ? "bg-accent-muted text-accent"
+                    : "text-text-secondary hover:bg-surface-2 hover:text-text-primary",
+                )
+              }
+            >
+              <tab.icon className="h-4 w-4 shrink-0" />
+              {!collapsed && <span className="truncate">{t(tab.labelKey)}</span>}
+            </NavLink>
+          );
+        })}
       </nav>
     </aside>
   );

--- a/src/config/about.ts
+++ b/src/config/about.ts
@@ -6,6 +6,9 @@ import pkg from "../../package.json";
  * Versions come from `package.json` so the About page never lies after a
  * version bump. Empty social URLs are hidden by the page; fill in the
  * channel / handle URLs you want to expose before tagging a release.
+ *
+ * Note: Ko-fi / Patreon were moved out of `socials` into `@config/donate`
+ * in v0.13.1 — they're "support" links, not "presence" links.
  */
 export const ABOUT = {
   appName: "YTDescGen",
@@ -13,14 +16,23 @@ export const ABOUT = {
   license: "MIT",
   repo: "https://github.com/poli0981/youtube-generator",
   issuesUrl: "https://github.com/poli0981/youtube-generator/issues",
+  bugReportUrl: "https://github.com/poli0981/youtube-generator/issues/new?template=bug_report.yml",
+  discussionsUrl: "https://github.com/poli0981/youtube-generator/discussions",
   licenseUrl: "https://github.com/poli0981/youtube-generator/blob/main/LICENSE",
   githubAuthor: "https://github.com/poli0981",
+  pcSpecDocUrl: "https://github.com/poli0981/youtube-generator/blob/main/docs/pc_spec.md",
+  devEnvDocUrl: "https://github.com/poli0981/youtube-generator/blob/main/docs/dev_env.md",
   socials: {
     youtube: "https://www.youtube.com/@SkullMute",
     x: "https://x.com/SkullMute0011",
+    bluesky: "https://bsky.app/profile/skullmute0011.bsky.social",
+    mastodon: "https://mastodon.social/@skullmute1122",
     discord: "https://discord.gg/2aNR3aVt",
-    kofi: "https://ko-fi.com/skullmute",
-    patreon: "https://www.patreon.com/skullmute",
+    discordGame: "https://discord.gg/kDM9GMu5vm",
+    steam: "https://steamcommunity.com/profiles/76561199544666292/",
+    telegramBot: "https://t.me/my_skull_bot",
+    telegramUser: "https://t.me/SkullMute0011",
+    email: "mailto:lopop05905@proton.me",
   },
 } as const;
 

--- a/src/config/content-warning-groups.ts
+++ b/src/config/content-warning-groups.ts
@@ -106,6 +106,19 @@ export const CONTENT_WARNING_GROUPS: readonly ContentWarningGroup[] = [
     ],
   },
   {
+    id: "horror_specific",
+    labelKey: "editor.contentWarningGroups.horror_specific",
+    items: [
+      "eye_horror",
+      "body_horror",
+      "face_horror",
+      "cosmic_horror",
+      "extreme_gore",
+      "decay_rot",
+      "mutilation",
+    ],
+  },
+  {
     id: "playstyle",
     labelKey: "editor.contentWarningGroups.playstyle",
     items: [

--- a/src/config/donate.ts
+++ b/src/config/donate.ts
@@ -1,0 +1,22 @@
+/**
+ * Donate / support links surfaced on the About page and via the persistent
+ * Donate button in the Header.
+ *
+ * Mirrors `.github/FUNDING.yml` so GitHub's "Sponsor this project" picker
+ * and the in-app surface stay aligned. Update both files together.
+ */
+export const DONATE = {
+  githubSponsors: "https://github.com/sponsors/poli0981",
+  kofi: "https://ko-fi.com/skullmute",
+  buyMeACoffee: "https://buymeacoffee.com/skullmute",
+  patreon: "https://www.patreon.com/skullmute",
+  paypal: "https://paypal.me/DungDang212",
+} as const;
+
+export type DonateId = keyof typeof DONATE;
+
+/**
+ * Single "primary" link the Header button points at. Ko-fi has no account
+ * gate and lowest friction — change here to swap the Header default.
+ */
+export const PRIMARY_DONATE_URL = DONATE.kofi;

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -285,6 +285,14 @@ export const CONTENT_WARNINGS = [
   "slavery_themes",
   "terrorism_themes",
   "bullying_themes",
+  // Heavy-horror specific (v0.13.1)
+  "eye_horror",
+  "body_horror",
+  "face_horror",
+  "cosmic_horror",
+  "extreme_gore",
+  "decay_rot",
+  "mutilation",
   // Playstyle disclosures
   "blind_playthrough",
   "no_spoilers_chat",

--- a/src/hooks/use-document-title.ts
+++ b/src/hooks/use-document-title.ts
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+
+/**
+ * Sets `document.title` to `"<title> · YTDescGen"` for the lifetime of the
+ * component, and restores the previous title on unmount. Per-page titles
+ * help with browser-tab readability and OS-level window menus (and feed
+ * the OG tag in `index.html` for the root route).
+ *
+ * Pass the localized page name — e.g. `useDocumentTitle(t("tabs.editor"))`.
+ */
+export function useDocumentTitle(title: string): void {
+  useEffect(() => {
+    const previous = document.title;
+    document.title = `${title} · YTDescGen`;
+    return () => {
+      document.title = previous;
+    };
+  }, [title]);
+}

--- a/src/i18n/locales/_schema.json
+++ b/src/i18n/locales/_schema.json
@@ -1,14 +1,20 @@
 {
   "ui": {
     "app": ["title", "subtitle"],
-    "tabs": ["editor", "output", "profiles", "history", "settings", "batch", "playlist", "logs", "about"],
+    "tabs": ["editor", "output", "profiles", "history", "settings", "batch", "playlist", "logs", "about", "reportBug"],
     "sidebar": ["expand", "collapse"],
+    "header": ["donate"],
     "about": [
       "tagline",
-      "repoHeading", "repoLabel", "issuesLabel", "authorLabel", "licenseLabel",
-      "connectHeading", "thirdPartyHeading", "thirdPartyHelp"
+      "repoHeading", "repoLabel", "issuesLabel", "reportBugLabel", "discussionsLabel", "authorLabel", "licenseLabel",
+      "donateHeading", "donateHelp",
+      "connectHeading",
+      "devEnvHeading", "devEnvHelp",
+      "thirdPartyHeading", "thirdPartyHelp"
     ],
-    "about.socials": ["youtube", "x", "discord", "kofi", "patreon"],
+    "about.donate": ["githubSponsors", "kofi", "buyMeACoffee", "patreon", "paypal"],
+    "about.devEnv": ["os", "cpu", "gpu", "ram", "ide", "toolchains", "fullSpecLink", "fullDevEnvLink"],
+    "about.socials": ["youtube", "x", "bluesky", "mastodon", "discord", "discordGame", "steam", "telegramBot", "telegramUser", "email"],
     "editor.sections": ["gameInfo", "videoSettings", "contentDetails", "attribution", "rig", "storeAndSocial"],
     "editor": [
       "videoType", "language", "genre", "gameName", "gameNamePlaceholder",
@@ -93,7 +99,7 @@
       "not_no_hit_run", "not_clean_walkthrough", "casual_no_commentary", "many_deaths_patience", "slow_exploration", "puzzle_stuck_possible", "grinding_cut", "not_speedrun_relaxed",
       "exploration_focus_skip_combat", "edited_for_pacing", "support_developers", "online_connectivity_issues"
     ],
-    "editor.contentWarningGroups": ["spoilers", "photosensitive", "phobias", "mental_health", "sensitive", "playstyle"],
+    "editor.contentWarningGroups": ["spoilers", "photosensitive", "phobias", "mental_health", "sensitive", "playstyle", "horror_specific"],
     "editor.contentWarningOptions": [
       "spoiler_story", "spoiler_ending", "spoiler_true_ending", "spoiler_post_game", "spoiler_secret_ending", "spoiler_dlc",
       "flashing_lights", "motion_sickness", "migraine_trigger", "loud_noises",
@@ -103,7 +109,8 @@
       "bipolar_themes", "ocd_themes", "panic_attacks", "dissociation",
       "blood_gore", "mature_18plus", "disturbing_imagery", "animal_abuse", "child_harm", "domestic_violence", "sexual_assault", "torture", "religion_themes", "war_violence", "discrimination", "police_violence", "smoking_drinking", "detailed_killing", "cult_occult", "psychological_manipulation", "grief_loss", "kidnapping",
       "hate_speech", "historical_atrocity", "slavery_themes", "terrorism_themes", "bullying_themes",
-      "blind_playthrough", "no_spoilers_chat", "casual_difficulty", "hardcore_difficulty", "permadeath_run", "speedrun_attempt", "completionist_run", "learning_mechanics"
+      "blind_playthrough", "no_spoilers_chat", "casual_difficulty", "hardcore_difficulty", "permadeath_run", "speedrun_attempt", "completionist_run", "learning_mechanics",
+      "eye_horror", "body_horror", "face_horror", "cosmic_horror", "extreme_gore", "decay_rot", "mutilation"
     ],
     "editor.gachaQuestTypeOptions": [
       "main_story", "world_quest", "side_quest", "spinoff_quest", "companion_quest", "bond_quest",
@@ -196,7 +203,8 @@
       "bipolar_themes", "ocd_themes", "panic_attacks", "dissociation",
       "blood_gore", "mature_18plus", "disturbing_imagery", "animal_abuse", "child_harm", "domestic_violence", "sexual_assault", "torture", "religion_themes", "war_violence", "discrimination", "police_violence", "smoking_drinking", "detailed_killing", "cult_occult", "psychological_manipulation", "grief_loss", "kidnapping",
       "hate_speech", "historical_atrocity", "slavery_themes", "terrorism_themes", "bullying_themes",
-      "blind_playthrough", "no_spoilers_chat", "casual_difficulty", "hardcore_difficulty", "permadeath_run", "speedrun_attempt", "completionist_run", "learning_mechanics"
+      "blind_playthrough", "no_spoilers_chat", "casual_difficulty", "hardcore_difficulty", "permadeath_run", "speedrun_attempt", "completionist_run", "learning_mechanics",
+      "eye_horror", "body_horror", "face_horror", "cosmic_horror", "extreme_gore", "decay_rot", "mutilation"
     ],
     "description.storeLinkSuffix": ["free", "demo"],
     "description.graphics": ["with", "artStyle", "videoLabel", "inGameSettingLabel", "versionLabel"],

--- a/src/i18n/locales/en/templates.json
+++ b/src/i18n/locales/en/templates.json
@@ -259,7 +259,14 @@
         "permadeath_run": "Permadeath / Iron Man run",
         "speedrun_attempt": "Speedrun attempt",
         "completionist_run": "100% completionist run",
-        "learning_mechanics": "Still learning the mechanics"
+        "learning_mechanics": "Still learning the mechanics",
+        "eye_horror": "Eyeball clusters / distorted gaze imagery",
+        "body_horror": "Body horror — flesh distortion and mutation",
+        "face_horror": "Distorted or mutilated face imagery",
+        "cosmic_horror": "Cosmic / eldritch / Lovecraftian horror",
+        "extreme_gore": "Extreme gore — dismemberment and viscera",
+        "decay_rot": "Decay, rot, maggots, corpse imagery",
+        "mutilation": "Mutilation / amputation imagery"
       }
     },
     "graphics": {

--- a/src/i18n/locales/en/ui.json
+++ b/src/i18n/locales/en/ui.json
@@ -12,28 +12,60 @@
     "batch": "Batch",
     "playlist": "Playlist",
     "logs": "Logs",
-    "about": "About"
+    "about": "About",
+    "reportBug": "Report Bug"
   },
   "sidebar": {
     "expand": "Expand sidebar",
     "collapse": "Collapse sidebar"
+  },
+  "header": {
+    "donate": "Donate"
   },
   "about": {
     "tagline": "YouTube title, description, and tag generator for Gameplay No Commentary channels.",
     "repoHeading": "Repository & License",
     "repoLabel": "GitHub Repo",
     "issuesLabel": "Report an Issue",
+    "reportBugLabel": "Report a Bug",
+    "discussionsLabel": "Discussions",
     "authorLabel": "Author",
     "licenseLabel": "License",
+    "donateHeading": "Donate / Support",
+    "donateHelp": "If YTDescGen saves you time, consider buying me a coffee. Every bit helps keep the project going.",
+    "donate": {
+      "githubSponsors": "GitHub Sponsors",
+      "kofi": "Ko-fi",
+      "buyMeACoffee": "Buy Me a Coffee",
+      "patreon": "Patreon",
+      "paypal": "PayPal"
+    },
     "connectHeading": "Connect",
+    "devEnvHeading": "Dev Environment",
+    "devEnvHelp": "Hardware and toolchain the public web build and desktop binaries are produced on.",
+    "devEnv": {
+      "os": "OS",
+      "cpu": "CPU",
+      "gpu": "GPU",
+      "ram": "RAM",
+      "ide": "IDE",
+      "toolchains": "Toolchains",
+      "fullSpecLink": "Read full PC spec ↗",
+      "fullDevEnvLink": "Read dev environment guide ↗"
+    },
     "thirdPartyHeading": "Third-Party Credits",
     "thirdPartyHelp": "YTDescGen is built on top of these open-source projects. Versions are pulled live from package.json.",
     "socials": {
       "youtube": "YouTube Channel",
       "x": "X / Twitter",
-      "discord": "Discord Server",
-      "kofi": "Ko-fi",
-      "patreon": "Patreon"
+      "bluesky": "Bluesky",
+      "mastodon": "Mastodon",
+      "discord": "Discord — Repo / General",
+      "discordGame": "Discord — Game lobby",
+      "steam": "Steam profile",
+      "telegramBot": "Telegram bot",
+      "telegramUser": "Telegram",
+      "email": "Email"
     }
   },
   "editor": {
@@ -281,7 +313,8 @@
       "phobias": "Phobias",
       "mental_health": "Mental health",
       "sensitive": "Mature / Sensitive content",
-      "playstyle": "Playstyle disclosures"
+      "playstyle": "Playstyle disclosures",
+      "horror_specific": "Heavy horror"
     },
     "contentWarningOptions": {
       "spoiler_story": "Story / ending spoilers",
@@ -351,7 +384,14 @@
       "permadeath_run": "Permadeath / Iron Man",
       "speedrun_attempt": "Speedrun attempt",
       "completionist_run": "100% completionist",
-      "learning_mechanics": "Still learning mechanics"
+      "learning_mechanics": "Still learning mechanics",
+      "eye_horror": "Eyes / eyeball clusters",
+      "body_horror": "Body horror (flesh distortion)",
+      "face_horror": "Distorted / mutilated faces",
+      "cosmic_horror": "Cosmic / eldritch horror",
+      "extreme_gore": "Extreme gore / dismemberment",
+      "decay_rot": "Decay, rot, maggots",
+      "mutilation": "Mutilation / amputation"
     },
     "playthroughNotes": {
       "title": "Playthrough notes",

--- a/src/i18n/locales/es/templates.json
+++ b/src/i18n/locales/es/templates.json
@@ -259,7 +259,14 @@
         "permadeath_run": "Permadeath / Iron Man",
         "speedrun_attempt": "Intento de speedrun",
         "completionist_run": "Completista 100%",
-        "learning_mechanics": "Aprendiendo las mecánicas"
+        "learning_mechanics": "Aprendiendo las mecánicas",
+        "eye_horror": "Racimos oculares / imágenes de miradas distorsionadas",
+        "body_horror": "Body horror — deformación corporal y mutación",
+        "face_horror": "Imágenes de rostros deformados o mutilados",
+        "cosmic_horror": "Horror cósmico / lovecraftiano",
+        "extreme_gore": "Gore extremo — desmembramiento y vísceras",
+        "decay_rot": "Putrefacción, larvas, imágenes de cadáveres",
+        "mutilation": "Imágenes de mutilación o amputación"
       }
     },
     "graphics": {

--- a/src/i18n/locales/es/ui.json
+++ b/src/i18n/locales/es/ui.json
@@ -12,28 +12,60 @@
     "batch": "Lote",
     "playlist": "Playlist",
     "logs": "Registros",
-    "about": "Acerca de"
+    "about": "Acerca de",
+    "reportBug": "Reportar bug"
   },
   "sidebar": {
     "expand": "Expandir barra lateral",
     "collapse": "Colapsar barra lateral"
+  },
+  "header": {
+    "donate": "Donar"
   },
   "about": {
     "tagline": "Generador de título, descripción y etiquetas de YouTube para canales de Gameplay sin comentarios.",
     "repoHeading": "Repositorio y Licencia",
     "repoLabel": "Repositorio en GitHub",
     "issuesLabel": "Reportar un Problema",
+    "reportBugLabel": "Reportar un bug",
+    "discussionsLabel": "Discusiones",
     "authorLabel": "Autor",
     "licenseLabel": "Licencia",
+    "donateHeading": "Donar / Apoyar",
+    "donateHelp": "Si YTDescGen te ahorra tiempo, considera invitarme un café. Cada aporte ayuda al proyecto.",
+    "donate": {
+      "githubSponsors": "GitHub Sponsors",
+      "kofi": "Ko-fi",
+      "buyMeACoffee": "Buy Me a Coffee",
+      "patreon": "Patreon",
+      "paypal": "PayPal"
+    },
     "connectHeading": "Contacto",
+    "devEnvHeading": "Entorno de desarrollo",
+    "devEnvHelp": "Hardware y toolchain con los que se compilan la web pública y los binarios de escritorio.",
+    "devEnv": {
+      "os": "SO",
+      "cpu": "CPU",
+      "gpu": "GPU",
+      "ram": "RAM",
+      "ide": "IDE",
+      "toolchains": "Toolchain",
+      "fullSpecLink": "Ver spec completa ↗",
+      "fullDevEnvLink": "Guía de entorno dev ↗"
+    },
     "thirdPartyHeading": "Créditos de Terceros",
     "thirdPartyHelp": "YTDescGen se basa en estos proyectos de código abierto. Las versiones se toman automáticamente de package.json.",
     "socials": {
       "youtube": "Canal de YouTube",
       "x": "X / Twitter",
-      "discord": "Servidor de Discord",
-      "kofi": "Ko-fi",
-      "patreon": "Patreon"
+      "bluesky": "Bluesky",
+      "mastodon": "Mastodon",
+      "discord": "Discord — Repo / General",
+      "discordGame": "Discord — Sala de juego",
+      "steam": "Perfil de Steam",
+      "telegramBot": "Bot de Telegram",
+      "telegramUser": "Telegram",
+      "email": "Email"
     }
   },
   "editor": {
@@ -281,7 +313,8 @@
       "phobias": "Fobias",
       "mental_health": "Salud mental",
       "sensitive": "Adulto / Sensible",
-      "playstyle": "Notas de juego"
+      "playstyle": "Notas de juego",
+      "horror_specific": "Horror intenso"
     },
     "contentWarningOptions": {
       "spoiler_story": "Spoilers — historia / final",
@@ -351,7 +384,14 @@
       "permadeath_run": "Permadeath / Iron Man",
       "speedrun_attempt": "Intento de speedrun",
       "completionist_run": "Completista 100%",
-      "learning_mechanics": "Aprendiendo mecánicas"
+      "learning_mechanics": "Aprendiendo mecánicas",
+      "eye_horror": "Ojos / racimos oculares",
+      "body_horror": "Body horror (deformación)",
+      "face_horror": "Rostros deformados",
+      "cosmic_horror": "Horror cósmico / eldritch",
+      "extreme_gore": "Gore extremo / desmembramiento",
+      "decay_rot": "Putrefacción, larvas",
+      "mutilation": "Mutilación / amputación"
     },
     "playthroughNotes": {
       "title": "Notas de la partida",

--- a/src/i18n/locales/ja/templates.json
+++ b/src/i18n/locales/ja/templates.json
@@ -259,7 +259,14 @@
         "permadeath_run": "パーマデス / アイアンマン縛り",
         "speedrun_attempt": "RTAチャレンジ",
         "completionist_run": "100% コンプリート",
-        "learning_mechanics": "操作 / システム学習中"
+        "learning_mechanics": "操作 / システム学習中",
+        "eye_horror": "眼球の集合体・歪んだ視線の描写",
+        "body_horror": "ボディホラー — 肉体変形・突然変異",
+        "face_horror": "顔の歪み・損傷描写",
+        "cosmic_horror": "コズミック / クトゥルフ系ホラー",
+        "extreme_gore": "過激なゴア — 解体と内臓描写",
+        "decay_rot": "腐敗・腐肉・蛆・死体描写",
+        "mutilation": "切断・損傷の描写"
       }
     },
     "graphics": {

--- a/src/i18n/locales/ja/ui.json
+++ b/src/i18n/locales/ja/ui.json
@@ -12,28 +12,60 @@
     "batch": "一括",
     "playlist": "プレイリスト",
     "logs": "ログ",
-    "about": "情報"
+    "about": "情報",
+    "reportBug": "バグ報告"
   },
   "sidebar": {
     "expand": "サイドバーを展開",
     "collapse": "サイドバーを折りたたむ"
+  },
+  "header": {
+    "donate": "寄付"
   },
   "about": {
     "tagline": "ゲームプレイ実況なしチャンネル向けのタイトル・説明文・タグ生成ツール。",
     "repoHeading": "リポジトリ & ライセンス",
     "repoLabel": "GitHub リポジトリ",
     "issuesLabel": "問題を報告",
+    "reportBugLabel": "バグを報告",
+    "discussionsLabel": "ディスカッション",
     "authorLabel": "作者",
     "licenseLabel": "ライセンス",
+    "donateHeading": "寄付 / サポート",
+    "donateHelp": "YTDescGenが時短に役立ったら、コーヒー一杯分でも支援していただけると嬉しいです。",
+    "donate": {
+      "githubSponsors": "GitHub Sponsors",
+      "kofi": "Ko-fi",
+      "buyMeACoffee": "Buy Me a Coffee",
+      "patreon": "Patreon",
+      "paypal": "PayPal"
+    },
     "connectHeading": "リンク",
+    "devEnvHeading": "開発環境",
+    "devEnvHelp": "パブリックなWebビルドとデスクトップバイナリを生成しているハードウェアとツールチェーン。",
+    "devEnv": {
+      "os": "OS",
+      "cpu": "CPU",
+      "gpu": "GPU",
+      "ram": "RAM",
+      "ide": "IDE",
+      "toolchains": "ツールチェーン",
+      "fullSpecLink": "PCスペック詳細 ↗",
+      "fullDevEnvLink": "開発環境ガイド ↗"
+    },
     "thirdPartyHeading": "サードパーティ クレジット",
     "thirdPartyHelp": "YTDescGen は以下のオープンソースプロジェクトを利用しています。バージョンは package.json から自動取得しています。",
     "socials": {
       "youtube": "YouTube チャンネル",
       "x": "X / Twitter",
-      "discord": "Discord サーバー",
-      "kofi": "Ko-fi",
-      "patreon": "Patreon"
+      "bluesky": "Bluesky",
+      "mastodon": "Mastodon",
+      "discord": "Discord — リポジトリ / 一般",
+      "discordGame": "Discord — ゲームロビー",
+      "steam": "Steamプロフィール",
+      "telegramBot": "Telegram bot",
+      "telegramUser": "Telegram",
+      "email": "メール"
     }
   },
   "editor": {
@@ -281,7 +313,8 @@
       "phobias": "恐怖症",
       "mental_health": "メンタルヘルス",
       "sensitive": "成人向け / センシティブ",
-      "playstyle": "プレイ情報"
+      "playstyle": "プレイ情報",
+      "horror_specific": "ヘビーホラー"
     },
     "contentWarningOptions": {
       "spoiler_story": "ストーリー / エンディングのネタバレ",
@@ -351,7 +384,14 @@
       "permadeath_run": "パーマデス / アイアンマン",
       "speedrun_attempt": "RTAチャレンジ",
       "completionist_run": "100% コンプ",
-      "learning_mechanics": "操作を覚え中"
+      "learning_mechanics": "操作を覚え中",
+      "eye_horror": "眼球 / 集合した眼",
+      "body_horror": "ボディホラー（肉体変形）",
+      "face_horror": "顔の歪み / 損傷",
+      "cosmic_horror": "コズミックホラー",
+      "extreme_gore": "過激なゴア / 解体",
+      "decay_rot": "腐敗 / 蛆",
+      "mutilation": "切断 / 損傷"
     },
     "playthroughNotes": {
       "title": "プレイ情報",

--- a/src/i18n/locales/ko/templates.json
+++ b/src/i18n/locales/ko/templates.json
@@ -259,7 +259,14 @@
         "permadeath_run": "영구 사망 / 아이언맨 모드",
         "speedrun_attempt": "스피드런 시도",
         "completionist_run": "100% 컴플리션 도전",
-        "learning_mechanics": "조작 / 시스템 학습 중"
+        "learning_mechanics": "조작 / 시스템 학습 중",
+        "eye_horror": "안구 군집·왜곡된 시선 묘사",
+        "body_horror": "신체 호러 — 육체 변형·돌연변이",
+        "face_horror": "일그러지거나 훼손된 얼굴 묘사",
+        "cosmic_horror": "코즈믹 / 크툴루 / 러브크래프트적 호러",
+        "extreme_gore": "극도의 고어 — 사지 절단·내장 묘사",
+        "decay_rot": "부패·구더기·시체 묘사",
+        "mutilation": "절단·손상 묘사"
       }
     },
     "graphics": {

--- a/src/i18n/locales/ko/ui.json
+++ b/src/i18n/locales/ko/ui.json
@@ -12,28 +12,60 @@
     "batch": "일괄",
     "playlist": "플레이리스트",
     "logs": "로그",
-    "about": "정보"
+    "about": "정보",
+    "reportBug": "버그 신고"
   },
   "sidebar": {
     "expand": "사이드바 펼치기",
     "collapse": "사이드바 접기"
+  },
+  "header": {
+    "donate": "후원"
   },
   "about": {
     "tagline": "게임플레이 무편집 채널을 위한 YouTube 제목, 설명, 태그 생성기.",
     "repoHeading": "저장소 및 라이선스",
     "repoLabel": "GitHub 저장소",
     "issuesLabel": "문제 보고",
+    "reportBugLabel": "버그 신고",
+    "discussionsLabel": "디스커션",
     "authorLabel": "저자",
     "licenseLabel": "라이선스",
+    "donateHeading": "후원 / 지원",
+    "donateHelp": "YTDescGen이 시간을 아껴드렸다면 커피 한 잔으로 응원 부탁드립니다.",
+    "donate": {
+      "githubSponsors": "GitHub Sponsors",
+      "kofi": "Ko-fi",
+      "buyMeACoffee": "Buy Me a Coffee",
+      "patreon": "Patreon",
+      "paypal": "PayPal"
+    },
     "connectHeading": "연결",
+    "devEnvHeading": "개발 환경",
+    "devEnvHelp": "공개 웹 빌드와 데스크톱 바이너리가 빌드되는 하드웨어 및 툴체인입니다.",
+    "devEnv": {
+      "os": "OS",
+      "cpu": "CPU",
+      "gpu": "GPU",
+      "ram": "RAM",
+      "ide": "IDE",
+      "toolchains": "툴체인",
+      "fullSpecLink": "전체 PC 스펙 보기 ↗",
+      "fullDevEnvLink": "개발 환경 가이드 ↗"
+    },
     "thirdPartyHeading": "서드파티 크레딧",
     "thirdPartyHelp": "YTDescGen은 다음 오픈소스 프로젝트를 기반으로 합니다. 버전은 package.json에서 자동으로 가져옵니다.",
     "socials": {
       "youtube": "YouTube 채널",
       "x": "X / Twitter",
-      "discord": "Discord 서버",
-      "kofi": "Ko-fi",
-      "patreon": "Patreon"
+      "bluesky": "Bluesky",
+      "mastodon": "Mastodon",
+      "discord": "Discord — 저장소 / 일반",
+      "discordGame": "Discord — 게임 로비",
+      "steam": "Steam 프로필",
+      "telegramBot": "텔레그램 봇",
+      "telegramUser": "텔레그램",
+      "email": "이메일"
     }
   },
   "editor": {
@@ -281,7 +313,8 @@
       "phobias": "공포증",
       "mental_health": "정신 건강",
       "sensitive": "성인 / 민감",
-      "playstyle": "플레이 안내"
+      "playstyle": "플레이 안내",
+      "horror_specific": "중증 호러"
     },
     "contentWarningOptions": {
       "spoiler_story": "스토리 / 엔딩 스포일러",
@@ -351,7 +384,14 @@
       "permadeath_run": "영구 사망 / 아이언맨",
       "speedrun_attempt": "스피드런 시도",
       "completionist_run": "100% 컴플리션",
-      "learning_mechanics": "조작 학습 중"
+      "learning_mechanics": "조작 학습 중",
+      "eye_horror": "눈 / 안구 군집",
+      "body_horror": "신체 호러 (육체 변형)",
+      "face_horror": "일그러진 얼굴",
+      "cosmic_horror": "코즈믹 / 크툴루 호러",
+      "extreme_gore": "극도의 고어 / 사지 절단",
+      "decay_rot": "부패 / 구더기",
+      "mutilation": "절단 / 손상"
     },
     "playthroughNotes": {
       "title": "플레이 노트",

--- a/src/i18n/locales/vi/templates.json
+++ b/src/i18n/locales/vi/templates.json
@@ -259,7 +259,14 @@
         "permadeath_run": "Lối chơi Permadeath / Iron Man",
         "speedrun_attempt": "Thử speedrun",
         "completionist_run": "Chơi 100% completionist",
-        "learning_mechanics": "Vẫn đang học cơ chế game"
+        "learning_mechanics": "Vẫn đang học cơ chế game",
+        "eye_horror": "Cụm nhãn cầu / hình ảnh ánh nhìn ám ảnh",
+        "body_horror": "Kinh dị cơ thể — biến dạng thịt, đột biến",
+        "face_horror": "Hình ảnh khuôn mặt biến dạng / huỷ hoại",
+        "cosmic_horror": "Kinh dị vũ trụ / Lovecraftian",
+        "extreme_gore": "Máu me cực đoan — phân thây, nội tạng",
+        "decay_rot": "Phân huỷ, thối rữa, dòi bọ, xác chết",
+        "mutilation": "Hình ảnh cắt xẻo / cụt chi"
       }
     },
     "graphics": {

--- a/src/i18n/locales/vi/ui.json
+++ b/src/i18n/locales/vi/ui.json
@@ -12,28 +12,60 @@
     "batch": "Hàng loạt",
     "playlist": "Playlist",
     "logs": "Nhật ký",
-    "about": "Giới thiệu"
+    "about": "Giới thiệu",
+    "reportBug": "Báo lỗi"
   },
   "sidebar": {
     "expand": "Mở rộng sidebar",
     "collapse": "Thu gọn sidebar"
+  },
+  "header": {
+    "donate": "Ủng hộ"
   },
   "about": {
     "tagline": "Công cụ tạo title, description, tag cho kênh YouTube Gameplay No Commentary.",
     "repoHeading": "Repository & License",
     "repoLabel": "GitHub Repo",
     "issuesLabel": "Báo lỗi / Góp ý",
+    "reportBugLabel": "Báo lỗi",
+    "discussionsLabel": "Thảo luận",
     "authorLabel": "Tác giả",
     "licenseLabel": "Giấy phép",
+    "donateHeading": "Ủng hộ / Donate",
+    "donateHelp": "Nếu YTDescGen giúp bạn tiết kiệm thời gian, mời mình một ly cà phê nhé. Mọi ủng hộ đều giúp dự án tiếp tục.",
+    "donate": {
+      "githubSponsors": "GitHub Sponsors",
+      "kofi": "Ko-fi",
+      "buyMeACoffee": "Buy Me a Coffee",
+      "patreon": "Patreon",
+      "paypal": "PayPal"
+    },
     "connectHeading": "Kết nối",
+    "devEnvHeading": "Môi trường phát triển",
+    "devEnvHelp": "Phần cứng và toolchain dùng để build bản web public và binary desktop.",
+    "devEnv": {
+      "os": "Hệ điều hành",
+      "cpu": "CPU",
+      "gpu": "GPU",
+      "ram": "RAM",
+      "ide": "IDE",
+      "toolchains": "Toolchain",
+      "fullSpecLink": "Xem PC spec đầy đủ ↗",
+      "fullDevEnvLink": "Xem hướng dẫn dev environment ↗"
+    },
     "thirdPartyHeading": "Thư viện bên thứ ba",
     "thirdPartyHelp": "YTDescGen được xây dựng dựa trên các dự án mã nguồn mở dưới đây. Phiên bản lấy tự động từ package.json.",
     "socials": {
       "youtube": "Kênh YouTube",
       "x": "X / Twitter",
-      "discord": "Server Discord",
-      "kofi": "Ko-fi",
-      "patreon": "Patreon"
+      "bluesky": "Bluesky",
+      "mastodon": "Mastodon",
+      "discord": "Discord — Repo / Chung",
+      "discordGame": "Discord — Game lobby",
+      "steam": "Profile Steam",
+      "telegramBot": "Telegram bot",
+      "telegramUser": "Telegram",
+      "email": "Email"
     }
   },
   "editor": {
@@ -281,7 +313,8 @@
       "phobias": "Hội chứng sợ",
       "mental_health": "Sức khoẻ tinh thần",
       "sensitive": "Nội dung nhạy cảm / 18+",
-      "playstyle": "Chú thích lối chơi"
+      "playstyle": "Chú thích lối chơi",
+      "horror_specific": "Kinh dị nặng đô"
     },
     "contentWarningOptions": {
       "spoiler_story": "Spoiler cốt truyện / kết thúc",
@@ -351,7 +384,14 @@
       "permadeath_run": "Permadeath / Iron Man",
       "speedrun_attempt": "Thử speedrun",
       "completionist_run": "100% completionist",
-      "learning_mechanics": "Đang học cơ chế"
+      "learning_mechanics": "Đang học cơ chế",
+      "eye_horror": "Mắt / cụm nhãn cầu",
+      "body_horror": "Kinh dị cơ thể (biến dạng)",
+      "face_horror": "Khuôn mặt biến dạng",
+      "cosmic_horror": "Kinh dị vũ trụ / Lovecraft",
+      "extreme_gore": "Máu me cực đoan / phân thây",
+      "decay_rot": "Phân huỷ, thối rữa, dòi bọ",
+      "mutilation": "Cắt xẻo / cụt chi"
     },
     "playthroughNotes": {
       "title": "Ghi chú lượt chơi",

--- a/src/i18n/locales/zh/templates.json
+++ b/src/i18n/locales/zh/templates.json
@@ -259,7 +259,14 @@
         "permadeath_run": "永久死亡 / Iron Man 玩法",
         "speedrun_attempt": "速通挑战",
         "completionist_run": "100% 全收集挑战",
-        "learning_mechanics": "仍在熟悉游戏机制"
+        "learning_mechanics": "仍在熟悉游戏机制",
+        "eye_horror": "眼球群 / 扭曲注视画面",
+        "body_horror": "身体恐怖 — 肉体扭曲与变异",
+        "face_horror": "扭曲或毁伤的面孔画面",
+        "cosmic_horror": "宇宙 / 邪神 / 克苏鲁式恐怖",
+        "extreme_gore": "极端血腥 — 肢解与内脏描绘",
+        "decay_rot": "腐烂、蛆虫、尸体画面",
+        "mutilation": "残害或截肢画面"
       }
     },
     "graphics": {

--- a/src/i18n/locales/zh/ui.json
+++ b/src/i18n/locales/zh/ui.json
@@ -12,28 +12,60 @@
     "batch": "批量",
     "playlist": "播放列表",
     "logs": "日志",
-    "about": "关于"
+    "about": "关于",
+    "reportBug": "报告 Bug"
   },
   "sidebar": {
     "expand": "展开侧边栏",
     "collapse": "折叠侧边栏"
+  },
+  "header": {
+    "donate": "赞助"
   },
   "about": {
     "tagline": "为游戏实况无解说频道生成 YouTube 标题、描述和标签的工具。",
     "repoHeading": "仓库与许可",
     "repoLabel": "GitHub 仓库",
     "issuesLabel": "报告问题",
+    "reportBugLabel": "报告 Bug",
+    "discussionsLabel": "讨论区",
     "authorLabel": "作者",
     "licenseLabel": "许可证",
+    "donateHeading": "赞助 / 支持",
+    "donateHelp": "如果 YTDescGen 帮你省下了时间，欢迎请我喝一杯咖啡。每份支持都让项目走得更远。",
+    "donate": {
+      "githubSponsors": "GitHub Sponsors",
+      "kofi": "Ko-fi",
+      "buyMeACoffee": "Buy Me a Coffee",
+      "patreon": "Patreon",
+      "paypal": "PayPal"
+    },
     "connectHeading": "联系方式",
+    "devEnvHeading": "开发环境",
+    "devEnvHelp": "用于构建公开 Web 版本和桌面二进制的硬件与工具链。",
+    "devEnv": {
+      "os": "系统",
+      "cpu": "CPU",
+      "gpu": "GPU",
+      "ram": "RAM",
+      "ide": "IDE",
+      "toolchains": "工具链",
+      "fullSpecLink": "查看完整 PC 配置 ↗",
+      "fullDevEnvLink": "开发环境指南 ↗"
+    },
     "thirdPartyHeading": "第三方致谢",
     "thirdPartyHelp": "YTDescGen 基于以下开源项目构建。版本号从 package.json 自动同步。",
     "socials": {
       "youtube": "YouTube 频道",
       "x": "X / Twitter",
-      "discord": "Discord 服务器",
-      "kofi": "Ko-fi",
-      "patreon": "Patreon"
+      "bluesky": "Bluesky",
+      "mastodon": "Mastodon",
+      "discord": "Discord — 仓库 / 综合",
+      "discordGame": "Discord — 游戏频道",
+      "steam": "Steam 个人主页",
+      "telegramBot": "Telegram 机器人",
+      "telegramUser": "Telegram",
+      "email": "邮箱"
     }
   },
   "editor": {
@@ -281,7 +313,8 @@
       "phobias": "恐惧症",
       "mental_health": "心理健康",
       "sensitive": "成人 / 敏感",
-      "playstyle": "游玩说明"
+      "playstyle": "游玩说明",
+      "horror_specific": "重度恐怖"
     },
     "contentWarningOptions": {
       "spoiler_story": "剧情 / 结局剧透",
@@ -351,7 +384,14 @@
       "permadeath_run": "永久死亡 / Iron Man",
       "speedrun_attempt": "速通挑战",
       "completionist_run": "100% 全收集",
-      "learning_mechanics": "仍在熟悉机制"
+      "learning_mechanics": "仍在熟悉机制",
+      "eye_horror": "眼球 / 眼球群",
+      "body_horror": "身体恐怖（肉体扭曲）",
+      "face_horror": "扭曲的面孔",
+      "cosmic_horror": "宇宙 / 邪神恐怖",
+      "extreme_gore": "极端血腥 / 肢解",
+      "decay_rot": "腐烂 / 蛆虫",
+      "mutilation": "残害 / 截肢"
     },
     "playthroughNotes": {
       "title": "本期游玩说明",

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -6,12 +6,23 @@ import {
   Youtube,
   Twitter,
   MessageCircle,
+  MessageSquare,
+  Cloud,
+  Gamepad2,
+  Send,
+  Mail,
   Coffee,
   Heart,
+  Sparkles,
+  DollarSign,
+  Cpu,
+  Monitor,
   type LucideIcon,
 } from "lucide-react";
 import { ABOUT, type AboutSocialId } from "@config/about";
+import { DONATE, type DonateId } from "@config/donate";
 import { THIRD_PARTY } from "@config/third-party";
+import { useDocumentTitle } from "@hooks/use-document-title";
 
 interface SocialLinkConfig {
   id: AboutSocialId;
@@ -20,19 +31,52 @@ interface SocialLinkConfig {
   labelKey: string;
 }
 
+interface DonateLinkConfig {
+  id: DonateId;
+  url: string;
+  icon: LucideIcon;
+  labelKey: string;
+}
+
 export function AboutPage() {
   const { t } = useTranslation("ui");
+  useDocumentTitle(t("tabs.about"));
 
   // Hidden when empty so a fresh clone with no socials filled in still
-  // looks tidy on the About page.
+  // looks tidy on the About page. Ko-fi / Patreon were moved to the
+  // Donate section in v0.13.1 — keep them out of this list.
   const allSocials: readonly SocialLinkConfig[] = [
     { id: "youtube", url: ABOUT.socials.youtube, icon: Youtube, labelKey: "about.socials.youtube" },
     { id: "x", url: ABOUT.socials.x, icon: Twitter, labelKey: "about.socials.x" },
+    { id: "bluesky", url: ABOUT.socials.bluesky, icon: Cloud, labelKey: "about.socials.bluesky" },
+    { id: "mastodon", url: ABOUT.socials.mastodon, icon: MessageSquare, labelKey: "about.socials.mastodon" },
     { id: "discord", url: ABOUT.socials.discord, icon: MessageCircle, labelKey: "about.socials.discord" },
-    { id: "kofi", url: ABOUT.socials.kofi, icon: Coffee, labelKey: "about.socials.kofi" },
-    { id: "patreon", url: ABOUT.socials.patreon, icon: Heart, labelKey: "about.socials.patreon" },
+    { id: "discordGame", url: ABOUT.socials.discordGame, icon: Gamepad2, labelKey: "about.socials.discordGame" },
+    { id: "steam", url: ABOUT.socials.steam, icon: Gamepad2, labelKey: "about.socials.steam" },
+    { id: "telegramBot", url: ABOUT.socials.telegramBot, icon: Send, labelKey: "about.socials.telegramBot" },
+    { id: "telegramUser", url: ABOUT.socials.telegramUser, icon: Send, labelKey: "about.socials.telegramUser" },
+    { id: "email", url: ABOUT.socials.email, icon: Mail, labelKey: "about.socials.email" },
   ];
   const socials = allSocials.filter((s) => s.url.trim().length > 0);
+
+  const donateLinks: readonly DonateLinkConfig[] = [
+    { id: "githubSponsors", url: DONATE.githubSponsors, icon: Sparkles, labelKey: "about.donate.githubSponsors" },
+    { id: "kofi", url: DONATE.kofi, icon: Coffee, labelKey: "about.donate.kofi" },
+    { id: "buyMeACoffee", url: DONATE.buyMeACoffee, icon: Coffee, labelKey: "about.donate.buyMeACoffee" },
+    { id: "patreon", url: DONATE.patreon, icon: Heart, labelKey: "about.donate.patreon" },
+    { id: "paypal", url: DONATE.paypal, icon: DollarSign, labelKey: "about.donate.paypal" },
+  ];
+
+  // Pulled from docs/pc_spec.md — keep them in sync when the box gets an
+  // upgrade. The page surfaces the summary; the full spec lives in docs.
+  const devEnvRows: ReadonlyArray<{ icon: LucideIcon; labelKey: string; value: string }> = [
+    { icon: Monitor, labelKey: "about.devEnv.os", value: "Windows 11 Pro 25H2 Insider (build 26300.8376)" },
+    { icon: Cpu, labelKey: "about.devEnv.cpu", value: "Intel Core i7-14700KF" },
+    { icon: Cpu, labelKey: "about.devEnv.gpu", value: "NVIDIA GeForce RTX 5080 (16 GB)" },
+    { icon: Cpu, labelKey: "about.devEnv.ram", value: "32 GB DDR5" },
+    { icon: Monitor, labelKey: "about.devEnv.ide", value: "JetBrains 2026.x · VS Code" },
+    { icon: Cpu, labelKey: "about.devEnv.toolchains", value: "Node ≥ 25.8.1 · Python 3.12 · Rust stable · Tauri 2" },
+  ];
 
   return (
     <div className="mx-auto flex max-w-3xl flex-col gap-8 p-6">
@@ -59,9 +103,14 @@ export function AboutPage() {
             label={t("about.repoLabel")}
           />
           <ExternalLinkRow
-            href={ABOUT.issuesUrl}
+            href={ABOUT.bugReportUrl}
             icon={Bug}
-            label={t("about.issuesLabel")}
+            label={t("about.reportBugLabel")}
+          />
+          <ExternalLinkRow
+            href={ABOUT.discussionsUrl}
+            icon={MessageSquare}
+            label={t("about.discussionsLabel")}
           />
           <ExternalLinkRow
             href={ABOUT.githubAuthor}
@@ -73,6 +122,24 @@ export function AboutPage() {
             icon={ExternalLink}
             label={`${t("about.licenseLabel")} · ${ABOUT.license}`}
           />
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-text-muted">
+          {t("about.donateHeading")}
+        </h2>
+        <p className="text-xs text-text-muted">{t("about.donateHelp")}</p>
+        <div className="grid gap-2 sm:grid-cols-2">
+          {donateLinks.map((d) => (
+            <ExternalLinkRow
+              key={d.id}
+              href={d.url}
+              icon={d.icon}
+              label={t(d.labelKey)}
+              accent
+            />
+          ))}
         </div>
       </section>
 
@@ -93,6 +160,40 @@ export function AboutPage() {
           </div>
         </section>
       )}
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-text-muted">
+          {t("about.devEnvHeading")}
+        </h2>
+        <p className="text-xs text-text-muted">{t("about.devEnvHelp")}</p>
+        <ul className="overflow-hidden rounded-lg border border-border bg-surface-1">
+          {devEnvRows.map((row) => {
+            const Icon = row.icon;
+            return (
+              <li
+                key={row.labelKey}
+                className="flex items-center gap-3 border-b border-border px-3 py-2 text-sm last:border-b-0"
+              >
+                <Icon className="h-4 w-4 shrink-0 text-text-muted" />
+                <span className="w-32 shrink-0 text-text-secondary">{t(row.labelKey)}</span>
+                <span className="flex-1 truncate font-mono text-xs text-text-primary">{row.value}</span>
+              </li>
+            );
+          })}
+        </ul>
+        <div className="grid gap-2 sm:grid-cols-2">
+          <ExternalLinkRow
+            href={ABOUT.pcSpecDocUrl}
+            icon={ExternalLink}
+            label={t("about.devEnv.fullSpecLink")}
+          />
+          <ExternalLinkRow
+            href={ABOUT.devEnvDocUrl}
+            icon={ExternalLink}
+            label={t("about.devEnv.fullDevEnvLink")}
+          />
+        </div>
+      </section>
 
       <section className="flex flex-col gap-3">
         <h2 className="text-sm font-semibold uppercase tracking-wide text-text-muted">
@@ -126,17 +227,22 @@ interface ExternalLinkRowProps {
   href: string;
   icon: LucideIcon;
   label: string;
+  accent?: boolean;
 }
 
-function ExternalLinkRow({ href, icon: Icon, label }: ExternalLinkRowProps) {
+function ExternalLinkRow({ href, icon: Icon, label, accent }: ExternalLinkRowProps) {
   return (
     <a
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className="flex items-center gap-3 rounded-lg border border-border bg-surface-1 px-3 py-2.5 text-sm text-text-primary transition-colors hover:border-accent hover:bg-surface-2"
+      className={
+        accent
+          ? "flex items-center gap-3 rounded-lg border border-pink-500/30 bg-pink-500/5 px-3 py-2.5 text-sm text-text-primary transition-colors hover:border-pink-400/60 hover:bg-pink-500/10"
+          : "flex items-center gap-3 rounded-lg border border-border bg-surface-1 px-3 py-2.5 text-sm text-text-primary transition-colors hover:border-accent hover:bg-surface-2"
+      }
     >
-      <Icon className="h-4 w-4 shrink-0 text-text-secondary" />
+      <Icon className={accent ? "h-4 w-4 shrink-0 text-pink-300" : "h-4 w-4 shrink-0 text-text-secondary"} />
       <span className="flex-1 truncate">{label}</span>
       <ExternalLink className="h-3.5 w-3.5 shrink-0 text-text-muted" />
     </a>

--- a/src/pages/BatchPage.tsx
+++ b/src/pages/BatchPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { useDocumentTitle } from "@hooks/use-document-title";
 import i18n from "i18next";
 import { Input } from "@components/ui/Input";
 import { Button } from "@components/ui/Button";
@@ -29,6 +30,7 @@ interface BatchResult {
 
 export function BatchPage() {
   const { t } = useTranslation("ui");
+  useDocumentTitle(t("tabs.batch"));
   const state = useEditorStore();
   const baseInput = useCurrentGeneratorInput();
   const {

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -26,12 +26,14 @@ import { Accordion } from "@components/ui/Accordion";
 import { useEditorStore } from "@store/editor-store";
 import { useSettingsStore } from "@store/settings-store";
 import { useTranslation } from "react-i18next";
+import { useDocumentTitle } from "@hooks/use-document-title";
 import { validateEmails, validatePlaylistUrl } from "@utils/validation";
 import { RotateCcw } from "lucide-react";
 import { useState } from "react";
 
 export function EditorPage() {
   const { t } = useTranslation("ui");
+  useDocumentTitle(t("tabs.editor"));
   const store = useEditorStore();
   const accordion = useSettingsStore((s) => s.editorAccordionState);
   const toggleAccordion = useSettingsStore((s) => s.toggleEditorAccordion);

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useDocumentTitle } from "@hooks/use-document-title";
 import { Trash2 } from "lucide-react";
 import { Input } from "@components/ui/Input";
 import { Button } from "@components/ui/Button";
@@ -9,6 +10,7 @@ import { useHistoryStore } from "@store/history-store";
 
 export function HistoryPage() {
   const { t } = useTranslation("ui");
+  useDocumentTitle(t("tabs.history"));
   const { entries, clearAll } = useHistoryStore();
   const [search, setSearch] = useState("");
   const [showClearAll, setShowClearAll] = useState(false);

--- a/src/pages/LogPage.tsx
+++ b/src/pages/LogPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import { useDocumentTitle } from "@hooks/use-document-title";
 import { Trash2 } from "lucide-react";
 import { Input } from "@components/ui/Input";
 import { Button } from "@components/ui/Button";
@@ -18,6 +19,7 @@ const LEVEL_FILTERS: Array<{ value: LogLevel | "all"; label: string; color: stri
 
 export function LogPage() {
   const { t } = useTranslation("ui");
+  useDocumentTitle(t("tabs.logs"));
   const { entries, clearAll } = useLogStore();
   const [search, setSearch] = useState("");
   const [levelFilter, setLevelFilter] = useState<LogLevel | "all">("all");

--- a/src/pages/OutputPage.tsx
+++ b/src/pages/OutputPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { useDocumentTitle } from "@hooks/use-document-title";
 import { Shuffle, Bookmark } from "lucide-react";
 import { Button } from "@components/ui/Button";
 import { OutputPreview } from "@components/output/OutputPreview";
@@ -18,6 +19,7 @@ import clsx from "clsx";
 
 export function OutputPage() {
   const { t } = useTranslation("ui");
+  useDocumentTitle(t("tabs.output"));
   const defaultOutput = useGeneratedOutput();
   const { gameName, videoType, language, genres } = useEditorStore();
   const addEntry = useHistoryStore((s) => s.addEntry);

--- a/src/pages/PlaylistPage.tsx
+++ b/src/pages/PlaylistPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { useDocumentTitle } from "@hooks/use-document-title";
 import i18n from "i18next";
 import { Input } from "@components/ui/Input";
 import { Textarea } from "@components/ui/Textarea";
@@ -38,6 +39,7 @@ const CONTENT_TYPE_OPTIONS = [
 
 export function PlaylistPage() {
   const { t } = useTranslation("ui");
+  useDocumentTitle(t("tabs.playlist"));
   const editor = useEditorStore();
 
   const [status, setStatus] = useState<PlaylistStatus>("completed");

--- a/src/pages/ProfilesPage.tsx
+++ b/src/pages/ProfilesPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useDocumentTitle } from "@hooks/use-document-title";
 import { Download, Upload } from "lucide-react";
 import { Button } from "@components/ui/Button";
 import { ProfileList } from "@components/profiles/ProfileList";
@@ -16,6 +17,7 @@ type Tab = "profiles" | "presets" | "templates";
 
 export function ProfilesPage() {
   const { t } = useTranslation("ui");
+  useDocumentTitle(t("tabs.profiles"));
   const [tab, setTab] = useState<Tab>("profiles");
   const { profiles, importProfiles } = useProfileStore();
   const { presets, importPresets } = usePresetStore();

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import { useDocumentTitle } from "@hooks/use-document-title";
 import { FolderOpen, Save } from "lucide-react";
 import { Toggle } from "@components/ui/Toggle";
 import { Select } from "@components/ui/Select";
@@ -54,6 +55,7 @@ async function exportSettingsToFile() {
 
 export function SettingsPage() {
   const { t, i18n } = useTranslation("ui");
+  useDocumentTitle(t("tabs.settings"));
   const settings = useSettingsStore();
 
   const langOptions = SUPPORTED_LANGUAGES.map((l) => ({

--- a/webapp/TAURI.md
+++ b/webapp/TAURI.md
@@ -1,0 +1,69 @@
+# Tauri 2 desktop build prerequisites
+
+YTDescGen ships a Tauri 2 desktop shell alongside the web build. This file
+covers the per-platform native dependencies you need before
+`npm run tauri:dev` or `npm run tauri:build` will succeed.
+
+The corresponding hardware reference is in [`../docs/pc_spec.md`](../docs/pc_spec.md);
+toolchain versions are in [`../docs/dev_env.md`](../docs/dev_env.md).
+
+## All platforms
+
+- **Rust stable** via `rustup`. Tauri 2 currently tracks the latest stable.
+- **Node.js ≥ 25.8.1**. Tauri-action in CI uses Node 20; locally we use ≥ 25
+  so the JetBrains and VS Code dev tools have a single shared LTS.
+
+```bash
+rustup update stable
+rustup target add x86_64-pc-windows-msvc       # Windows
+rustup target add aarch64-apple-darwin         # Apple Silicon
+rustup target add x86_64-unknown-linux-gnu     # Linux
+```
+
+## Windows
+
+- **MSVC build tools** — install via "Desktop development with C++" workload in
+  Visual Studio Installer, or `winget install Microsoft.VisualStudio.2022.BuildTools`.
+- **WebView2 Runtime** — ships with Windows 11; on Windows 10 you may need
+  to install the Evergreen Bootstrapper from Microsoft.
+- Default bundles produced: MSI installer + NSIS `.exe`.
+
+## macOS
+
+- **Xcode Command Line Tools** — `xcode-select --install`.
+- **Apple Silicon only** for hosted CI; Intel is not in the matrix anymore.
+- Bundling DMG on hosted runners has historically flaked inside
+  `bundle_dmg.sh`. The release matrix builds the `.app` bundle and tar-gzips
+  it (`--bundles app`). Users expand and drag-drop into `/Applications`.
+
+## Linux
+
+Hosted Ubuntu runners need these apt packages:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  libwebkit2gtk-4.1-dev \
+  libgtk-3-dev \
+  libayatana-appindicator3-dev \
+  librsvg2-dev \
+  patchelf
+```
+
+Default bundles produced: AppImage + `.deb`.
+
+## Verifying the toolchain
+
+```bash
+npm run tauri info
+```
+
+`tauri info` prints versions of Rust, the WebView, the Node runtime, and the
+detected bundle targets. Use this before opening a bug — most "Tauri won't
+build" reports are version mismatches.
+
+## CI reference
+
+Release builds run on tagged pushes via
+[`.github/workflows/release-desktop.yml`](../.github/workflows/release-desktop.yml).
+That file is the source of truth for what versions actually shipped.


### PR DESCRIPTION
## Summary

Hotfix v0.13.1 — six independent QoL improvements that have built up since v0.13.0 (shipped 2026-05-05).

- **Workflows** — Narrow `workflow_run.workflows` filters at the caller level so non-matching events no longer instantiate the wrapper (kills Actions tab Skipped spam). Also adds `link-discussion` job that auto-creates the linked Discussion when a release is published.
- **Repo metadata** — `FUNDING.yml` (mirrors `Donate.txt`), `ISSUE_TEMPLATE/{config,bug_report,feature_request}.yml` with a structured bug-report form.
- **Docs** — `docs/pc_spec.md`, `docs/dev_env.md` + VI mirrors; `webapp/TAURI.md` for per-platform build prerequisites.
- **About page** — Restructured with new Donate (GitHub Sponsors, Ko-fi, Buy Me a Coffee, Patreon, PayPal) and Dev Environment sections, expanded Connect section (Bluesky, Mastodon, Steam, Telegram bot+user, email, game Discord). Ko-fi/Patreon moved from `ABOUT.socials` → new `@config/donate`.
- **Header** — Persistent Donate button (Ko-fi) left of the language switcher.
- **Sidebar** — External Report Bug item linking directly to `bug_report.yml`.
- **SEO** — Full `<head>` metadata (description, OG, Twitter card, JSON-LD WebApplication schema, 6 locale alternates). Per-route `useDocumentTitle` hook on all 9 pages. `robots.txt`, `sitemap.xml`, `manifest.webmanifest`, placeholder `favicon.svg`.
- **Horror warnings** — New `horror_specific` group with 7 IDs: `eye_horror`, `body_horror`, `face_horror`, `cosmic_horror`, `extreme_gore`, `decay_rot`, `mutilation`. Localized to en/vi/ja/es/ko/zh in both `ui.json` and `templates.json`.

Additive — no breaking changes to engine, store schema, or persisted content-warning IDs. `_schema.json` updated for the new keys.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test:run` — 350/350 pass
- [x] `npm run validate:locales` — 663/663 ui + 346/346 templates × 6 locales
- [x] `npm run build` clean (main bundle 385 KB, under 500 KB budget)
- [x] Local dev — Header donate button, Sidebar Report Bug, About donate/devEnv/socials, EditorPage horror_specific group all render and click through
- [ ] After merge: confirm `Notify Deploy Status` no longer fires on CI runs (Actions tab smoke)
- [ ] After v0.13.1 tag: confirm `link-discussion` job creates a Discussion under Announcements

🤖 Generated with [Claude Code](https://claude.com/claude-code)