### PR TITLE
ci(node): bump workflows from EOL Node 20 to Node 22 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run typecheck

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -59,7 +59,7 @@ jobs:
           ref: ${{ github.event.inputs.tag || github.ref }}
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -27,7 +27,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 # Tauri CLI
 cargo install tauri-cli
 
-# Node.js 20+
+# Node.js 22+
 # npm already installed from web development
 
 # Platform-specific

--- a/webapp/TAURI.md
+++ b/webapp/TAURI.md
@@ -11,7 +11,7 @@ The hardware reference and toolchain versions are documented in
 ## All platforms
 
 - **Rust stable** via `rustup`. Tauri 2 currently tracks the latest stable.
-- **Node.js ≥ 25.8.1**. Tauri-action in CI uses Node 20; locally we use ≥ 25
+- **Node.js ≥ 25.8.1**. Tauri-action in CI uses Node 22; locally we use ≥ 25
   so the JetBrains and VS Code dev tools have a single shared LTS.
 
 ```bash


### PR DESCRIPTION
## Summary
- Bump `node-version: 20` → `22` in all three workflows (`ci.yml`, `deploy-web.yml`, `release-desktop.yml`). Node 20 reached end-of-life April 2026, and GitHub is removing the preinstalled Node 20 from runner images ([actions/runner-images#14029](https://github.com/actions/runner-images/issues/14029)), so setup-node currently downloads it on every run.
- Node 22 (LTS) satisfies Vite 7''s engine range (`^20.19 || >=22.12`) and matches the workflow snippets in `docs/TECH-SPEC.md`, fixing that drift.
- Sync the two doc mentions of CI''s Node version: `webapp/TAURI.md` and `docs/PACKAGING.md`.

## Verification
- CI on this PR runs the full suite on Node 22: typecheck, lint, validate:locales, tests, build.
- The Tauri release workflow uses Node only for npm/vite, so CI coverage is sufficient; no release rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)