### PR TITLE
v0.17.1: per-video Output preview selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to YTDescGen ship as tagged releases on `main`.
 
+## v0.17.1 — 2026-05-15
+
+Per-video Output selector — closes the last deferred piece from the
+v0.16 ending redesign. Multi-video ending playthroughs (case C) can
+now flip between per-video previews of title / description / tags
+without leaving the editor.
+
+### Added
+
+- **`endingVideoIndex` field on `EditorData`** (1-indexed, default 1). Stored on the editor (vs. recomputed per render) so the creator's pick survives navigating away and back. Engine already respected the corresponding `GeneratorInput.endingVideoIndex` since v0.17.0 — this just persists it.
+- **"Preview video" Select dropdown** in `EndingsEditor` case C ([src/components/editor/EndingsEditor.tsx](src/components/editor/EndingsEditor.tsx)). Renders `endingVideoCount` options labelled `"Video N (X–Y)"` where X–Y are the matching ending-range bounds. Changing it pipes `endingVideoIndex` into the engine, which slices `endings[]` for both title (via `buildStructuredEndingLabel`) and description (via `sliceEndingsForVideo`).
+- **"Previewing Video X of Y — Endings A–B" banner** at the top of the Output page when in case C ([src/pages/OutputPage.tsx](src/pages/OutputPage.tsx)). Persistent reminder so a creator flipping through videos doesn't forget which slice they're looking at.
+- **3 new locale keys × 6 locales**: `editor.endings.videoIndexLabel`, `editor.endings.videoIndexHint`, `output.previewingVideo`. All 718/718 ui keys per locale (up from 715).
+
+### Changed
+
+- **`use-current-generator-input`** forwards `endingVideoIndex` only when `endingVideoCount > 1` — single-video mode passes `undefined` so the slice helpers short-circuit to "render the union", keeping the input cleaner for tests.
+- **`EndingsEditor.setVideoCount`** now clamps `endingVideoIndex` down when the creator shrinks `endingVideoCount` (e.g. 6 → 2 with index = 4 → snaps to 2), so the preview never targets a non-existent video.
+- **Persist version 12 → 13**. Additive — `endingVideoIndex` back-fills to 1 on first rehydrate; pre-v0.17.1 drafts with a stale higher index get clamped to `endingVideoCount` by `migrateEditorState`.
+
+### Tests
+
+- 4 new tests in `editor-store.endings.test.ts` for the v12 → v13 migration (default back-fill, valid value preserved, clamp above max, clamp below 1). Total 426/426 pass.
+
+### Under the hood
+
+- The banner copy is locale-aware and pluralised inline via i18next interpolation (`{{index}} / {{total}} / {{from}} / {{to}}`).
+- `OutputPage` selects `endingVideoCount`, `endingVideoIndex`, `endingVideoRanges` as individual store slices so the page only re-renders when those specific fields change — no broader subscription drag.
+- Bundle: index 473.91 KB (+3 KB for Select + banner + migration). Under the 500 KB cap.
+
 ## v0.17.0 — 2026-05-14
 
 Combined release: logging overhaul + the deferred ending title piece

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yt-desc-gen",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yt-desc-gen",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yt-desc-gen",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5535,7 +5535,7 @@ dependencies = [
 
 [[package]]
 name = "yt-desc-gen"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yt-desc-gen"
-version = "0.17.0"
+version = "0.17.1"
 description = "YouTube Gameplay Description Generator"
 authors = ["poli0981"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "YTDescGen",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "identifier": "com.skullmute.ytdescgen",
   "build": {
     "beforeBuildCommand": "npm run build",

--- a/src/components/editor/EndingsEditor.tsx
+++ b/src/components/editor/EndingsEditor.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Plus, Minus, AlertTriangle } from "lucide-react";
 import { Input } from "@components/ui/Input";
 import { Button } from "@components/ui/Button";
+import { Select } from "@components/ui/Select";
 import {
   useEditorStore,
   computeContiguousRanges,
@@ -50,6 +51,7 @@ export function EndingsEditor() {
   const endings = useEditorStore((s) => s.endings);
   const endingVideoCount = useEditorStore((s) => s.endingVideoCount);
   const endingVideoRanges = useEditorStore((s) => s.endingVideoRanges);
+  const endingVideoIndex = useEditorStore((s) => s.endingVideoIndex);
   const timestamps = useEditorStore((s) => s.timestamps);
   const set = useEditorStore((s) => s.set);
 
@@ -99,12 +101,17 @@ export function EndingsEditor() {
   /** Update the multi-video count (case C). Recomputes default ranges
    *  on change unless the creator has already customised them — we
    *  always reset on count change because a manual override at the old
-   *  count is unlikely to make sense at the new one. */
+   *  count is unlikely to make sense at the new one. Also clamps
+   *  `endingVideoIndex` so a shrink doesn't leave us previewing a
+   *  video that no longer exists. */
   const setVideoCount = (next: number) => {
     if (count === 0) return;
     const clamped = Math.max(1, Math.min(count, Math.floor(next)));
     set("endingVideoCount", clamped);
     set("endingVideoRanges", computeContiguousRanges(count, clamped));
+    if (endingVideoIndex > clamped) {
+      set("endingVideoIndex", clamped);
+    }
   };
 
   /** Update one video's `from` / `to` bound (case C). Doesn't enforce
@@ -369,8 +376,26 @@ export function EndingsEditor() {
                   ))}
                 </ul>
               )}
+
+              {/* v0.17.1: preview-video selector. Lets the creator
+               *  pick which video's slice the Output renders. Engine
+               *  already respects `endingVideoIndex` for both title +
+               *  description; this just exposes the knob. */}
+              <Select
+                label={t("editor.endings.videoIndexLabel")}
+                options={Array.from({ length: endingVideoCount }, (_, i) => {
+                  const r = endingVideoRanges[i];
+                  const rangeLabel = r ? ` (${r.from}–${r.to})` : "";
+                  return {
+                    value: String(i + 1),
+                    label: `${t("editor.endings.videoLabel")} ${i + 1}${rangeLabel}`,
+                  };
+                })}
+                value={String(Math.min(endingVideoIndex, endingVideoCount))}
+                onChange={(v) => set("endingVideoIndex", Number(v) || 1)}
+              />
               <p className="text-xs text-text-muted">
-                {t("editor.endings.multiVideoOutputNote")}
+                {t("editor.endings.videoIndexHint")}
               </p>
             </>
           )}

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -104,6 +104,8 @@ export interface EditorDefaults {
   endingVideoCount: number;
   /** Per-video ending range (v0.16.0). */
   endingVideoRanges: EndingVideoRange[];
+  /** Which per-video slice the Output previews (v0.17.1). */
+  endingVideoIndex: number;
   /** Language-patch enum for Playthrough Notes section (v0.12). */
   languagePatch: LanguagePatch;
   /** Free-form label when `languagePatch` is `"official_other"` or `"custom"`. */
@@ -187,6 +189,7 @@ export const DEFAULTS = {
     endings: [],
     endingVideoCount: 1,
     endingVideoRanges: [],
+    endingVideoIndex: 1,
     languagePatch: "none",
     languagePatchCustom: "",
     gameVersion: "full_release",

--- a/src/hooks/use-current-generator-input.ts
+++ b/src/hooks/use-current-generator-input.ts
@@ -71,6 +71,13 @@ export function buildGeneratorInputFromEditor(
     endings: state.endings,
     endingVideoCount: state.endingVideoCount,
     endingVideoRanges: state.endingVideoRanges,
+    // v0.17.1: only forward the index when the playthrough is
+    // actually split across multiple videos. Single-video mode
+    // means the engine should see the union (the slice helpers
+    // already short-circuit on `videoCount <= 1`, but skipping the
+    // pass-through here keeps the input cleaner for tests).
+    endingVideoIndex:
+      state.endingVideoCount > 1 ? state.endingVideoIndex : undefined,
     languagePatch: state.languagePatch,
     languagePatchCustom: state.languagePatchCustom,
     gameVersion: state.gameVersion,

--- a/src/i18n/locales/_schema.json
+++ b/src/i18n/locales/_schema.json
@@ -96,7 +96,8 @@
       "numberLabel", "nameLabel", "namePlaceholder",
       "previewLabel", "previewEmpty",
       "emptyHint", "addOne", "removeLast",
-      "videoRangeHint", "multiVideoOutputNote"
+      "videoRangeHint", "multiVideoOutputNote",
+      "videoIndexLabel", "videoIndexHint"
     ],
     "editor.endings.warnings": [
       "singleEmpty", "timelineShort",
@@ -140,7 +141,8 @@
       "thumbnailText", "copyThumbnailText",
       "pinnedComment", "copyPinnedComment",
       "pinnedCommentTemplate", "copyPinnedCommentTemplate",
-      "generateAlternatives", "saveAsTemplate"
+      "generateAlternatives", "saveAsTemplate",
+      "previewingVideo"
     ],
     "output.variants": ["default", "typeFirst", "qualityFirst"],
     "output.copy": ["overLimit", "fieldGeneric", "failed"],

--- a/src/i18n/locales/en/ui.json
+++ b/src/i18n/locales/en/ui.json
@@ -459,7 +459,9 @@
       "addOne": "Add ending",
       "removeLast": "Remove last ending",
       "videoRangeHint": "Each video covers a contiguous slice of endings. Default split is balanced; adjust per row to override.",
-      "multiVideoOutputNote": "Each video's description renders that video's ending slice. Generate from the editor as usual — the Output preview shows video 1 by default.",
+      "multiVideoOutputNote": "Each video's description renders that video's ending slice. Generate from the editor as usual — switch which video the Output previews using the selector below.",
+      "videoIndexLabel": "Preview video",
+      "videoIndexHint": "Output preview, title, and tags update to reflect the selected video's ending slice. Copy each one separately to publish per-video.",
       "warnings": {
         "singleEmpty": "Fill at least the number or the name — empty entries are dropped from the description.",
         "timelineShort": "Timeline needs {{needed}} ending markers; only {{found}} found. Add the missing rows before copying.",
@@ -553,6 +555,7 @@
     "copyPinnedCommentTemplate": "Copy pinned comment template",
     "generateAlternatives": "Generate Alternatives",
     "saveAsTemplate": "Save as Template",
+    "previewingVideo": "Previewing Video {{index}} of {{total}} — Endings {{from}}–{{to}}",
     "variants": {
       "default": "Default",
       "typeFirst": "Type First",

--- a/src/i18n/locales/es/ui.json
+++ b/src/i18n/locales/es/ui.json
@@ -459,7 +459,9 @@
       "addOne": "Añadir final",
       "removeLast": "Eliminar último",
       "videoRangeHint": "Cada video cubre un tramo contiguo de finales. La división por defecto es equilibrada; ajusta por fila para sobrescribir.",
-      "multiVideoOutputNote": "La descripción de cada video renderiza su tramo. Genera desde el editor como siempre — la vista previa muestra el video 1 por defecto.",
+      "multiVideoOutputNote": "La descripción de cada video renderiza su tramo. Genera desde el editor como siempre — cambia el video previsualizado con el selector de abajo.",
+      "videoIndexLabel": "Video de previsualización",
+      "videoIndexHint": "La vista previa de Output, el título y las etiquetas se actualizan según el tramo del video seleccionado. Copia cada uno por separado para publicar por video.",
       "warnings": {
         "singleEmpty": "Completa al menos número o nombre — las entradas vacías se omiten de la descripción.",
         "timelineShort": "La línea de tiempo necesita {{needed}} marcadores de final; solo se encontraron {{found}}. Añade los faltantes antes de copiar.",
@@ -553,6 +555,7 @@
     "copyPinnedCommentTemplate": "Copiar plantilla de comentario fijado",
     "generateAlternatives": "Generar Alternativas",
     "saveAsTemplate": "Guardar como Plantilla",
+    "previewingVideo": "Vista previa: Video {{index}} de {{total}} — Finales {{from}}–{{to}}",
     "variants": {
       "default": "Predeterminado",
       "typeFirst": "Tipo Primero",

--- a/src/i18n/locales/ja/ui.json
+++ b/src/i18n/locales/ja/ui.json
@@ -459,7 +459,9 @@
       "addOne": "エンディング追加",
       "removeLast": "最後を削除",
       "videoRangeHint": "各動画はエンディングの連続したスライスを担当します。デフォルトでは均等に分割されますが、行ごとに上書きできます。",
-      "multiVideoOutputNote": "各動画の説明はそのスライスを描画します。通常どおりエディタから生成 — プレビューはデフォルトで動画 1 を表示します。",
+      "multiVideoOutputNote": "各動画の説明はそのスライスを描画します。通常どおりエディタから生成 — 下のセレクタでプレビューする動画を切り替えできます。",
+      "videoIndexLabel": "プレビュー動画",
+      "videoIndexHint": "選択した動画のエンディングスライスに合わせて Output プレビュー・タイトル・タグが更新されます。動画ごとに個別にコピーして公開してください。",
       "warnings": {
         "singleEmpty": "番号か名前のいずれかを入力してください — 空欄のエントリは説明から除外されます。",
         "timelineShort": "タイムラインに {{needed}} 件のエンディングマーカーが必要ですが、{{found}} 件のみ。コピー前に不足分を追加してください。",
@@ -553,6 +555,7 @@
     "copyPinnedCommentTemplate": "固定コメントのテンプレートをコピー",
     "generateAlternatives": "タイトル案を生成",
     "saveAsTemplate": "テンプレートとして保存",
+    "previewingVideo": "プレビュー中: 動画 {{index}}/{{total}} — エンディング {{from}}–{{to}}",
     "variants": {
       "default": "デフォルト",
       "typeFirst": "タイプ優先",

--- a/src/i18n/locales/ko/ui.json
+++ b/src/i18n/locales/ko/ui.json
@@ -459,7 +459,9 @@
       "addOne": "엔딩 추가",
       "removeLast": "마지막 항목 삭제",
       "videoRangeHint": "각 영상은 연속된 엔딩 구간을 담당합니다. 기본은 균등 분할이며 행 단위로 수정 가능합니다.",
-      "multiVideoOutputNote": "각 영상의 설명은 해당 구간을 렌더링합니다. 평소대로 생성 — 미리보기는 기본적으로 영상 1을 표시합니다.",
+      "multiVideoOutputNote": "각 영상의 설명은 해당 구간을 렌더링합니다. 평소대로 생성 — 아래 셀렉터에서 미리보기 영상을 전환하세요.",
+      "videoIndexLabel": "미리보기 영상",
+      "videoIndexHint": "선택한 영상의 엔딩 구간에 맞춰 Output 미리보기, 제목, 태그가 업데이트됩니다. 영상별로 각각 복사하여 게시하세요.",
       "warnings": {
         "singleEmpty": "번호 또는 이름 중 하나는 입력해야 합니다 — 빈 항목은 설명에서 제외됩니다.",
         "timelineShort": "타임라인에 엔딩 마커가 {{needed}}개 필요하지만 {{found}}개만 있습니다. 복사 전에 누락분을 추가하세요.",
@@ -553,6 +555,7 @@
     "copyPinnedCommentTemplate": "고정 댓글 템플릿 복사",
     "generateAlternatives": "제목 대안 생성",
     "saveAsTemplate": "템플릿으로 저장",
+    "previewingVideo": "미리보기: 영상 {{index}}/{{total}} — 엔딩 {{from}}–{{to}}",
     "variants": {
       "default": "기본",
       "typeFirst": "유형 우선",

--- a/src/i18n/locales/vi/ui.json
+++ b/src/i18n/locales/vi/ui.json
@@ -459,7 +459,9 @@
       "addOne": "Thêm ending",
       "removeLast": "Xoá ending cuối",
       "videoRangeHint": "Mỗi video chứa một dải ending liên tiếp. Chia mặc định cân đối; sửa theo hàng để tuỳ chỉnh.",
-      "multiVideoOutputNote": "Mỗi video xuất một dải ending riêng. Bấm Generate như bình thường — bản preview hiển thị video 1.",
+      "multiVideoOutputNote": "Mỗi video xuất một dải ending riêng. Bấm Generate như bình thường — chọn video preview bằng dropdown bên dưới.",
+      "videoIndexLabel": "Video xem trước",
+      "videoIndexHint": "Output preview, tiêu đề và tag sẽ cập nhật theo dải ending của video đang chọn. Copy từng cái để xuất bản theo từng video.",
       "warnings": {
         "singleEmpty": "Hãy điền ít nhất số hoặc tên — entry rỗng sẽ bị bỏ khỏi mô tả.",
         "timelineShort": "Timeline cần {{needed}} mốc ending; hiện chỉ có {{found}}. Thêm các mốc còn thiếu trước khi copy.",
@@ -553,6 +555,7 @@
     "copyPinnedCommentTemplate": "Sao chép mẫu bình luận ghim",
     "generateAlternatives": "Tạo biến thể tiêu đề",
     "saveAsTemplate": "Lưu thành template",
+    "previewingVideo": "Đang xem Video {{index}}/{{total}} — Ending {{from}}–{{to}}",
     "variants": {
       "default": "Mặc định",
       "typeFirst": "Loại video trước",

--- a/src/i18n/locales/zh/ui.json
+++ b/src/i18n/locales/zh/ui.json
@@ -459,7 +459,9 @@
       "addOne": "添加结局",
       "removeLast": "删除最后一个",
       "videoRangeHint": "每个视频覆盖一段连续的结局。默认均匀分配，可按行覆盖。",
-      "multiVideoOutputNote": "每个视频的描述渲染对应结局段。从编辑器照常生成 — 预览默认显示视频 1。",
+      "multiVideoOutputNote": "每个视频的描述渲染对应结局段。从编辑器照常生成 — 使用下方选择器切换预览视频。",
+      "videoIndexLabel": "预览视频",
+      "videoIndexHint": "Output 预览、标题、标签会按所选视频的结局段更新。请按视频分别复制后发布。",
       "warnings": {
         "singleEmpty": "至少填写编号或名称 — 空白条目将从描述中排除。",
         "timelineShort": "时间线需要 {{needed}} 个结局标记，但只有 {{found}} 个。复制前请补齐。",
@@ -553,6 +555,7 @@
     "copyPinnedCommentTemplate": "复制置顶评论模板",
     "generateAlternatives": "生成标题备选",
     "saveAsTemplate": "保存为模板",
+    "previewingVideo": "预览中：视频 {{index}}/{{total}} — 结局 {{from}}–{{to}}",
     "variants": {
       "default": "默认",
       "typeFirst": "类型优先",

--- a/src/pages/OutputPage.tsx
+++ b/src/pages/OutputPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useDocumentTitle } from "@hooks/use-document-title";
-import { Shuffle, Bookmark } from "lucide-react";
+import { Shuffle, Bookmark, Film } from "lucide-react";
 import { Button } from "@components/ui/Button";
 import { OutputPreview } from "@components/output/OutputPreview";
 import { OutputExtras } from "@components/output/OutputExtras";
@@ -22,6 +22,17 @@ export function OutputPage() {
   useDocumentTitle(t("tabs.output"));
   const defaultOutput = useGeneratedOutput();
   const { gameName, videoType, language, genres } = useEditorStore();
+  // v0.17.1: surface the per-video preview state so the page can
+  // render a "Showing: Video N of M" banner — without it, a creator
+  // who flipped the EndingsEditor selector wouldn't see which video
+  // they're currently looking at without scrolling back.
+  const endingVideoCount = useEditorStore((s) => s.endingVideoCount);
+  const endingVideoIndex = useEditorStore((s) => s.endingVideoIndex);
+  const endingVideoRanges = useEditorStore((s) => s.endingVideoRanges);
+  const isMultiVideoEnding = videoType === "ending" && endingVideoCount > 1;
+  const currentRange = isMultiVideoEnding
+    ? endingVideoRanges[Math.max(0, Math.min(endingVideoCount, endingVideoIndex) - 1)]
+    : undefined;
   const addEntry = useHistoryStore((s) => s.addEntry);
   const historyLimit = useSettingsStore((s) => s.historyLimit);
   const savedRef = useRef<string>("");
@@ -134,6 +145,19 @@ export function OutputPage() {
           </div>
         )}
 
+        {isMultiVideoEnding && (
+          <div className="mb-4 flex items-center gap-2 rounded-lg border border-accent/40 bg-accent/10 px-3 py-2 text-xs text-text-secondary">
+            <Film className="h-3.5 w-3.5 shrink-0 text-accent" />
+            <span>
+              {t("output.previewingVideo", {
+                index: Math.min(endingVideoIndex, endingVideoCount),
+                total: endingVideoCount,
+                from: currentRange?.from ?? 1,
+                to: currentRange?.to ?? 1,
+              })}
+            </span>
+          </div>
+        )}
         {currentOutput && <OutputPreview output={isMultiLang ? currentOutput : undefined} />}
         <div className="mt-6">
           <OutputExtras />

--- a/src/store/editor-store.ts
+++ b/src/store/editor-store.ts
@@ -124,6 +124,17 @@ export interface EditorData {
    * can override.
    */
   endingVideoRanges: EndingVideoRange[];
+  /**
+   * Which per-video slice the Output page should preview (v0.17.1).
+   * 1-indexed to match the user-facing "Video 1, Video 2…" labels.
+   * Only meaningful when `endingVideoCount > 1`; in single-video
+   * mode the index is ignored and the engine renders the union.
+   *
+   * Stored on the editor (vs. derived per-render) so the creator's
+   * choice survives page navigation — flipping to Profiles and back
+   * shouldn't reset the preview to video 1.
+   */
+  endingVideoIndex: number;
   /** Language-patch enum for Playthrough Notes (v0.12). */
   languagePatch: LanguagePatch;
   /** Free-form label paired with `languagePatch === "official_other" | "custom"`. */
@@ -307,6 +318,7 @@ const initialState: EditorData = {
   endings: [...DEFAULTS.editor.endings] as EndingEntry[],
   endingVideoCount: DEFAULTS.editor.endingVideoCount,
   endingVideoRanges: [...DEFAULTS.editor.endingVideoRanges] as EndingVideoRange[],
+  endingVideoIndex: DEFAULTS.editor.endingVideoIndex,
   languagePatch: DEFAULTS.editor.languagePatch,
   languagePatchCustom: DEFAULTS.editor.languagePatchCustom,
   gameVersion: DEFAULTS.editor.gameVersion,
@@ -421,13 +433,18 @@ export const useEditorStore = create<EditorState>()(
       //         the array first, falls back to the freeform when the
       //         array is empty) produces identical output for
       //         existing drafts.
+      // v12 → v13: v0.17.1. `endingVideoIndex` joined the schema —
+      //         which per-video slice the Output preview renders
+      //         when `endingVideoCount > 1`. Additive — defaults to
+      //         1; the rehydrate spread of `initialState` covers the
+      //         back-fill for pre-v0.17.1 drafts.
       // v10 → v11: v0.13. Gacha-quest gained three new structured fields:
       //         `characterName` (used for the Showcase quest type, replacing
       //         chapter/quest in templates), `anniversaryYear` (1–20 number
       //         used by the Anniversary quest type), and `gachaVersion`
       //         (free-form game version like "1.2"). All additive — empty
       //         / null defaults round-trip cleanly.
-      version: 12,
+      version: 13,
       migrate: (persistedState, version) =>
         migrateEditorState(persistedState, version),
       partialize: (state) => ({
@@ -482,6 +499,7 @@ export const useEditorStore = create<EditorState>()(
         endings: state.endings,
         endingVideoCount: state.endingVideoCount,
         endingVideoRanges: state.endingVideoRanges,
+        endingVideoIndex: state.endingVideoIndex,
         languagePatch: state.languagePatch,
         languagePatchCustom: state.languagePatchCustom,
         gameVersion: state.gameVersion,
@@ -701,6 +719,15 @@ export function migrateEditorState(
           ? []
           : computeContiguousRanges(endingsLen, state.endingVideoCount as number);
     }
+  }
+  if (version < 13) {
+    // v0.17.1 per-video Output selector. Clamp to [1, videoCount]
+    // so a stale higher index (e.g. user shrank videoCount before
+    // upgrade) doesn't slice off-the-end and surface a confusing
+    // "empty video" preview.
+    const vc = typeof state.endingVideoCount === "number" ? state.endingVideoCount : 1;
+    const idx = typeof state.endingVideoIndex === "number" ? state.endingVideoIndex : 1;
+    state.endingVideoIndex = Math.max(1, Math.min(vc, Math.floor(idx)));
   }
   return { ...initialState, ...state } as EditorData;
 }

--- a/tests/store/editor-store.endings.test.ts
+++ b/tests/store/editor-store.endings.test.ts
@@ -145,3 +145,61 @@ describe("migrateEditorState v11 → v12 (endings)", () => {
     ]);
   });
 });
+
+describe("migrateEditorState v12 → v13 (endingVideoIndex)", () => {
+  it("defaults endingVideoIndex to 1 when absent", () => {
+    const result = migrateEditorState(
+      { endings: [{ number: 1, name: "A" }], endingVideoCount: 1 },
+      12,
+    );
+    expect(result.endingVideoIndex).toBe(1);
+  });
+
+  it("preserves a valid endingVideoIndex within bounds", () => {
+    const result = migrateEditorState(
+      {
+        endings: [
+          { number: 1, name: "A" },
+          { number: 2, name: "B" },
+        ],
+        endingVideoCount: 2,
+        endingVideoIndex: 2,
+        endingVideoRanges: [
+          { from: 1, to: 1 },
+          { from: 2, to: 2 },
+        ],
+      },
+      12,
+    );
+    expect(result.endingVideoIndex).toBe(2);
+  });
+
+  it("clamps endingVideoIndex above endingVideoCount", () => {
+    // Pretend the creator shrank videoCount before upgrade — stale
+    // index 5 should clamp to the new max 2.
+    const result = migrateEditorState(
+      {
+        endings: [
+          { number: 1, name: "A" },
+          { number: 2, name: "B" },
+        ],
+        endingVideoCount: 2,
+        endingVideoIndex: 5,
+        endingVideoRanges: [
+          { from: 1, to: 1 },
+          { from: 2, to: 2 },
+        ],
+      },
+      12,
+    );
+    expect(result.endingVideoIndex).toBe(2);
+  });
+
+  it("clamps below 1 to 1", () => {
+    const result = migrateEditorState(
+      { endingVideoCount: 3, endingVideoIndex: -2 },
+      12,
+    );
+    expect(result.endingVideoIndex).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the last deferred piece from the v0.16 ending redesign. Multi-video ending playthroughs (**case C**) can now flip between per-video previews of title / description / tags without leaving the editor.

## What's new

- **`endingVideoIndex` field on `EditorData`** (1-indexed, default 1). Stored on the editor so the creator's pick survives page navigation. Engine already respected the corresponding `GeneratorInput.endingVideoIndex` since v0.17.0 — this just persists it.
- **\"Preview video\" Select dropdown** in `EndingsEditor` case C ([src/components/editor/EndingsEditor.tsx](src/components/editor/EndingsEditor.tsx)). Options labelled `\"Video N (X–Y)\"` where X–Y are the matching ending-range bounds. Changing it pipes `endingVideoIndex` into the engine, which slices `endings[]` for both title (via `buildStructuredEndingLabel`) and description (via `sliceEndingsForVideo`).
- **\"Previewing Video X of Y — Endings A–B\" banner** at the top of the Output page when in case C ([src/pages/OutputPage.tsx](src/pages/OutputPage.tsx)). Persistent reminder so a creator flipping through videos doesn't forget which slice they're looking at.
- **Auto-clamp on shrink**: `setVideoCount` snaps the index down when the creator reduces `endingVideoCount` (e.g. 6 → 2 with index = 4 → snaps to 2).
- **Persist version 12 → 13 additive** with clamp on rehydrate for stale higher indices.

## Tests

- 4 new tests for v12→v13 migration (default back-fill, valid preserved, clamp above max, clamp below 1).
- 426/426 total pass.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test -- --run` (426/426)
- [x] `npm run validate:locales` (all 6 clean, 718/718 ui per locale)
- [x] `npm run build` (index 473.91 KB, under 500 KB cap)
- [ ] (Post-merge) Smoke test: 6 endings split into 2 videos, flip dropdown between Video 1 (endings 1–3) and Video 2 (endings 4–6), confirm Output title + description update inline
- [ ] (Post-merge) Tag `v0.17.1` on the merge commit

## Migration

- Persist v12 → v13 additive — `endingVideoIndex` defaults to 1 on rehydrate. Pre-v0.17.1 drafts with a stale higher index get clamped to `endingVideoCount`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)