### PR TITLE
chore(release): bump src-tauri manifests to 0.13.1 (recover from v0.13.1 release miss)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5535,7 +5535,7 @@ dependencies = [
 
 [[package]]
 name = "yt-desc-gen"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yt-desc-gen"
-version = "0.13.0"
+version = "0.13.1"
 description = "YouTube Gameplay Description Generator"
 authors = ["poli0981"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "YTDescGen",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "identifier": "com.skullmute.ytdescgen",
   "build": {
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
## Summary

Closes the version-bump gap left by [PR #50](https://github.com/poli0981/youtube-generator/pull/50). Only `package.json` was bumped from 0.13.0 → 0.13.1 in that PR; the three Tauri-side manifests stayed at 0.13.0:

- `src-tauri/Cargo.toml`
- `src-tauri/tauri.conf.json`
- `src-tauri/Cargo.lock` (`yt-desc-gen` entry)

Because `release-desktop.yml` resolves `tagName: 'v__VERSION__'` from `tauri.conf.json`, the v0.13.1 tag push built binaries labeled 0.13.0 and `tauri-action` uploaded them to the existing v0.13.0 release object — clobbering the original v0.13.0 binaries and leaving v0.13.1 with no release on GitHub.

## Recovery after merge

1. Force-move tag `v0.13.1` from `d1cc099` → this merge commit
2. Push the tag with `--force` to retrigger `release-desktop` on the corrected commit → proper v0.13.1 release lands
3. Trigger `release-desktop` via `workflow_dispatch` with input `tag: v0.13.0` → rebuilds from the v0.13.0 commit (where Tauri manifests are still 0.13.0) → restores the original v0.13.0 release assets

## Test plan

- [x] Diff is 3 lines, one per manifest — no code changes
- [x] npm-side build / test / lint unchanged (those don't touch Tauri config)
- [ ] After merge + tag force-move: release-desktop matrix builds 3 platforms with `0.13.1` artifact names and creates a real `v0.13.1` release
- [ ] After `workflow_dispatch tag=v0.13.0`: v0.13.0 release's six assets show updated_at matching the rebuild and version strings inside binaries match v0.13.0 code

## Lessons learned

The repo's version-bump ritual is **5 files** (per the v0.9.0 lockfile-bump miss documented in memory):

1. `package.json`
2. `package-lock.json`
3. `src-tauri/Cargo.toml`
4. `src-tauri/Cargo.lock` (yt-desc-gen entry)
5. `src-tauri/tauri.conf.json`

Future version bumps should batch all 5 in the same commit before the tag push, or use a single CI guard that fails if `tauri.conf.json` version disagrees with `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)