### PR TITLE
feat(v0.18.0): Vietnamese bank dropdown + persistence/export fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to YTDescGen ship as tagged releases on `main`.
 
+## v0.18.0 — 2026-05-15
+
+Vietnamese-bank dropdown for the donate form + two persistence-layer
+bug fixes (UI language reverting to English after relaunch, Settings
+export bundling unrelated stores) + one cleanup (Open Folder button
+removed) + a new content-inventory documentation page (EN + VI).
+
+### Added
+
+- **Vietnamese bank dropdown** in `VietnameseDonateEditor` ([src/components/editor/VietnameseDonateEditor.tsx](src/components/editor/VietnameseDonateEditor.tsx), [src/config/vietnamese-banks.ts](src/config/vietnamese-banks.ts)). When the output language is Vietnamese, the "Bank name" field upgrades from a plain text input to a `<Select>` listing 30 of Vietnam's most-used banks (Big 4 state-owned + top 22 joint-stock commercial banks by retail presence + 4 foreign banks with the strongest Vietnam footprint). Sourced from the State Bank of Vietnam's 2026 register via [bankervn.com](https://bankervn.com/danh-sach-ngan-hang/). Picking "Khác (nhập tay)" reveals an inline text input so unlisted / digital-only / regional banks still work. Persisted shape is unchanged — `vnBankName` stays a plain string — so saved profiles and exports round-trip cleanly. When the output language is not Vietnamese, the field falls back to the legacy text input.
+- **`docs/CONTENT-INVENTORY.md`** + **Vietnamese mirror** ([docs/i18n/vi/CONTENT-INVENTORY.md](docs/i18n/vi/CONTENT-INVENTORY.md)). Static, hand-maintained manifest of every video type (20), game genre (41), and content warning (96 across 8 groups) the editor surfaces. Linked from the main `README.md` Documentation table. Transparency aid for anyone evaluating the editor's coverage without reading source.
+- **2 new locale keys × 6 locales**: `editor.vnBankNameSelectPlaceholder`, `editor.vnBankNameOther`. Localised for VI; left in English for JA/KO/ZH/ES to match the existing convention for VN-donate fields. Schema (`src/i18n/locales/_schema.json`) updated accordingly.
+
+### Fixed
+
+- **UI language reverts to English after app relaunch** ([src/App.tsx](src/App.tsx)). i18next initialises synchronously with `fallbackLng: "en"` while Zustand's persist middleware rehydrates `appLanguage` either synchronously (localStorage) or asynchronously (Tauri `settings.json`). Neither path bridged the persisted value back to i18n, so the UI rendered English even when the saved setting was Vietnamese / Japanese / etc. App.tsx now reads `appLanguage` at mount and calls `i18n.changeLanguage` once, then subscribes to subsequent store changes so the async Tauri rehydrate (and any future external mutation) propagate to i18n automatically.
+- **Settings JSON export was a multi-store dump** ([src/pages/SettingsPage.tsx](src/pages/SettingsPage.tsx)). The pre-v0.18.0 "Export Settings" button copied the whole on-disk `settings.json` — which the storage adapter writes as a gross dump of every Zustand store (settings + profiles + presets + templates + history). The new exporter writes only the Settings data through `exportTypedToJsonFile("settings", …)` — the same envelope-typed flow the Profiles tab already uses. Importer is the matching `importParsedFromJsonFile` + `resolveForType("settings")` chain, with an explicit reject for the legacy multi-store dump (friendly toast instead of silent profile-store pollution). `extractData` was promoted from a private helper in `settings-store` to a named export for this. The IS_TAURI gate stays — surfacing the buttons on the web build is out of scope for this release.
+
+### Removed
+
+- **"Open Folder" button** in Settings → top bar ([src/pages/SettingsPage.tsx](src/pages/SettingsPage.tsx)). Niche utility — most users never opened the app-data folder, and Tauri-only meant web builds never saw it. The `ensure_dir` Tauri command stays in the Rust side for the export/import paths that still rely on it. ~25 LOC removed including the unused `FolderOpen` icon import.
+
+### Under the hood
+
+- `App.tsx` mount effect now subscribes to `useSettingsStore` for `appLanguage` changes — Header and SettingsPage still call `i18n.changeLanguage` directly when the user switches, which is now redundant but harmless. Cleanup deferred to a future PR.
+- Persist version unchanged — this release adds no new persisted fields.
+- Bundle: under the 500 KB cap. The bank list is a 33-entry static array, negligible weight; the new envelope flow is a net-negative on SettingsPage size (Tauri dialog + ensure_dir + read_from_file paths replaced with one browser-API call).
+
+### Migration notes
+
+- **Pre-v0.18.0 settings export files (multi-store dump)** are rejected with a friendly "Legacy export format from v0.17.x or earlier is no longer supported" toast on import. Re-export from v0.18.0+ to get a clean settings-only envelope file.
+- **Profiles, presets, templates, history** export/import flows on the Profiles tab are unchanged. v0.17.x exports of those types still import unmodified.
+- **Saved `vnBankName` values** that don't match any of the 30 preset banks auto-detect as "custom" on first render — the dropdown shows "Khác" and the inline text input is pre-filled with the saved value. No persisted data is lost.
+
 ## v0.17.1 — 2026-05-15
 
 Per-video Output selector — closes the last deferred piece from the

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Architecture overview: [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md).
 | [Development Guide](./docs/DEVELOPMENT.md) | Toolchain, IDE setup, build commands, troubleshooting. *(Also: [Vietnamese](./docs/i18n/vi/DEVELOPMENT.md).)* |
 | [Architecture](./docs/ARCHITECTURE.md) | Layer model, data flow, engine design. |
 | [Features](./docs/FEATURES.md) | Full feature matrix. |
+| [Content Inventory](./docs/CONTENT-INVENTORY.md) | Every video type, genre, and content warning the editor surfaces. *(Also: [Vietnamese](./docs/i18n/vi/CONTENT-INVENTORY.md).)* |
 | [Roadmap](./docs/ROADMAP.md) | Development phases. |
 | [Tech Spec](./docs/TECH-SPEC.md) | Implementation details and configs. |
 | [i18n Guide](./docs/I18N.md) | Adding new locales. |

--- a/docs/CONTENT-INVENTORY.md
+++ b/docs/CONTENT-INVENTORY.md
@@ -1,0 +1,145 @@
+# Content Inventory
+
+A static manifest of every video type, game genre, and content warning surfaced in YTDescGen's editor. Maintained manually — when adding a new option to one of the source files below, **add a row here too** in the same PR.
+
+This file exists for **transparency** — anyone curious about what the editor can describe (without installing the app or reading the source) can scan it in one minute.
+
+**Vietnamese mirror:** [`docs/i18n/vi/CONTENT-INVENTORY.md`](./i18n/vi/CONTENT-INVENTORY.md).
+
+**Source of truth:**
+- Video types: [`src/config/video-types.ts`](../src/config/video-types.ts)
+- Game genres: [`src/config/genres.ts`](../src/config/genres.ts)
+- Content warnings: [`src/config/content-warning-groups.ts`](../src/config/content-warning-groups.ts)
+
+---
+
+## 1. Video types (20)
+
+Each video type drives a dedicated description template + title structure + tag bias. The "Extra fields" column lists fields the editor reveals when this type is selected.
+
+| Icon | Type | Extra fields |
+|---|---|---|
+| 🎮 | Full Gameplay | — |
+| 📂 | Gameplay Part | Part Number |
+| 🎬 | Full Demo | — |
+| 🎞 | Demo Part | Part Number |
+| 👹 | Boss Fight | Boss Name |
+| 💀 | Boss No Hit | Boss Name |
+| 🏁 | Ending / All Endings | — |
+| ⚡ | Speedrun | — |
+| 💯 | 100% Completion | — |
+| 📦 | DLC Content | DLC Name |
+| 🔄 | New Game+ | — |
+| 🏆 | Challenge Run | Challenge Name |
+| 📌 | Side Quests | — |
+| 🔍 | Secrets / Hidden | — |
+| ⚖️ | Graphics Comparison | — |
+| 📘 | Silent Guide | — |
+| 🧩 | Modded Gameplay | Mod Name |
+| ⭐ | All Collectibles | — |
+| 🔴 | Livestream | Live URL, Scheduled Time |
+| 🎴 | Gacha Quest | Quest Type, Chapter Name, Quest Name, Part Number |
+
+---
+
+## 2. Game genres (41)
+
+Selected genres feed the title format, the tag pool, and (when configured in Settings → Genre Playlists) the pinned-comment recommendation.
+
+Bulk-select groups available in the editor: **All RPGs** (rpg + jrpg + action_rpg + crpg), **All Shooters** (fps + arena_shooter + tactical_fps + boomer_shooter + extraction_shooter + shmup), **All Horror** (horror + survival_horror + psychological_horror).
+
+| Icon | Genre |
+|---|---|
+| ⚔️ | Action / Adventure |
+| 🗡 | Hack & Slash |
+| 👊 | Beat 'em Up |
+| 🦘 | Platformer |
+| 👻 | Horror / Survival |
+| 🧟 | Survival Horror |
+| 🧠 | Psychological Horror |
+| 🛡 | RPG |
+| 🎎 | JRPG |
+| 🏹 | Action RPG |
+| 📜 | CRPG / Isometric |
+| 🔫 | FPS / Shooter |
+| 🎯 | Arena Shooter |
+| 🎖 | Tactical FPS |
+| 💥 | Boomer Shooter |
+| 🎒 | Extraction Shooter |
+| 🛸 | SHMUP / Bullet Hell |
+| 🌍 | Open World / Sandbox |
+| 🕹 | Indie |
+| 💀 | Souls-like |
+| 🏎 | Racing / Sports |
+| 📖 | Story / Narrative |
+| 🏗 | Simulation / Strategy |
+| 🏙 | City Builder |
+| 🥊 | Fighting |
+| 🥷 | Stealth / Espionage |
+| ⛏ | Survival / Crafting |
+| 🎲 | Roguelike / Roguelite |
+| 🗺 | Metroidvania |
+| 🌐 | MMO / Online |
+| 🎵 | Rhythm / Music |
+| 🧩 | Puzzle |
+| 🏰 | Tower Defense |
+| 🃏 | Card Game |
+| 🎴 | Deck Builder |
+| 🤖 | Auto Battler |
+| 🏆 | Battle Royale |
+| ♟ | Tactical / Turn-based |
+| 🚀 | Space / Sci-Fi |
+| 🌾 | Farming / Life Sim |
+| 🎬 | FMV / Interactive Movie |
+| 💬 | Visual Novel |
+
+---
+
+## 3. Content warnings (96, grouped)
+
+Selected warnings are appended to a `⚠ CONTENT WARNINGS` block in the description, ahead of timestamps. Each group is collapsible in the editor; warnings render in description order = user's selection order.
+
+### Spoilers (6)
+
+Story / ending spoilers · Ending spoilers · True-ending spoilers · Post-game / NG+ spoilers · Secret-ending spoilers · DLC story spoilers
+
+### Photosensitive / Health (6)
+
+Flashing lights · Motion sickness · Migraine trigger · Loud / sudden sounds · Strobe lighting · Heavy screen shake
+
+### Phobias (16)
+
+Jumpscares · Heights (acrophobia) · Holes / clusters (trypophobia) · Deep water (thalassophobia) · Confined spaces (claustrophobia) · Spiders (arachnophobia) · Insects (entomophobia) · Snakes (ophidiophobia) · Dogs (cynophobia) · Darkness (nyctophobia) · Fire (pyrophobia) · Dolls (pediophobia) · Blood (hemophobia) · Clowns (coulrophobia) · Drowning / water immersion (ablutophobia) · Live burial (taphophobia)
+
+### Mental health (17)
+
+Anxiety-inducing scenes · Depression themes · Eating disorders · Substance use · Self-harm / suicide · PTSD content · Needles · Body fluids · Pregnancy / birth horror · Illness / infection · Bipolar themes · OCD themes · Panic attacks · Dissociation · Paranoia · Intrusive thoughts · Medical horror
+
+### Mature / Sensitive content (26)
+
+Blood and gore · Mature 18+ · Disturbing imagery · Animal cruelty · Violence against minors · Domestic violence · Sexual assault references · Torture · Religious themes · War violence · Discrimination · State / police violence · Smoking / drinking · Detailed killing · Cult / occult · Psychological manipulation · Loss / grief · Kidnapping · Hate speech · Historical atrocities · Slavery themes · Terrorism themes · Bullying themes · Human experimentation · Cannibalism · Nuclear / radiation
+
+### Heavy horror (12)
+
+Eyes / eyeball clusters · Body horror (flesh distortion) · Distorted / mutilated faces · Cosmic / eldritch horror · Extreme gore / dismemberment · Decay, rot, maggots · Mutilation / amputation · Liminal spaces · Analog horror / VHS · Unreality / distortion · Pursuit / chase · Entity / SCP horror
+
+### Playstyle disclosures (10)
+
+Blind playthrough · No spoilers in chat · Casual / story mode · Hardcore / max difficulty · Permadeath / Iron Man · Speedrun attempt · 100% completionist · Still learning mechanics · First time playing · Returning / NG+
+
+### Gameplay disclosure (4)
+
+Mods used · Cheats / debug · Glitches used · Guide-assisted
+
+---
+
+## 4. Maintenance
+
+When adding a new item to any of the source files:
+
+1. **Video types** → append to [`src/config/video-types.ts`](../src/config/video-types.ts) AND add a row in section 1 above.
+2. **Genres** → append to [`src/config/genres.ts`](../src/config/genres.ts) AND add a row in section 2.
+3. **Content warnings** → append to the relevant group in [`src/config/content-warning-groups.ts`](../src/config/content-warning-groups.ts) AND add the label to the right group in section 3 — keep the group count in the heading accurate.
+4. Update the Vietnamese mirror at [`docs/i18n/vi/CONTENT-INVENTORY.md`](./i18n/vi/CONTENT-INVENTORY.md) in the same PR.
+
+Mismatch between this file and the source files is treated as a documentation bug — open an issue or PR.

--- a/docs/i18n/vi/CONTENT-INVENTORY.md
+++ b/docs/i18n/vi/CONTENT-INVENTORY.md
@@ -1,0 +1,145 @@
+# Danh mục Nội dung
+
+Bản kê khai tĩnh cho mọi loại video, thể loại game, và cảnh báo nội dung trong editor của YTDescGen. Cập nhật thủ công — khi thêm mục mới vào một trong các file nguồn dưới đây, **thêm dòng tương ứng vào đây** trong cùng PR.
+
+File này tồn tại để **minh bạch** — bất kỳ ai tò mò về việc editor có thể mô tả được gì (mà không cần cài app hay đọc source) đều có thể quét trong một phút.
+
+**Bản gốc tiếng Anh:** [`docs/CONTENT-INVENTORY.md`](../../CONTENT-INVENTORY.md).
+
+**Nguồn tham chiếu (source of truth):**
+- Loại video: [`src/config/video-types.ts`](../../../src/config/video-types.ts)
+- Thể loại game: [`src/config/genres.ts`](../../../src/config/genres.ts)
+- Cảnh báo nội dung: [`src/config/content-warning-groups.ts`](../../../src/config/content-warning-groups.ts)
+
+---
+
+## 1. Loại video (20)
+
+Mỗi loại video kéo theo một template description, cấu trúc title, và tag bias riêng. Cột "Trường bổ sung" liệt kê các trường editor sẽ hiển thị khi chọn loại video tương ứng.
+
+| Icon | Loại | Trường bổ sung |
+|---|---|---|
+| 🎮 | Gameplay đầy đủ | — |
+| 📂 | Gameplay theo phần | Số phần |
+| 🎬 | Demo đầy đủ | — |
+| 🎞 | Demo theo phần | Số phần |
+| 👹 | Đấu trùm | Tên trùm |
+| 💀 | Đấu trùm không trúng đòn | Tên trùm |
+| 🏁 | Kết thúc / Toàn bộ Ending | — |
+| ⚡ | Speedrun | — |
+| 💯 | Hoàn thành 100% | — |
+| 📦 | Nội dung DLC | Tên DLC |
+| 🔄 | New Game+ | — |
+| 🏆 | Thử thách | Tên thử thách |
+| 📌 | Nhiệm vụ phụ | — |
+| 🔍 | Bí mật / Ẩn | — |
+| ⚖️ | So sánh đồ họa | — |
+| 📘 | Hướng dẫn không lời | — |
+| 🧩 | Chơi với Mod | Tên Mod |
+| ⭐ | Toàn bộ vật phẩm sưu tầm | — |
+| 🔴 | Livestream | URL Live, Thời gian dự kiến |
+| 🎴 | Nhiệm vụ Gacha | Loại nhiệm vụ, Tên chapter, Tên quest, Số phần |
+
+---
+
+## 2. Thể loại game (41)
+
+Thể loại được chọn ảnh hưởng đến định dạng title, tag pool, và (khi cấu hình ở Settings → Genre Playlists) gợi ý playlist trong pinned comment.
+
+Các nhóm bulk-select trong editor: **All RPGs** (rpg + jrpg + action_rpg + crpg), **All Shooters** (fps + arena_shooter + tactical_fps + boomer_shooter + extraction_shooter + shmup), **All Horror** (horror + survival_horror + psychological_horror).
+
+| Icon | Thể loại |
+|---|---|
+| ⚔️ | Hành động / Phiêu lưu |
+| 🗡 | Hack & Slash |
+| 👊 | Beat 'em Up |
+| 🦘 | Platformer |
+| 👻 | Kinh dị / Sinh tồn |
+| 🧟 | Kinh dị Sinh tồn |
+| 🧠 | Kinh dị Tâm lý |
+| 🛡 | RPG |
+| 🎎 | JRPG |
+| 🏹 | Action RPG |
+| 📜 | CRPG / Góc nhìn từ trên |
+| 🔫 | FPS / Bắn súng |
+| 🎯 | Bắn súng Arena |
+| 🎖 | Bắn súng Chiến thuật |
+| 💥 | Boomer Shooter |
+| 🎒 | Extraction Shooter |
+| 🛸 | SHMUP / Bullet Hell |
+| 🌍 | Thế giới mở / Sandbox |
+| 🕹 | Indie |
+| 💀 | Souls-like |
+| 🏎 | Đua xe / Thể thao |
+| 📖 | Cốt truyện |
+| 🏗 | Mô phỏng / Chiến thuật |
+| 🏙 | Xây thành |
+| 🥊 | Đối kháng |
+| 🥷 | Lén lút / Gián điệp |
+| ⛏ | Sinh tồn / Chế tạo |
+| 🎲 | Roguelike / Roguelite |
+| 🗺 | Metroidvania |
+| 🌐 | MMO / Trực tuyến |
+| 🎵 | Âm nhạc / Nhịp điệu |
+| 🧩 | Giải đố |
+| 🏰 | Tower Defense |
+| 🃏 | Bài / Card |
+| 🎴 | Deck Builder |
+| 🤖 | Auto Battler |
+| 🏆 | Battle Royale |
+| ♟ | Chiến thuật theo lượt |
+| 🚀 | Không gian / Sci-Fi |
+| 🌾 | Nông trại / Life Sim |
+| 🎬 | FMV / Phim tương tác |
+| 💬 | Visual Novel |
+
+---
+
+## 3. Cảnh báo nội dung (96, chia nhóm)
+
+Cảnh báo được chọn sẽ thêm vào khối `⚠ CONTENT WARNINGS` trong description, trước phần timestamp. Mỗi nhóm có thể thu gọn trong editor; cảnh báo hiển thị theo thứ tự người dùng chọn.
+
+### Spoiler (6)
+
+Spoiler cốt truyện / ending · Spoiler ending · Spoiler ending thật · Spoiler hậu game / NG+ · Spoiler ending bí mật · Spoiler cốt truyện DLC
+
+### Sức khỏe / Quang nhạy (6)
+
+Đèn nháy · Say tàu xe · Kích thích migraine · Âm thanh lớn / đột ngột · Hiệu ứng strobe · Rung hình mạnh
+
+### Ám ảnh / Phobia (16)
+
+Jumpscare · Sợ độ cao (acrophobia) · Sợ lỗ / cụm (trypophobia) · Sợ nước sâu (thalassophobia) · Sợ không gian kín (claustrophobia) · Sợ nhện (arachnophobia) · Sợ côn trùng (entomophobia) · Sợ rắn (ophidiophobia) · Sợ chó (cynophobia) · Sợ bóng tối (nyctophobia) · Sợ lửa (pyrophobia) · Sợ búp bê (pediophobia) · Sợ máu (hemophobia) · Sợ chú hề (coulrophobia) · Sợ chết đuối (ablutophobia) · Sợ bị chôn sống (taphophobia)
+
+### Sức khỏe tâm thần (17)
+
+Cảnh gây lo âu · Trầm cảm · Rối loạn ăn uống · Sử dụng chất kích thích · Tự hại / tự tử · PTSD · Kim tiêm · Dịch cơ thể · Mang thai / sinh nở kinh dị · Bệnh tật / nhiễm trùng · Lưỡng cực · OCD · Hoảng loạn · Phân ly · Hoang tưởng · Suy nghĩ xâm nhập · Y khoa kinh dị
+
+### Nội dung nhạy cảm / 18+ (26)
+
+Máu me · 18+ · Hình ảnh gây khó chịu · Bạo hành động vật · Bạo lực với trẻ em · Bạo lực gia đình · Tham chiếu xâm hại tình dục · Tra tấn · Tôn giáo · Bạo lực chiến tranh · Phân biệt đối xử · Bạo lực nhà nước / cảnh sát · Hút thuốc / uống rượu · Giết người chi tiết · Tà giáo / huyền bí · Thao túng tâm lý · Mất mát / đau buồn · Bắt cóc · Phát ngôn thù hận · Tội ác lịch sử · Nô lệ · Khủng bố · Bắt nạt · Thử nghiệm trên người · Ăn thịt người · Hạt nhân / phóng xạ
+
+### Kinh dị nặng (12)
+
+Mắt / cụm mắt · Body horror (biến dạng cơ thể) · Mặt biến dạng / cắt xén · Kinh dị vũ trụ · Máu me / phân thây cực độ · Phân hủy, thối rữa, dòi bọ · Cắt xẻo / cụt chi · Liminal space · Analog horror / VHS · Phi thực tế / méo mó · Truy đuổi · Thực thể / SCP
+
+### Thông tin về playstyle (10)
+
+Lần đầu chơi (blind) · Không spoiler trong chat · Chế độ easy / story · Chế độ khó cao · Permadeath / Iron Man · Thử speedrun · 100% completionist · Đang học cơ chế · Chơi lần đầu · Chơi lại / NG+
+
+### Thông tin về gameplay (4)
+
+Dùng mod · Bật cheat / debug · Dùng glitch · Có guide hỗ trợ
+
+---
+
+## 4. Bảo trì
+
+Khi thêm mục mới vào bất kỳ file nguồn nào:
+
+1. **Loại video** → thêm vào [`src/config/video-types.ts`](../../../src/config/video-types.ts) VÀ thêm dòng vào mục 1 ở trên.
+2. **Thể loại** → thêm vào [`src/config/genres.ts`](../../../src/config/genres.ts) VÀ thêm dòng vào mục 2.
+3. **Cảnh báo nội dung** → thêm vào nhóm phù hợp ở [`src/config/content-warning-groups.ts`](../../../src/config/content-warning-groups.ts) VÀ thêm label vào đúng nhóm ở mục 3 — giữ số đếm trong tiêu đề chính xác.
+4. Cập nhật cả bản gốc EN tại [`docs/CONTENT-INVENTORY.md`](../../CONTENT-INVENTORY.md) trong cùng PR.
+
+Sai lệch giữa file này và file nguồn được xem là lỗi tài liệu — mở issue hoặc PR.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yt-desc-gen",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yt-desc-gen",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yt-desc-gen",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5535,7 +5535,7 @@ dependencies = [
 
 [[package]]
 name = "yt-desc-gen"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yt-desc-gen"
-version = "0.17.1"
+version = "0.18.0"
 description = "YouTube Gameplay Description Generator"
 authors = ["poli0981"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "YTDescGen",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "identifier": "com.skullmute.ytdescgen",
   "build": {
     "beforeBuildCommand": "npm run build",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import { OutputPage } from "@pages/OutputPage";
 import { checkDataFileHealth } from "@utils/storage-adapter";
 import { hydrateLogStore } from "@store/log-store";
 import { useSettingsStore } from "@store/settings-store";
-import "@i18n/index";
+import i18n from "@i18n/index";
 
 const ProfilesPage = lazy(() =>
   import("@pages/ProfilesPage").then((m) => ({ default: m.ProfilesPage })),
@@ -66,6 +66,36 @@ export default function App() {
     // every settings tweak.
     const retentionDays = useSettingsStore.getState().logRetentionDays;
     void hydrateLogStore(retentionDays);
+  }, []);
+
+  // v0.18.0: bridge the persisted `appLanguage` setting back to i18next.
+  //
+  // i18n is initialised synchronously at module load with `fallbackLng:
+  // "en"` and no `lng` field — so on a fresh app boot the UI renders in
+  // English even when localStorage / settings.json contain a non-English
+  // preference. Zustand's persist middleware rehydrates the store
+  // synchronously from localStorage *before* React mounts, and the
+  // storage-adapter then *asynchronously* reads the Tauri `settings.json`
+  // and may overwrite the value again. We cover both paths:
+  //
+  //   1. Read the current `appLanguage` at mount time and push it into
+  //      i18n — handles the synchronous localStorage hydrate.
+  //   2. Subscribe to subsequent changes so the async Tauri rehydrate
+  //      (and any future user-driven switch via Header / SettingsPage)
+  //      also propagates. The Header/SettingsPage callsites still call
+  //      `i18n.changeLanguage` directly, which is now redundant but
+  //      harmless — the subscribe is the single source of truth.
+  useEffect(() => {
+    const initialLang = useSettingsStore.getState().appLanguage;
+    if (initialLang && i18n.language !== initialLang) {
+      void i18n.changeLanguage(initialLang);
+    }
+    const unsub = useSettingsStore.subscribe((state, prev) => {
+      if (state.appLanguage !== prev.appLanguage) {
+        void i18n.changeLanguage(state.appLanguage);
+      }
+    });
+    return () => unsub();
   }, []);
 
   return (

--- a/src/components/editor/VietnameseDonateEditor.tsx
+++ b/src/components/editor/VietnameseDonateEditor.tsx
@@ -1,6 +1,13 @@
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Input } from "@components/ui/Input";
+import { Select } from "@components/ui/Select";
 import { useEditorStore } from "@store/editor-store";
+import {
+  VIETNAMESE_BANKS,
+  VIETNAMESE_BANK_OTHER,
+  isCustomVietnameseBank,
+} from "@config/vietnamese-banks";
 
 /**
  * Vietnam-specific donate fields — bank transfer + e-wallets. The
@@ -13,10 +20,45 @@ import { useEditorStore } from "@store/editor-store";
  * output language — we don't want creators to have to flip language
  * just to fill in their bank info, and the data is preserved in the
  * draft either way.
+ *
+ * v0.18.0: when the output language is Vietnamese, the bank-name field
+ * upgrades to a dropdown sourced from
+ * {@link VIETNAMESE_BANKS}. Picking "Khác" (Other) reveals an inline
+ * text input so the field still accepts unlisted / digital-only / less
+ * common banks. The persisted shape is unchanged — `vnBankName` is
+ * still a `string` — so saved profiles and exports keep round-tripping.
  */
 export function VietnameseDonateEditor() {
   const { t } = useTranslation("ui");
   const store = useEditorStore();
+  const language = useEditorStore((s) => s.language);
+  const vnBankName = useEditorStore((s) => s.vnBankName);
+
+  const isVi = language === "vi";
+
+  // Sticky flag for the "user explicitly chose Other from the dropdown"
+  // case. We can't derive it purely from `vnBankName` because the user
+  // might pick "Other" with the field still empty — at that point the
+  // value is `""`, which the auto-detector would treat as "use the
+  // dropdown placeholder". The initial value still uses the auto-detect
+  // (any non-preset saved name lights up custom mode on mount), so a
+  // reload of e.g. "Citibank Vietnam" renders correctly without the
+  // sticky flag needing to be hydrated.
+  const [otherSticky, setOtherSticky] = useState(
+    () => isVi && isCustomVietnameseBank(vnBankName ?? ""),
+  );
+
+  const customMode =
+    isVi && (otherSticky || isCustomVietnameseBank(vnBankName ?? ""));
+  const selectValue = customMode
+    ? VIETNAMESE_BANK_OTHER
+    : (vnBankName ?? "");
+
+  const bankOptions = [
+    { value: "", label: t("editor.vnBankNameSelectPlaceholder") },
+    ...VIETNAMESE_BANKS.map((b) => ({ value: b, label: b })),
+    { value: VIETNAMESE_BANK_OTHER, label: t("editor.vnBankNameOther") },
+  ];
 
   return (
     <div className="flex flex-col gap-3">
@@ -28,12 +70,39 @@ export function VietnameseDonateEditor() {
       </div>
 
       <div className="grid grid-cols-2 gap-3">
-        <Input
-          label={t("editor.vnBankName")}
-          placeholder={t("editor.vnBankNamePlaceholder")}
-          value={store.vnBankName ?? ""}
-          onChange={(e) => store.set("vnBankName", e.target.value)}
-        />
+        {isVi ? (
+          <div className="flex flex-col gap-2">
+            <Select
+              label={t("editor.vnBankName")}
+              options={bankOptions}
+              value={selectValue}
+              onChange={(v) => {
+                if (v === VIETNAMESE_BANK_OTHER) {
+                  // Keep any value the creator already had — pre-existing
+                  // free-form names should survive a Khác re-selection.
+                  setOtherSticky(true);
+                } else {
+                  setOtherSticky(false);
+                  store.set("vnBankName", v);
+                }
+              }}
+            />
+            {customMode && (
+              <Input
+                placeholder={t("editor.vnBankNamePlaceholder")}
+                value={vnBankName ?? ""}
+                onChange={(e) => store.set("vnBankName", e.target.value)}
+              />
+            )}
+          </div>
+        ) : (
+          <Input
+            label={t("editor.vnBankName")}
+            placeholder={t("editor.vnBankNamePlaceholder")}
+            value={vnBankName ?? ""}
+            onChange={(e) => store.set("vnBankName", e.target.value)}
+          />
+        )}
         <Input
           label={t("editor.vnBankAccount")}
           placeholder={t("editor.vnBankAccountPlaceholder")}

--- a/src/config/vietnamese-banks.ts
+++ b/src/config/vietnamese-banks.ts
@@ -1,0 +1,79 @@
+/**
+ * Vietnamese banks dropdown options for the donate / Vietnam-specific
+ * bank field. Sourced from the State Bank of Vietnam's published list
+ * (sbv.gov.vn) of operating credit institutions as of 2026: Big 4
+ * state-owned commercial banks, top 22 joint-stock commercial banks
+ * (TMCP) by retail presence, and the four most-recognised 100%
+ * foreign-owned banks operating in Vietnam.
+ *
+ * Order is intentional, not alphabetical: Big 4 first (highest brand
+ * recognition for retail transfers), then the dominant private TMCP
+ * banks roughly by retail footprint, then the foreign banks. A
+ * sentinel `__other__` option is appended by the editor component
+ * itself so the renderer can surface a fall-through text input for
+ * banks the creator's audience uses that aren't on the list (e.g.
+ * regional / digital-only banks).
+ *
+ * Values double as labels — the bank's common Vietnamese display name
+ * is what gets persisted into the editor draft and rendered into the
+ * Vietnamese donate block. Keep the string spellings stable: changing
+ * one would silently turn a previously-saved profile into a "custom"
+ * entry on next render. If a bank rebrands (e.g. LienVietPostBank →
+ * LPBank in 2024), add the new name and keep the old as an alias in
+ * a separate constant rather than mutating in place.
+ */
+export const VIETNAMESE_BANKS = [
+  // Big 4 state-owned commercial banks
+  "Vietcombank",
+  "BIDV",
+  "VietinBank",
+  "Agribank",
+  // Top joint-stock commercial banks (TMCP), roughly by retail presence
+  "Techcombank",
+  "MB Bank",
+  "ACB",
+  "VPBank",
+  "TPBank",
+  "Sacombank",
+  "HDBank",
+  "VIB",
+  "SHB",
+  "Eximbank",
+  "OCB",
+  "MSB",
+  "LPBank",
+  "SeABank",
+  "ABBank",
+  "BAC A Bank",
+  "PVcomBank",
+  "NCB",
+  "Nam A Bank",
+  "KienlongBank",
+  "Saigonbank",
+  "VietABank",
+  "Vietbank",
+  "BVBank",
+  // 100% foreign-owned banks with the strongest retail presence in VN
+  "HSBC Vietnam",
+  "Standard Chartered",
+  "Shinhan Bank",
+  "UOB Vietnam",
+] as const;
+
+export type VietnameseBank = (typeof VIETNAMESE_BANKS)[number];
+
+/** Sentinel select-option value the editor uses to surface a fall-through
+ *  text input. Kept as a non-bank-name string so a real bank could
+ *  never collide with it. */
+export const VIETNAMESE_BANK_OTHER = "__other__" as const;
+
+/**
+ * True when `value` is a non-empty string that doesn't match any preset
+ * bank — i.e. the editor should render the custom text input below the
+ * select. Pure helper so the conditional logic in
+ * `VietnameseDonateEditor` stays declarative.
+ */
+export function isCustomVietnameseBank(value: string): boolean {
+  if (!value) return false;
+  return !(VIETNAMESE_BANKS as readonly string[]).includes(value);
+}

--- a/src/i18n/locales/_schema.json
+++ b/src/i18n/locales/_schema.json
@@ -32,7 +32,7 @@
       "gpu_brand", "gpu_series", "gpu_model", "gpu_custom",
       "ram_size", "ram_ddr",
       "vnDonate", "vnDonateHelp",
-      "vnBankName", "vnBankNamePlaceholder",
+      "vnBankName", "vnBankNamePlaceholder", "vnBankNameSelectPlaceholder", "vnBankNameOther",
       "vnBankAccount", "vnBankAccountPlaceholder",
       "vnBankHolder", "vnBankHolderPlaceholder",
       "vnMomo", "vnMomoPlaceholder",

--- a/src/i18n/locales/en/ui.json
+++ b/src/i18n/locales/en/ui.json
@@ -144,6 +144,8 @@
     "vnDonateHelp": "Only rendered into the description when output language is Vietnamese.",
     "vnBankName": "Bank name",
     "vnBankNamePlaceholder": "e.g. Vietcombank, MB Bank, Techcombank",
+    "vnBankNameSelectPlaceholder": "— Select bank —",
+    "vnBankNameOther": "Other (type manually)",
     "vnBankAccount": "Account number",
     "vnBankAccountPlaceholder": "e.g. 0123456789",
     "vnBankHolder": "Account holder",

--- a/src/i18n/locales/es/ui.json
+++ b/src/i18n/locales/es/ui.json
@@ -144,6 +144,8 @@
     "vnDonateHelp": "Only rendered into the description when output language is Vietnamese.",
     "vnBankName": "Bank name",
     "vnBankNamePlaceholder": "e.g. Vietcombank, MB Bank, Techcombank",
+    "vnBankNameSelectPlaceholder": "— Select bank —",
+    "vnBankNameOther": "Other (type manually)",
     "vnBankAccount": "Account number",
     "vnBankAccountPlaceholder": "e.g. 0123456789",
     "vnBankHolder": "Account holder",

--- a/src/i18n/locales/ja/ui.json
+++ b/src/i18n/locales/ja/ui.json
@@ -144,6 +144,8 @@
     "vnDonateHelp": "Only rendered into the description when output language is Vietnamese.",
     "vnBankName": "Bank name",
     "vnBankNamePlaceholder": "e.g. Vietcombank, MB Bank, Techcombank",
+    "vnBankNameSelectPlaceholder": "— Select bank —",
+    "vnBankNameOther": "Other (type manually)",
     "vnBankAccount": "Account number",
     "vnBankAccountPlaceholder": "e.g. 0123456789",
     "vnBankHolder": "Account holder",

--- a/src/i18n/locales/ko/ui.json
+++ b/src/i18n/locales/ko/ui.json
@@ -144,6 +144,8 @@
     "vnDonateHelp": "Only rendered into the description when output language is Vietnamese.",
     "vnBankName": "Bank name",
     "vnBankNamePlaceholder": "e.g. Vietcombank, MB Bank, Techcombank",
+    "vnBankNameSelectPlaceholder": "— Select bank —",
+    "vnBankNameOther": "Other (type manually)",
     "vnBankAccount": "Account number",
     "vnBankAccountPlaceholder": "e.g. 0123456789",
     "vnBankHolder": "Account holder",

--- a/src/i18n/locales/vi/ui.json
+++ b/src/i18n/locales/vi/ui.json
@@ -144,6 +144,8 @@
     "vnDonateHelp": "Chỉ hiển thị trong description khi ngôn ngữ đầu ra là Tiếng Việt.",
     "vnBankName": "Tên ngân hàng",
     "vnBankNamePlaceholder": "vd: Vietcombank, MB Bank, Techcombank",
+    "vnBankNameSelectPlaceholder": "— Chọn ngân hàng —",
+    "vnBankNameOther": "Khác (nhập tay)",
     "vnBankAccount": "Số tài khoản",
     "vnBankAccountPlaceholder": "vd: 0123456789",
     "vnBankHolder": "Chủ tài khoản",

--- a/src/i18n/locales/zh/ui.json
+++ b/src/i18n/locales/zh/ui.json
@@ -144,6 +144,8 @@
     "vnDonateHelp": "Only rendered into the description when output language is Vietnamese.",
     "vnBankName": "Bank name",
     "vnBankNamePlaceholder": "e.g. Vietcombank, MB Bank, Techcombank",
+    "vnBankNameSelectPlaceholder": "— Select bank —",
+    "vnBankNameOther": "Other (type manually)",
     "vnBankAccount": "Account number",
     "vnBankAccountPlaceholder": "e.g. 0123456789",
     "vnBankHolder": "Account holder",

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { useDocumentTitle } from "@hooks/use-document-title";
-import { FolderOpen, Save, Upload } from "lucide-react";
+import { Save, Upload } from "lucide-react";
 import { Toggle } from "@components/ui/Toggle";
 import { Select } from "@components/ui/Select";
 import { Input } from "@components/ui/Input";
@@ -9,9 +9,14 @@ import { ChipGroup } from "@components/ui/ChipGroup";
 import { ValidatedInput } from "@components/ui/ValidatedInput";
 import { SUPPORTED_LANGUAGES } from "@i18n/index";
 import { GENRES, type GenreId } from "@config/genres";
-import { useSettingsStore, healSettings } from "@store/settings-store";
+import { useSettingsStore, healSettings, extractData } from "@store/settings-store";
 import { validatePlaylistUrl } from "@utils/validation";
 import { IS_TAURI } from "@utils/platform";
+import {
+  exportTypedToJsonFile,
+  importParsedFromJsonFile,
+} from "@utils/import-export";
+import { resolveForType } from "@utils/file-schema";
 import {
   MAX_GENRES,
   type SupportedLanguage,
@@ -24,43 +29,36 @@ import { logger } from "@utils/logger";
 
 const SETTINGS_STORE_KEY = "ytdescgen-settings";
 
-async function openSettingsFolder() {
-  try {
-    const { appDataDir } = await import("@tauri-apps/api/path");
-    const { openPath } = await import("@tauri-apps/plugin-opener");
-    const { invoke } = await import("@tauri-apps/api/core");
-    const dir = await appDataDir();
-    // Windows fix (v0.14.0): `appDataDir()` only returns the path string —
-    // the folder itself is created lazily, on the first call to
-    // `save_to_file`. On a fresh install where no setting has yet been
-    // written, the directory doesn't exist, and `openPath()` falls through
-    // to Explorer which surfaces "Windows cannot find ... com.skullmute
-    // .ytdescgen". Pre-create the folder so the shell never sees a
-    // non-existent path.
-    await invoke("ensure_dir", { path: dir });
-    await openPath(dir);
-  } catch (e) {
-    toast.error("Could not open settings folder");
-    logger.error("settings", "Failed to open settings folder", String(e));
-  }
+/**
+ * Identifier-fingerprint check: pre-v0.18.0 exports were a raw dump of
+ * the entire on-disk `settings.json`, keyed by every store's
+ * localStorage name (`ytdescgen-settings`, `ytdescgen-profiles`, …).
+ * v0.18.0 narrowed Export Settings to write only the Settings store,
+ * wrapped in the typed envelope used by the rest of the Profiles tab.
+ * Detect the legacy shape so we can refuse the import with a friendly
+ * message instead of silently injecting profiles / templates / history
+ * into the Settings store.
+ */
+function isLegacyMultiStoreDump(parsed: unknown): boolean {
+  if (!parsed || typeof parsed !== "object") return false;
+  const asRecord = parsed as Record<string, unknown>;
+  if ("_type" in asRecord) return false; // already an envelope
+  return SETTINGS_STORE_KEY in asRecord;
 }
 
-async function exportSettingsToFile() {
+/**
+ * Write the Settings store to disk as a typed envelope JSON file.
+ * v0.18.0 replaced the old "dump the entire on-disk settings.json"
+ * approach (which leaked Profiles / Templates / History into the
+ * exported file). The envelope wrapper matches what the Profiles tab
+ * produces, so users can swap export files between machines without
+ * worrying about which tab they're using.
+ */
+function exportSettingsToFile() {
   try {
-    const { save } = await import("@tauri-apps/plugin-dialog");
-    const { invoke } = await import("@tauri-apps/api/core");
-    const { appDataDir } = await import("@tauri-apps/api/path");
-    const dir = await appDataDir();
-    // Ensure the folder exists — same reason as `openSettingsFolder`.
-    // On a fresh install nobody may have triggered a settings write yet.
-    await invoke("ensure_dir", { path: dir });
-    const srcPath = `${dir}settings.json`;
-    const content: string = await invoke("read_from_file", { path: srcPath });
-    const destPath = await save({ defaultPath: "ytdescgen-settings.json" });
-    if (destPath) {
-      await invoke("save_to_file", { path: destPath, content });
-      toast.success("Settings exported!");
-    }
+    const data = extractData(useSettingsStore.getState());
+    exportTypedToJsonFile("settings", data, "ytdescgen-settings.json");
+    toast.success("Settings exported!");
   } catch (e) {
     toast.error("Export failed");
     logger.error("settings", "Failed to export settings", String(e));
@@ -68,79 +66,101 @@ async function exportSettingsToFile() {
 }
 
 /**
- * Import settings from a user-picked `.json` file. Accepts either the
- * full multi-store dump that {@link exportSettingsToFile} produces
- * (object keyed by `ytdescgen-settings` etc.) or a bare `SettingsData`
- * payload — the latter so hand-edited / partial files keep working.
+ * Import settings from a user-picked `.json` file. Accepts the
+ * v0.18.0 envelope shape (`{ _type: "settings", data: {...} }`) and a
+ * bare `SettingsData` object (hand-edited / shared partial files).
+ * Pre-v0.18.0 multi-store dumps are rejected with a friendly toast —
+ * see {@link isLegacyMultiStoreDump} for the rationale.
  *
- * All five failure modes from the v0.14 plan are reported as distinct
- * toasts (cancel, empty, parse, shape, unknown). `healSettings()` then
- * back-fills any missing keys, so a partial import never leaves the
- * store in an incomplete state. The healed payload is dispatched via
- * `setState`, which both updates React and triggers the persist
- * `subscribe` → `saveSettings`, syncing localStorage *and* the on-disk
- * `settings.json` (so re-opening the app doesn't undo the import).
+ * `healSettings()` back-fills any missing keys, so a partial import
+ * never leaves the store in an incomplete state. The healed payload is
+ * dispatched via `setState`, which both updates React and triggers the
+ * persist `subscribe` → `saveSettings`, syncing localStorage *and* the
+ * on-disk `settings.json` (so re-opening the app doesn't undo the
+ * import).
  */
 async function importSettingsFromFile() {
-  try {
-    const { open } = await import("@tauri-apps/plugin-dialog");
-    const { invoke } = await import("@tauri-apps/api/core");
-    const path = await open({
-      filters: [{ name: "JSON", extensions: ["json"] }],
-    });
-    if (typeof path !== "string") return; // user cancelled
-
-    let content: string;
-    try {
-      content = await invoke("read_from_file", { path });
-    } catch (e) {
-      toast.error("Could not read file");
-      logger.error("settings", `read_from_file failed for "${path}"`, String(e));
-      return;
+  const read = await importParsedFromJsonFile();
+  if (!read.ok) {
+    // `importParsedFromJsonFile` only emits these four failure kinds —
+    // `wrong-shape` / `newer-schema` come from `importTypedFromJsonFile`
+    // (which layers `resolveForType` on top). The `default` keeps TS
+    // happy with the wider `ImportFailure` union without being reachable
+    // at runtime.
+    switch (read.failure.kind) {
+      case "cancelled":
+        return; // silent
+      case "read-failed":
+        toast.error(`Could not read file: ${read.failure.message}`);
+        logger.error("settings", "read-failed during settings import", read.failure.message);
+        return;
+      case "empty":
+        toast.error("File is empty");
+        logger.warn("settings", "Import file is empty");
+        return;
+      case "parse-error":
+        toast.error(`Invalid JSON syntax: ${read.failure.message}`);
+        logger.error("settings", "JSON parse failed during settings import", read.failure.message);
+        return;
+      default:
+        toast.error("Import failed");
+        logger.error("settings", "Unexpected import failure", JSON.stringify(read.failure));
+        return;
     }
-
-    if (!content.trim()) {
-      toast.error("File is empty");
-      logger.warn("settings", `Import file is empty: "${path}"`);
-      return;
-    }
-
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(content);
-    } catch (e) {
-      toast.error("Invalid JSON syntax");
-      logger.error("settings", `JSON parse failed for "${path}"`, String(e));
-      return;
-    }
-
-    if (!parsed || typeof parsed !== "object") {
-      toast.error("Invalid settings file");
-      logger.warn("settings", "Imported JSON is not an object");
-      return;
-    }
-
-    // Accept both shapes: full multi-store dump (matches the file
-    // produced by `exportSettingsToFile`) or a bare SettingsData
-    // object. The latter lets users hand-edit / share partial files.
-    const asRecord = parsed as Record<string, unknown>;
-    const raw =
-      SETTINGS_STORE_KEY in asRecord ? asRecord[SETTINGS_STORE_KEY] : parsed;
-
-    const healed = healSettings(raw);
-    useSettingsStore.setState(healed);
-    // Re-apply the theme class on <html> — `setTheme` does this in the
-    // store action, but `setState` bypasses actions, so the class can
-    // get out of sync if the imported theme differs from the current.
-    document.documentElement.classList.toggle("dark", healed.theme === "dark");
-    document.documentElement.classList.toggle("light", healed.theme === "light");
-
-    toast.success("Settings imported");
-    logger.info("settings", `Imported settings from "${path}"`);
-  } catch (e) {
-    toast.error("Import failed");
-    logger.error("settings", "Unexpected error during settings import", String(e));
   }
+
+  const { shape } = read;
+
+  // Pre-v0.18.0 multi-store dump → refuse with a targeted message so
+  // the user knows to re-export from v0.18.0+ rather than silently
+  // accept a file that would pollute the settings store with profile /
+  // template / history data.
+  if (isLegacyMultiStoreDump(shape.data)) {
+    toast.error(
+      "Legacy export format from v0.17.x or earlier is no longer supported. Please re-export from v0.18.0+.",
+    );
+    logger.warn("settings", "Refused legacy multi-store dump on import");
+    return;
+  }
+
+  const resolved = resolveForType(shape, "settings");
+  if (!resolved.ok) {
+    switch (resolved.reason.kind) {
+      case "wrong-type":
+        toast.error(
+          `This file looks like a ${resolved.reason.actual} export, not settings.`,
+        );
+        logger.warn(
+          "settings",
+          `Refused wrong-type file on settings import (got ${resolved.reason.actual})`,
+        );
+        return;
+      case "unknown-shape":
+        toast.error("File shape is not recognised — choose a YTDescGen settings export.");
+        logger.warn("settings", "Refused unknown-shape file on settings import");
+        return;
+      case "newer-schema":
+        toast.error(
+          `File was exported by a newer version (schema v${resolved.reason.actual}; this build supports up to v${resolved.reason.supported}). Update YTDescGen.`,
+        );
+        logger.warn(
+          "settings",
+          `Refused newer-schema settings file (file=v${resolved.reason.actual} supported=v${resolved.reason.supported})`,
+        );
+        return;
+    }
+  }
+
+  const healed = healSettings(resolved.data);
+  useSettingsStore.setState(healed);
+  // Re-apply the theme class on <html> — `setTheme` does this in the
+  // store action, but `setState` bypasses actions, so the class can
+  // get out of sync if the imported theme differs from the current.
+  document.documentElement.classList.toggle("dark", healed.theme === "dark");
+  document.documentElement.classList.toggle("light", healed.theme === "light");
+
+  toast.success("Settings imported");
+  logger.info("settings", "Imported settings from file");
 }
 
 export function SettingsPage() {
@@ -189,10 +209,6 @@ export function SettingsPage() {
         <h1 className="text-lg font-bold text-text-primary">{t("settings.title")}</h1>
         {IS_TAURI && (
           <div className="flex gap-2">
-            <Button variant="ghost" size="sm" onClick={openSettingsFolder}>
-              <FolderOpen className="h-3.5 w-3.5" />
-              Open Folder
-            </Button>
             <Button variant="ghost" size="sm" onClick={importSettingsFromFile}>
               <Upload className="h-3.5 w-3.5" />
               Import

--- a/src/store/settings-store.ts
+++ b/src/store/settings-store.ts
@@ -90,7 +90,17 @@ export const useSettingsStore = create<SettingsState>()(
   ),
 );
 
-function extractData(state: SettingsData): SettingsData {
+/**
+ * Strip the {@link SettingsState} action functions from a live store
+ * snapshot, returning only the persisted {@link SettingsData} fields.
+ * Used by the persist middleware's `partialize` hook and by
+ * {@link SettingsPage}'s typed export so a JSON file written from the
+ * Settings tab carries only data — not the actions that would otherwise
+ * leak into the file as `null` values.
+ *
+ * Pure — safe to call from anywhere, no side effects.
+ */
+export function extractData(state: SettingsData): SettingsData {
   return {
     appLanguage: state.appLanguage,
     defaultOutputLanguage: state.defaultOutputLanguage,


### PR DESCRIPTION
## Summary

Bundles one new feature, two persistence-layer bug fixes, one cleanup, and a transparency doc into `v0.18.0`. Each piece is independent and rolls back cleanly.

### 1. Vietnamese bank dropdown (`feat`)

When the output language is `vi`, the *Bank name* field in `VietnameseDonateEditor` upgrades from a plain text input to a [`<Select>`](src/components/ui/Select.tsx) listing 30 of Vietnam's most-used banks — Big 4 state-owned (Vietcombank, BIDV, VietinBank, Agribank) + top 22 joint-stock + 4 foreign banks with the strongest VN retail footprint. Sourced from the State Bank of Vietnam's 2026 register via bankervn.com.

Picking *Khác (nhập tay)* reveals an inline text input so unlisted / digital-only / regional banks still work. Persisted shape (`vnBankName: string`) is unchanged — saved profiles round-trip cleanly. When the output language is **not** `vi`, the field falls back to the legacy text input.

### 2. UI language reverts to English on relaunch (`fix`)

i18next initialised synchronously with `fallbackLng: "en"` while Zustand's persist middleware rehydrated `appLanguage` asynchronously (Tauri `settings.json`) or synchronously (localStorage). Nothing bridged the rehydrated value back to i18n, so the UI rendered English even when the saved setting was Vietnamese.

[`App.tsx`](src/App.tsx) now reads `appLanguage` at mount, calls `i18n.changeLanguage` once, then subscribes for future changes so both async-Tauri and external-mutation paths propagate to i18n.

### 3. Settings JSON export was a multi-store dump (`fix`)

Pre-v0.18.0 *Export Settings* copied the on-disk `settings.json` — which contains **every** Zustand store keyed by its localStorage name (settings + profiles + presets + templates + history). The new flow uses `exportTypedToJsonFile("settings", …)` — the same envelope-typed pipeline the Profiles tab already uses.

Importer rejects pre-v0.18.0 multi-store dumps with a friendly toast ("Legacy export format from v0.17.x or earlier is no longer supported. Please re-export from v0.18.0+") instead of silently injecting profile / template / history rows into the Settings store. `extractData` promoted from private helper to named export so the SettingsPage can use it.

### 4. Removed "Open Folder" button (`cleanup`)

Niche utility — most users never opened the app-data folder, and Tauri-only meant web builds never saw it. ~25 LOC removed including the unused `FolderOpen` icon import. The `ensure_dir` Rust command stays in `src-tauri` for other paths that still need it.

### 5. Content Inventory doc (EN + VI) (`docs`)

New static manifest at [docs/CONTENT-INVENTORY.md](docs/CONTENT-INVENTORY.md) + Vietnamese mirror listing every video type (20), genre (41), and content warning (96 across 8 groups) the editor surfaces. Linked from README's Documentation table. Transparency aid for anyone evaluating the editor's coverage without reading source.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test:run` — **426/426 pass** (no test count change)
- [x] `npm run validate:locales` — **720/720 ui keys per locale** (+2 from v0.17.1)
- [x] `npm run build` — 427.46 kB main bundle (under 500 kB cap)
- [ ] Manual smoke test — Vi UI: bank dropdown shows 30 banks, "Khác" reveals text input, saved Citibank Vietnam auto-detects as custom mode
- [ ] Manual smoke test — Set UI=vi → close app → reopen → UI stays vi (no flash to en)
- [ ] Manual smoke test — Export Settings → file contains only `_type: "settings"` envelope, no profile/template/history data
- [ ] Manual smoke test — Import pre-v0.18.0 multi-store dump → rejected with friendly toast
- [ ] Manual smoke test — "Open Folder" button absent in Settings

## Migration notes

- **Pre-v0.18.0 settings exports (multi-store dumps)** are rejected on import. Users with such backups should re-export from v0.18.0+.
- **Profiles / presets / templates / history** exports on the Profiles tab are unchanged — v0.17.x files still import.
- **Saved `vnBankName` values** not in the preset list auto-detect as custom mode on first render. No data loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)