### PR TITLE
ci(dependabot): ignore unfixable transitive cargo advisories (rand, glib)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# Dependabot configuration.
+#
+# This file exists only to configure SECURITY updates for cargo in /src-tauri.
+# Version updates stay disabled (open-pull-requests-limit: 0); npm and
+# GitHub Actions keep GitHub's default security-update behavior.
+#
+# Why the ignores: `rand` and `glib` are transitive dependencies of tauri,
+# and their security fixes require semver-major bumps that the dependency
+# tree does not allow, so every Dependabot security-update job for them
+# fails with `security_update_not_possible` (runs 27387346373, 27387346324):
+#
+#   rand 0.7.3 (fix: 0.8.6) pinned by
+#     tauri -> tauri-utils -> kuchikiki -> selectors -> phf_codegen 0.8
+#     -> phf_generator 0.8 (requires rand ^0.7)
+#   glib 0.18.5 (fix: 0.20.0) pinned by
+#     tauri's gtk-rs 0.18 Linux stack (gtk/gdk/gio 0.18 require glib 0.18)
+#
+# Remove these ignores once tauri updates kuchikiki / the gtk-rs bindings
+# (re-check with: cargo update -p rand@0.7.3 --precise 0.8.6 --dry-run).
+
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/src-tauri"
+    schedule:
+      interval: "weekly"
+    # No version-update PRs; this entry only feeds ignore rules to security updates.
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "rand"
+      - dependency-name: "glib"


### PR DESCRIPTION
## Problem

Dependabot "cargo in /src-tauri" security-update jobs for `rand` and `glib` fail every time `Cargo.lock` changes on main (observed at the v0.25.0 and v0.26.0 merges, runs 27387346373 and 27387346324).

`gh run view --log-failed` shows the actual error is `security_update_not_possible`:

| Dependency | Locked | Latest resolvable | Lowest non-vulnerable |
|---|---|---|---|
| `rand` | 0.7.3 | 0.7.3 | 0.8.6 |
| `glib` | 0.18.5 | 0.18.5 | 0.20.0 |

Both are transitive dependencies of tauri, and the fixes require semver-major bumps the tree does not allow. Verified locally:

```
cargo update -p rand@0.7.3 --precise 0.8.6 --dry-run
error: failed to select a version for the requirement `rand = "^0.7"`
required by package `phf_generator v0.8.0`
    ... phf_codegen 0.8.0 ... selectors 0.24.0 ... kuchikiki 0.8.8-speedreader
    ... tauri-utils 2.9.1 ... tauri 2.11.1
```

`glib` is pinned the same way by tauri''s gtk-rs 0.18 Linux stack (gtk/gdk/gio 0.18 all require glib 0.18); the fixed glib 0.20 needs the gtk-rs 0.20 bindings, which tauri 2 does not use.

So `cargo update` cannot clear these advisories — only a future tauri release that bumps kuchikiki / gtk-rs can.

## Fix

Add `.github/dependabot.yml` with a cargo entry for `/src-tauri` that:
- sets `open-pull-requests-limit: 0` so no version-update PRs start (security-only config entry),
- ignores `rand` and `glib` so Dependabot stops attempting the impossible security updates — ending the recurring red runs.

npm and GitHub Actions keep GitHub''s default security-update behavior (only the listed ecosystem/directory is affected). No `target-branch` is set, so the ignore rules apply to security updates.

`Cargo.toml` / `Cargo.lock` are untouched, so the Rust build is unaffected. The file documents when to remove the ignores and the re-check command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)