### PR TITLE
ci(v0.24.2): harden Linux AppImage build, rebuild to ship Linux binaries

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -74,6 +74,14 @@ jobs:
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # AppImage bundling on hosted runners flakes: linuxdeploy (itself
+          # an AppImage) needs FUSE to mount, which GitHub runners don't
+          # reliably provide → "failed to run linuxdeploy". Extract-and-run
+          # avoids FUSE; NO_STRIP skips a strip pass that also intermittently
+          # fails. (No-op on Windows / macOS.) Transient CDN 504s while
+          # *fetching* linuxdeploy are handled by re-running the job.
+          APPIMAGE_EXTRACT_AND_RUN: 1
+          NO_STRIP: true
         with:
           tagName: ${{ github.event.inputs.tag || 'v__VERSION__' }}
           releaseName: "YTDescGen ${{ github.event.inputs.tag || 'v__VERSION__' }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to YTDescGen ship as tagged releases on `main`.
 
+## v0.24.2 — 2026-06-08
+
+CI-only patch to recover the Linux desktop binaries. **No application code
+changes** — identical app to v0.24.1.
+
+### CI
+
+- **Hardened the Linux AppImage build** ([.github/workflows/release-desktop.yml](.github/workflows/release-desktop.yml)) — set `APPIMAGE_EXTRACT_AND_RUN=1` and `NO_STRIP=true` on the `tauri-action` step. `linuxdeploy` (itself an AppImage) needs FUSE to mount, which GitHub-hosted runners don't reliably provide → intermittent `failed to run linuxdeploy`. Extract-and-run sidesteps FUSE; `NO_STRIP` skips a strip pass that also flakes. No-op on Windows / macOS.
+- **Rebuilt to ship the Linux binaries** (`.deb` / `.AppImage` / `.rpm`) that v0.24.1 missed when the AppImage tooling download hit a sustained upstream GitHub-CDN `http status: 504` during bundling. v0.24.1 published with Windows + macOS binaries; this tag re-runs the full matrix once the transient outage cleared.
+
 ## v0.24.1 — 2026-06-08
 
 Maintenance patch: clears all `npm audit` advisories, drops unused Rust

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yt-desc-gen",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yt-desc-gen",
-      "version": "0.24.1",
+      "version": "0.24.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yt-desc-gen",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5535,7 +5535,7 @@ dependencies = [
 
 [[package]]
 name = "yt-desc-gen"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "tauri",
  "tauri-build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yt-desc-gen"
-version = "0.24.1"
+version = "0.24.2"
 description = "YouTube Gameplay Description Generator"
 authors = ["poli0981"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "YTDescGen",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "identifier": "com.skullmute.ytdescgen",
   "build": {
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
## v0.24.2 — CI-only patch (identical app to v0.24.1)

v0.24.1's Linux job failed on a sustained upstream GitHub-CDN **`http status: 504`** while the AppImage bundler fetched `linuxdeploy`, so v0.24.1 shipped with only Windows + macOS binaries.

### CI
- **Hardened the Linux AppImage build** — `APPIMAGE_EXTRACT_AND_RUN=1` + `NO_STRIP=true` on the `tauri-action` step. `linuxdeploy` (itself an AppImage) needs FUSE to mount, which GitHub runners don't reliably provide → intermittent `failed to run linuxdeploy`. Extract-and-run sidesteps FUSE; `NO_STRIP` skips a flaky strip pass. No-op on Windows / macOS.
- **Rebuild** to ship the `.deb` / `.AppImage` / `.rpm` binaries v0.24.1 missed.

No application code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)