### PR TITLE
feat(legal): first-run consent gate + Windows installer license — v0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to YTDescGen ship as tagged releases on `main`.
 
+## v0.28.0 — 2026-06-13
+
+Adds a first-run **legal consent gate**. Before the app is usable, the user
+reviews the Terms of Use, Privacy Policy, Disclaimer, and License (all already
+published at the repo root) and ticks a single "I agree" box. Acceptance is
+recorded and only re-prompts when the terms version changes — so it is a
+one-time step in normal use, and naturally re-appears in a fresh / incognito
+browser. On Windows desktop, the installer additionally shows a license page.
+
+### Added
+
+- **Legal consent gate** ([src/components/ConsentGate.tsx](src/components/ConsentGate.tsx), [src/config/legal.ts](src/config/legal.ts)) — a full-screen, non-dismissible screen rendered in place of the router until consent is recorded. Lists the four legal docs as links (open in the browser) + one combined agree checkbox; Continue is disabled until checked. Version-based re-prompt via `CURRENT_TERMS_VERSION` + `needsConsent()`; acceptance persists in the existing settings record (`legalConsentVersion` + timestamp) — **no cookie, no new storage key**.
+- **About → Legal section** ([src/pages/AboutPage.tsx](src/pages/AboutPage.tsx)) — the License/Terms/Privacy/Disclaimer docs are now linked in-app (previously only the License was), reusing the shared `LEGAL_DOCS` list.
+- **Windows installer license page** ([src-tauri/tauri.conf.json](src-tauri/tauri.conf.json), [src-tauri/installer-license.txt](src-tauri/installer-license.txt)) — `bundle.licenseFile` shows an "accept the terms" page in the MSI/NSIS installers. (macOS `.app`/Linux packages have no interactive license step — they rely on the in-app gate.)
+- **Accessible `Checkbox` primitive** ([src/components/ui/Checkbox.tsx](src/components/ui/Checkbox.tsx)) — a real `<input type="checkbox">` styled with theme tokens, distinct from the existing on/off `Toggle`.
+- **60 new locale strings** (10 keys × 6 languages: `consentGate.*` + `about.legalHeading`) + [`_schema.json`](src/i18n/locales/_schema.json); validator now expects 937 ui keys per locale (927 → 937).
+
+### Fixed
+
+- **Persisted theme is now applied on boot** ([src/main.tsx](src/main.tsx)) — `index.html` hardcodes `class="dark"`, and previously only the Header toggle wrote the theme class, so a light-theme user saw a brief dark flash on every cold start (and the new gate, which renders before the app shell, would have shown in the wrong theme). The persisted theme is now applied synchronously before first paint.
+
+### Under the hood
+
+- **+9 tests (500 → 509)** — [tests/config/legal.test.ts](tests/config/legal.test.ts) (the `needsConsent` version logic + `LEGAL_DOCS` shape; a `NaN`/Infinity version re-shows the gate) and two `legalConsentVersion` back-fill / coercion cases in [tests/store/settings-heal.test.ts](tests/store/settings-heal.test.ts).
+- Consent state is **additive** — `legalConsentVersion` / `legalConsentAt` join `SettingsData`, `initialSettings`, `extractData`, and `healSettings` (which coerces a malformed value to `0` so a corrupt file re-shows the gate, never skips it). **No persist version bump** (stays at 10).
+- The gate is a boot-time blocker but stays inside the root `ErrorBoundary`, behind a single boolean — a render error degrades to the designed error page, not a black screen.
+- Web bundle: the gate + Checkbox + legal config + English strings add ~4 kB min to the main chunk (local Rollup measure); the shipped size comes from CI's vite 8 / Rolldown build.
+- Five manifests bumped 0.27.1 → 0.28.0.
+
 ## v0.27.1 — 2026-06-13
 
 Security/dependency release. Resolves the 4 high-severity `esbuild` advisories

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -50,6 +50,8 @@ YouTube oEmbed, the Steam store API, Twitch helix, and similar services are **no
 
 The web version uses **`localStorage`**, not cookies. No cookie is set by the application. GitHub Pages itself may issue a session cookie at the platform level — that is GitHub's, not ours, and is governed by [GitHub's Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement).
 
+The first-run consent acknowledgement (added in v0.28.0) is recorded **inside the existing settings record** — a `legalConsentVersion` number plus a local timestamp — not as a separate cookie or storage key. It never leaves your device.
+
 ## Children's Privacy
 
 This application is not directed at children under 13 and does not knowingly process any personal data from anyone.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -270,6 +270,21 @@ in every locale (en/vi/ja/es/ko/zh).
 - **Non-blocking offline banner** — a dismissible bottom strip; the app stays
   fully usable offline, and a toast confirms when the connection returns.
 
+## ⚖️ Legal & Consent (v0.28)
+
+A first-run **consent gate** (`src/components/ConsentGate.tsx`, backed by the
+pure `src/config/legal.ts`) blocks the app until the user reviews the legal
+documents and ticks one "I agree" checkbox.
+
+| Aspect | Behaviour |
+|--------|-----------|
+| Documents | Terms of Use, Privacy Policy, Disclaimer, License — linked to the GitHub-hosted copies (open in the browser); also surfaced in About → Legal |
+| Acceptance | One combined checkbox; Continue disabled until checked |
+| Persistence | Stored in the existing settings record (`legalConsentVersion` + timestamp) — **no cookie, no new storage key** |
+| Re-prompt | Version-based — only when `CURRENT_TERMS_VERSION` is raised (terms changed); also re-shows in fresh / incognito storage |
+| Desktop | Same in-app gate on Windows/macOS/Linux, **plus** a license-acceptance page in the Windows MSI/NSIS installer (`bundle.licenseFile`) |
+| Layout | Full-screen, non-dismissible, theme- and locale-aware (all 6 languages) |
+
 ## 🔌 Future Extension Points
 
 | Extension | Description | Effort |

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -108,6 +108,15 @@ This creates `src-tauri/` directory.
 }
 ```
 
+> **Installer license page (v0.28).** The real `src-tauri/tauri.conf.json`
+> sets `bundle.licenseFile: "installer-license.txt"` (path relative to
+> `src-tauri/`). Tauri shows that file as an "accept the terms" page in the
+> **Windows MSI/NSIS** installers. macOS `.app`/`.dmg` and the Linux packages
+> have no interactive license step, so they rely on the app's first-run
+> consent gate instead. If a WiX/MSI build ever rejects the `.txt`, switch to
+> the per-bundler keys (`bundle.windows.wix.licenseFile` wants `.rtf`,
+> `bundle.windows.nsis.licenseFile` accepts `.txt`).
+
 ### 3. Rust Backend (src-tauri/src/main.rs)
 
 ```rust

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yt-desc-gen",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yt-desc-gen",
-      "version": "0.27.1",
+      "version": "0.28.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yt-desc-gen",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5535,7 +5535,7 @@ dependencies = [
 
 [[package]]
 name = "yt-desc-gen"
-version = "0.27.1"
+version = "0.28.0"
 dependencies = [
  "tauri",
  "tauri-build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yt-desc-gen"
-version = "0.27.1"
+version = "0.28.0"
 description = "YouTube Gameplay Description Generator"
 authors = ["poli0981"]
 edition = "2021"

--- a/src-tauri/installer-license.txt
+++ b/src-tauri/installer-license.txt
@@ -1,0 +1,30 @@
+YTDescGen — Installation & Terms Notice
+=======================================
+
+By installing and using YTDescGen, you confirm that you have read and agree
+to the following documents:
+
+  Terms of Use:  https://github.com/poli0981/youtube-generator/blob/main/TERMS.md
+  Privacy Policy: https://github.com/poli0981/youtube-generator/blob/main/PRIVACY.md
+  Disclaimer:    https://github.com/poli0981/youtube-generator/blob/main/DISCLAIMER.md
+  License:       https://github.com/poli0981/youtube-generator/blob/main/LICENSE
+
+In short:
+
+  * YTDescGen is free, open-source software, provided AS IS, WITHOUT WARRANTY
+    OF ANY KIND. You use it at your own risk (see the Disclaimer and License
+    sections 7-8).
+  * It works fully offline. It does not collect, transmit, or sell any
+    personal data; your profiles, history, and generated text stay on your
+    device (see the Privacy Policy).
+  * You are responsible for ensuring the titles, descriptions, and tags you
+    generate comply with YouTube's policies and applicable law (see the
+    Terms of Use).
+  * YTDescGen is an independent project and is not affiliated with, endorsed
+    by, or sponsored by YouTube, Google, or any game publisher.
+
+The software itself is licensed under the Apache License, Version 2.0. The
+full license text is included with this distribution and is available at the
+License URL above.
+
+If you do not agree to these terms, do not install or use the software.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "YTDescGen",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "identifier": "com.skullmute.ytdescgen",
   "build": {
     "beforeBuildCommand": "npm run build",
@@ -35,6 +35,7 @@
   },
   "bundle": {
     "active": true,
+    "licenseFile": "installer-license.txt",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ import { AppShell } from "@components/layout/AppShell";
 import { ErrorBoundary } from "@components/ErrorBoundary";
 import { ErrorPage } from "@components/errors/ErrorPage";
 import { OfflineBanner } from "@components/errors/OfflineBanner";
+import { ConsentGate } from "@components/ConsentGate";
+import { needsConsent } from "@config/legal";
 import { EditorPage } from "@pages/EditorPage";
 import { OutputPage } from "@pages/OutputPage";
 import { checkDataFileHealth } from "@utils/storage-adapter";
@@ -102,6 +104,30 @@ export default function App() {
     });
     return () => unsub();
   }, []);
+
+  // v0.28.0: first-run legal consent gate. Until the user accepts the current
+  // terms version, render the gate INSTEAD of the router so nothing in the app
+  // is reachable. The whole tree stays inside the root ErrorBoundary
+  // (main.tsx), so a gate render error still degrades to the error page.
+  const legalConsentVersion = useSettingsStore((s) => s.legalConsentVersion);
+
+  if (needsConsent(legalConsentVersion)) {
+    return (
+      <>
+        <ConsentGate />
+        <Toaster
+          position="bottom-right"
+          toastOptions={{
+            style: {
+              background: "var(--surface-2)",
+              color: "var(--text-primary)",
+              border: "1px solid var(--border)",
+            },
+          }}
+        />
+      </>
+    );
+  }
 
   return (
     <>

--- a/src/components/ConsentGate.tsx
+++ b/src/components/ConsentGate.tsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ExternalLink, ShieldCheck } from "lucide-react";
+import { Button } from "@components/ui/Button";
+import { Checkbox } from "@components/ui/Checkbox";
+import { useDocumentTitle } from "@hooks/use-document-title";
+import { useSettingsStore } from "@store/settings-store";
+import { LEGAL_DOCS } from "@config/legal";
+
+/**
+ * First-run legal consent gate. Rendered full-screen and **non-dismissible**
+ * (no ESC / backdrop / X — deliberately NOT the {@link import("@components/ui/Modal").Modal})
+ * in place of the router until the user accepts the current terms version.
+ *
+ * Layout mirrors the v0.27.0 ErrorPage fullscreen pattern. Acceptance is
+ * recorded in the settings store (`acceptLegalConsent`), which dual-writes to
+ * localStorage + the Tauri settings file; the gate then yields to the app.
+ * Re-shows automatically when CURRENT_TERMS_VERSION is bumped, and in fresh /
+ * incognito storage.
+ */
+export function ConsentGate() {
+  const { t } = useTranslation("ui");
+  const [agreed, setAgreed] = useState(false);
+  useDocumentTitle(t("consentGate.title"));
+
+  const onContinue = (): void => {
+    if (!agreed) return;
+    useSettingsStore.getState().acceptLegalConsent();
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="consent-title"
+      className="flex min-h-screen flex-col items-center justify-center gap-6 bg-surface-0 px-6 py-12 text-center"
+    >
+      <ShieldCheck className="h-14 w-14 text-accent" aria-hidden />
+
+      <div className="max-w-md space-y-2">
+        <h1 id="consent-title" className="text-2xl font-semibold text-text-primary">
+          {t("consentGate.title")}
+        </h1>
+        <p className="text-sm text-text-secondary">{t("consentGate.intro")}</p>
+      </div>
+
+      <div className="grid w-full max-w-md gap-2 sm:grid-cols-2">
+        {LEGAL_DOCS.map((doc) => (
+          <a
+            key={doc.id}
+            href={doc.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-3 rounded-lg border border-border bg-surface-1 px-3 py-2.5 text-sm text-text-primary transition-colors hover:border-accent hover:bg-surface-2"
+          >
+            <span className="flex-1 truncate text-left">{t(doc.labelKey)}</span>
+            <ExternalLink className="h-3.5 w-3.5 shrink-0 text-text-muted" />
+          </a>
+        ))}
+      </div>
+
+      <div className="w-full max-w-md rounded-lg border border-border bg-surface-1 p-4">
+        <Checkbox checked={agreed} onChange={setAgreed} label={t("consentGate.agreeLabel")} />
+      </div>
+
+      <div className="flex flex-col items-center gap-2">
+        <Button variant="primary" onClick={onContinue} disabled={!agreed}>
+          {t("consentGate.continue")}
+        </Button>
+        {!agreed && <p className="text-xs text-text-muted">{t("consentGate.mustAgree")}</p>}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/Checkbox.tsx
+++ b/src/components/ui/Checkbox.tsx
@@ -1,0 +1,52 @@
+import { type ReactNode, useId } from "react";
+import { Check } from "lucide-react";
+import clsx from "clsx";
+
+interface CheckboxProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  /** Visible label — accepts rich content (e.g. inline links). */
+  label: ReactNode;
+  className?: string;
+  id?: string;
+}
+
+/**
+ * Accessible square checkbox. A real `<input type="checkbox">` (visually
+ * hidden as a `peer`) keeps native keyboard + screen-reader semantics, while
+ * the styled box mirrors its state. Tailwind tokens only, so it tracks the
+ * dark/light theme. Distinct from {@link import("./Toggle").Toggle}, which is
+ * a `role="switch"` on/off pill — a checkbox is the right control for a
+ * one-time "I agree" acknowledgement.
+ */
+export function Checkbox({ checked, onChange, label, className, id }: CheckboxProps) {
+  const autoId = useId();
+  const inputId = id ?? autoId;
+  return (
+    <label
+      htmlFor={inputId}
+      className={clsx("group flex min-h-touch cursor-pointer items-start gap-3 text-left", className)}
+    >
+      <input
+        id={inputId}
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="peer sr-only"
+      />
+      <span
+        aria-hidden
+        className={clsx(
+          "mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded border transition-colors",
+          "peer-focus-visible:ring-2 peer-focus-visible:ring-accent/50",
+          checked
+            ? "border-accent bg-accent text-white"
+            : "border-border bg-surface-1 text-transparent group-hover:border-border-strong",
+        )}
+      >
+        <Check className="h-3.5 w-3.5" strokeWidth={3} />
+      </span>
+      <span className="text-sm leading-snug text-text-primary">{label}</span>
+    </label>
+  );
+}

--- a/src/config/legal.ts
+++ b/src/config/legal.ts
@@ -1,0 +1,41 @@
+const DOC_BASE = "https://github.com/poli0981/youtube-generator/blob/main";
+
+export interface LegalDoc {
+  readonly id: "terms" | "privacy" | "disclaimer" | "license";
+  /** i18n key under the `consentGate` ui section. */
+  readonly labelKey: string;
+  /** Absolute GitHub blob URL — opens in the system browser via target="_blank". */
+  readonly url: string;
+}
+
+/**
+ * The legal-terms version the user must accept. Bump this whenever the
+ * Terms / Privacy / Disclaimer change materially — every user whose stored
+ * `legalConsentVersion` is below this re-sees the first-run consent gate.
+ *
+ * v0.28.0 ships the first gate at version 1 (docs dated 2026-05-14).
+ */
+export const CURRENT_TERMS_VERSION = 1;
+
+/**
+ * The documents surfaced on the consent gate and the About → Legal section.
+ * Stored at the repo root and served from GitHub so they are always current;
+ * the in-app links open them in the browser (Tauri routes target="_blank" to
+ * the system browser). Order = display order.
+ */
+export const LEGAL_DOCS: readonly LegalDoc[] = [
+  { id: "terms", labelKey: "consentGate.docTerms", url: `${DOC_BASE}/TERMS.md` },
+  { id: "privacy", labelKey: "consentGate.docPrivacy", url: `${DOC_BASE}/PRIVACY.md` },
+  { id: "disclaimer", labelKey: "consentGate.docDisclaimer", url: `${DOC_BASE}/DISCLAIMER.md` },
+  { id: "license", labelKey: "consentGate.docLicense", url: `${DOC_BASE}/LICENSE` },
+];
+
+/**
+ * True when the consent gate must be shown — the user has not yet accepted the
+ * current terms version. A non-finite value (NaN / Infinity / non-number from a
+ * corrupt or legacy payload) is treated as "not accepted" so a bad value
+ * re-shows the gate rather than slipping past `<` comparison.
+ */
+export function needsConsent(acceptedVersion: number): boolean {
+  return !Number.isFinite(acceptedVersion) || acceptedVersion < CURRENT_TERMS_VERSION;
+}

--- a/src/i18n/locales/_schema.json
+++ b/src/i18n/locales/_schema.json
@@ -9,7 +9,8 @@
       "repoHeading", "repoLabel", "issuesLabel", "reportBugLabel", "discussionsLabel", "authorLabel", "licenseLabel",
       "donateHeading", "donateHelp",
       "connectHeading",
-      "thirdPartyHeading", "thirdPartyHelp"
+      "thirdPartyHeading", "thirdPartyHelp",
+      "legalHeading"
     ],
     "about.donate": ["githubSponsors", "kofi", "buyMeACoffee", "patreon", "paypal"],
     "about.socials": ["youtube", "x", "bluesky", "mastodon", "discord", "discordGame", "steam", "telegramBot", "telegramUser", "email"],
@@ -169,6 +170,7 @@
     "errorPages.serverError": ["title", "description"],
     "errorPages.offline": ["title", "description"],
     "errorPages.runtime": ["title", "description"],
+    "consentGate": ["title", "intro", "agreeLabel", "continue", "mustAgree", "docTerms", "docPrivacy", "docDisclaimer", "docLicense"],
     "videoTypes": ["full", "part", "full_demo", "demo_part", "boss", "boss_nohit", "ending", "speedrun", "100percent", "dlc", "newgame_plus", "challenge", "side_quest", "secret", "comparison", "guide", "mods", "collectibles", "livestream", "gacha_quest"],
     "genres": ["action", "hack_slash", "beatemup", "platformer", "horror", "survival_horror", "psychological_horror", "rpg", "jrpg", "action_rpg", "crpg", "fps", "arena_shooter", "tactical_fps", "boomer_shooter", "extraction_shooter", "shmup", "openworld", "indie", "soulslike", "racing", "story", "simulation", "city_builder", "fighting", "stealth", "survival_craft", "roguelike", "metroidvania", "mmo", "rhythm", "puzzle", "tower_defense", "card_game", "deck_builder", "auto_battler", "battle_royale", "tactical", "space", "farming", "fmv", "visual_novel"],
     "rig": ["os", "cpu", "gpu", "ram", "storage", "monitor", "capture", "motherboard", "controller", "video_editor"],

--- a/src/i18n/locales/en/ui.json
+++ b/src/i18n/locales/en/ui.json
@@ -35,6 +35,7 @@
     "licenseLabel": "License",
     "donateHeading": "Donate / Support",
     "donateHelp": "If YTDescGen saves you time, consider buying me a coffee. Every bit helps keep the project going.",
+    "legalHeading": "Legal",
     "donate": {
       "githubSponsors": "GitHub Sponsors",
       "kofi": "Ko-fi",
@@ -786,6 +787,17 @@
       "title": "Something went wrong",
       "description": "The app caught a render error before it could crash the page. Your data is safe — the error was logged to the Logs tab."
     }
+  },
+  "consentGate": {
+    "title": "Before you start",
+    "intro": "YTDescGen is a free, offline-first tool. Please review the documents below. By continuing, you confirm you have read and agree to them.",
+    "agreeLabel": "I have read and agree to the Terms of Use, Privacy Policy, Disclaimer, and License.",
+    "continue": "Continue",
+    "mustAgree": "Please check the box to continue.",
+    "docTerms": "Terms of Use",
+    "docPrivacy": "Privacy Policy",
+    "docDisclaimer": "Disclaimer",
+    "docLicense": "License (Apache-2.0)"
   },
   "videoTypes": {
     "full": "Full Gameplay",

--- a/src/i18n/locales/es/ui.json
+++ b/src/i18n/locales/es/ui.json
@@ -35,6 +35,7 @@
     "licenseLabel": "Licencia",
     "donateHeading": "Donar / Apoyar",
     "donateHelp": "Si YTDescGen te ahorra tiempo, considera invitarme un café. Cada aporte ayuda al proyecto.",
+    "legalHeading": "Legal",
     "donate": {
       "githubSponsors": "GitHub Sponsors",
       "kofi": "Ko-fi",
@@ -786,6 +787,17 @@
       "title": "Algo salió mal",
       "description": "La aplicación detectó un error de renderizado antes de que la página fallara. Tus datos están a salvo — el error se registró en la pestaña Registros."
     }
+  },
+  "consentGate": {
+    "title": "Antes de empezar",
+    "intro": "YTDescGen es una herramienta gratuita y con prioridad sin conexión. Revisa los documentos siguientes. Al continuar, confirmas que los has leído y los aceptas.",
+    "agreeLabel": "He leído y acepto los Términos de Uso, la Política de Privacidad, el Aviso Legal y la Licencia.",
+    "continue": "Continuar",
+    "mustAgree": "Marca la casilla para continuar.",
+    "docTerms": "Términos de Uso",
+    "docPrivacy": "Política de Privacidad",
+    "docDisclaimer": "Aviso Legal",
+    "docLicense": "Licencia (Apache-2.0)"
   },
   "videoTypes": {
     "full": "Gameplay Completo",

--- a/src/i18n/locales/ja/ui.json
+++ b/src/i18n/locales/ja/ui.json
@@ -35,6 +35,7 @@
     "licenseLabel": "ライセンス",
     "donateHeading": "寄付 / サポート",
     "donateHelp": "YTDescGenが時短に役立ったら、コーヒー一杯分でも支援していただけると嬉しいです。",
+    "legalHeading": "法的事項",
     "donate": {
       "githubSponsors": "GitHub Sponsors",
       "kofi": "Ko-fi",
@@ -786,6 +787,17 @@
       "title": "問題が発生しました",
       "description": "ページがクラッシュする前にレンダリングエラーを検出しました。データは安全です — エラーはログタブに記録されました。"
     }
+  },
+  "consentGate": {
+    "title": "始める前に",
+    "intro": "YTDescGen は無料・オフライン優先のツールです。下記の文書をご確認ください。続行すると、これらを読み同意したことになります。",
+    "agreeLabel": "利用規約、プライバシーポリシー、免責事項、およびライセンスを読み、同意します。",
+    "continue": "続行",
+    "mustAgree": "続行するにはチェックを入れてください。",
+    "docTerms": "利用規約",
+    "docPrivacy": "プライバシーポリシー",
+    "docDisclaimer": "免責事項",
+    "docLicense": "ライセンス (Apache-2.0)"
   },
   "videoTypes": {
     "full": "フルゲームプレイ",

--- a/src/i18n/locales/ko/ui.json
+++ b/src/i18n/locales/ko/ui.json
@@ -35,6 +35,7 @@
     "licenseLabel": "라이선스",
     "donateHeading": "후원 / 지원",
     "donateHelp": "YTDescGen이 시간을 아껴드렸다면 커피 한 잔으로 응원 부탁드립니다.",
+    "legalHeading": "법적 고지",
     "donate": {
       "githubSponsors": "GitHub Sponsors",
       "kofi": "Ko-fi",
@@ -786,6 +787,17 @@
       "title": "문제가 발생했습니다",
       "description": "페이지가 충돌하기 전에 앱이 렌더링 오류를 잡아냈습니다. 데이터는 안전합니다 — 오류는 로그 탭에 기록되었습니다."
     }
+  },
+  "consentGate": {
+    "title": "시작하기 전에",
+    "intro": "YTDescGen은 무료이며 오프라인을 우선하는 도구입니다. 아래 문서를 검토해 주세요. 계속하면 문서를 읽고 동의한 것으로 간주됩니다.",
+    "agreeLabel": "이용약관, 개인정보 처리방침, 면책 조항 및 라이선스를 읽고 동의합니다.",
+    "continue": "계속",
+    "mustAgree": "계속하려면 체크박스를 선택하세요.",
+    "docTerms": "이용약관",
+    "docPrivacy": "개인정보 처리방침",
+    "docDisclaimer": "면책 조항",
+    "docLicense": "라이선스 (Apache-2.0)"
   },
   "videoTypes": {
     "full": "전체 게임플레이",

--- a/src/i18n/locales/vi/ui.json
+++ b/src/i18n/locales/vi/ui.json
@@ -35,6 +35,7 @@
     "licenseLabel": "Giấy phép",
     "donateHeading": "Ủng hộ / Donate",
     "donateHelp": "Nếu YTDescGen giúp bạn tiết kiệm thời gian, mời mình một ly cà phê nhé. Mọi ủng hộ đều giúp dự án tiếp tục.",
+    "legalHeading": "Pháp lý",
     "donate": {
       "githubSponsors": "GitHub Sponsors",
       "kofi": "Ko-fi",
@@ -786,6 +787,17 @@
       "title": "Đã xảy ra lỗi",
       "description": "Ứng dụng đã bắt được lỗi hiển thị trước khi trang bị treo. Dữ liệu của bạn vẫn an toàn — lỗi đã được ghi vào tab Nhật ký."
     }
+  },
+  "consentGate": {
+    "title": "Trước khi bắt đầu",
+    "intro": "YTDescGen là công cụ miễn phí, ưu tiên hoạt động ngoại tuyến. Vui lòng xem các tài liệu bên dưới. Khi tiếp tục, bạn xác nhận đã đọc và đồng ý với chúng.",
+    "agreeLabel": "Tôi đã đọc và đồng ý với Điều khoản Sử dụng, Chính sách Bảo mật, Tuyên bố Miễn trừ và Giấy phép.",
+    "continue": "Tiếp tục",
+    "mustAgree": "Vui lòng tích vào ô để tiếp tục.",
+    "docTerms": "Điều khoản Sử dụng",
+    "docPrivacy": "Chính sách Bảo mật",
+    "docDisclaimer": "Tuyên bố Miễn trừ",
+    "docLicense": "Giấy phép (Apache-2.0)"
   },
   "videoTypes": {
     "full": "Full Gameplay",

--- a/src/i18n/locales/zh/ui.json
+++ b/src/i18n/locales/zh/ui.json
@@ -35,6 +35,7 @@
     "licenseLabel": "许可证",
     "donateHeading": "赞助 / 支持",
     "donateHelp": "如果 YTDescGen 帮你省下了时间，欢迎请我喝一杯咖啡。每份支持都让项目走得更远。",
+    "legalHeading": "法律",
     "donate": {
       "githubSponsors": "GitHub Sponsors",
       "kofi": "Ko-fi",
@@ -786,6 +787,17 @@
       "title": "出现问题",
       "description": "应用在页面崩溃前捕获了一个渲染错误。您的数据是安全的 — 错误已记录到日志标签页。"
     }
+  },
+  "consentGate": {
+    "title": "开始之前",
+    "intro": "YTDescGen 是一款免费、离线优先的工具。请查看以下文档。继续即表示您已阅读并同意这些文档。",
+    "agreeLabel": "我已阅读并同意《使用条款》《隐私政策》《免责声明》和《许可证》。",
+    "continue": "继续",
+    "mustAgree": "请勾选复选框以继续。",
+    "docTerms": "使用条款",
+    "docPrivacy": "隐私政策",
+    "docDisclaimer": "免责声明",
+    "docLicense": "许可证 (Apache-2.0)"
   },
   "videoTypes": {
     "full": "完整游戏实况",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -34,12 +34,28 @@ async function preloadLocales(): Promise<void> {
   ]).catch(() => undefined);
 }
 
+/**
+ * Apply the persisted theme class to <html> at boot. `index.html` hardcodes
+ * `class="dark"`, and `setTheme` (the Header toggle) is the only other place
+ * that touches the class — so before v0.28.0 a light-theme user saw a dark
+ * flash until they interacted. zustand persist has already hydrated from
+ * localStorage at module load, so `getState().theme` is the user's value.
+ * Runs before first paint so the consent gate (and AppShell) render in the
+ * right theme.
+ */
+function applyPersistedTheme(): void {
+  const { theme } = useSettingsStore.getState();
+  document.documentElement.classList.toggle("dark", theme === "dark");
+  document.documentElement.classList.toggle("light", theme === "light");
+}
+
 // Top-level safety net. Per-route boundaries in App.tsx catch most
 // errors with route-specific labels; this outer one only fires if
 // something explodes *before* the router mounts (e.g. i18n init, store
 // rehydrate). Without it, a top-level crash still produces a black
 // page — defeating the point of per-route boundaries.
 void preloadLocales().finally(() => {
+  applyPersistedTheme();
   createRoot(root).render(
     <StrictMode>
       <ErrorBoundary label="app">

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -20,6 +20,7 @@ import {
 import { ABOUT, type AboutSocialId } from "@config/about";
 import { DONATE, type DonateId } from "@config/donate";
 import { THIRD_PARTY } from "@config/third-party";
+import { LEGAL_DOCS } from "@config/legal";
 import { useDocumentTitle } from "@hooks/use-document-title";
 
 interface SocialLinkConfig {
@@ -109,6 +110,22 @@ export function AboutPage() {
             icon={ExternalLink}
             label={`${t("about.licenseLabel")} · ${ABOUT.license}`}
           />
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-text-muted">
+          {t("about.legalHeading")}
+        </h2>
+        <div className="grid gap-2 sm:grid-cols-2">
+          {LEGAL_DOCS.map((doc) => (
+            <ExternalLinkRow
+              key={doc.id}
+              href={doc.url}
+              icon={ExternalLink}
+              label={t(doc.labelKey)}
+            />
+          ))}
         </div>
       </section>
 

--- a/src/store/settings-heal.ts
+++ b/src/store/settings-heal.ts
@@ -97,6 +97,18 @@ export interface SettingsData {
    * by `healSettings`.
    */
   logRetentionDays: number;
+  /**
+   * v0.28.0 legal consent. The `CURRENT_TERMS_VERSION` (see
+   * `@config/legal`) the user last accepted on the first-run consent gate.
+   * `0` = never accepted → the gate shows. Bumped via `acceptLegalConsent`;
+   * re-shows whenever `CURRENT_TERMS_VERSION` is raised (terms changed).
+   * Persisted inside the existing `ytdescgen-settings` record — no cookie,
+   * no new storage key. A malformed value is coerced to `0` by
+   * {@link healSettings} so a corrupt file re-shows the gate, never skips it.
+   */
+  legalConsentVersion: number;
+  /** ISO timestamp of the most recent acceptance, or `null`. Audit-only. */
+  legalConsentAt: string | null;
 }
 
 function detectBrowserLanguage(): SupportedLanguage {
@@ -148,6 +160,8 @@ export const initialSettings: SettingsData = {
   },
   sidebarCollapsed: false,
   logRetentionDays: 7,
+  legalConsentVersion: 0,
+  legalConsentAt: null,
 };
 
 /**
@@ -200,6 +214,19 @@ export function healSettings(raw: unknown): SettingsData {
       1,
       Math.min(90, Math.floor(incoming.logRetentionDays)),
     );
+  }
+
+  // v0.28.0: `legalConsentVersion` added. A non-number / non-finite / negative
+  // value must fall through to "never accepted" (0) so a corrupt or
+  // hand-edited file re-shows the consent gate rather than silently skipping
+  // it. (Additive — the trailing spread back-fills legacy payloads to 0.)
+  if (
+    typeof incoming.legalConsentVersion !== "number" ||
+    !Number.isFinite(incoming.legalConsentVersion)
+  ) {
+    incoming.legalConsentVersion = initialSettings.legalConsentVersion;
+  } else {
+    incoming.legalConsentVersion = Math.max(0, Math.floor(incoming.legalConsentVersion));
   }
 
   return { ...initialSettings, ...incoming } as SettingsData;

--- a/src/store/settings-store.ts
+++ b/src/store/settings-store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import type { SupportedLanguage } from "@engine/types";
+import { CURRENT_TERMS_VERSION } from "@config/legal";
 import { saveSettings, loadSettings } from "@utils/storage-adapter";
 import {
   healSettings,
@@ -19,6 +20,8 @@ interface SettingsState extends SettingsData {
   setSetting: <K extends keyof SettingsData>(key: K, value: SettingsData[K]) => void;
   setTitleFormat: (patch: Partial<TitleFormatConfig>) => void;
   toggleEditorAccordion: (id: string) => void;
+  /** Record acceptance of the current legal terms (dismisses the consent gate). */
+  acceptLegalConsent: () => void;
 }
 
 const STORE_KEY = "ytdescgen-settings";
@@ -50,6 +53,12 @@ export const useSettingsStore = create<SettingsState>()(
             [id]: !state.editorAccordionState[id],
           },
         })),
+
+      acceptLegalConsent: () =>
+        set({
+          legalConsentVersion: CURRENT_TERMS_VERSION,
+          legalConsentAt: new Date().toISOString(),
+        }),
     }),
     {
       name: STORE_KEY,
@@ -116,6 +125,8 @@ export function extractData(state: SettingsData): SettingsData {
     editorAccordionState: state.editorAccordionState,
     sidebarCollapsed: state.sidebarCollapsed,
     logRetentionDays: state.logRetentionDays,
+    legalConsentVersion: state.legalConsentVersion,
+    legalConsentAt: state.legalConsentAt,
   };
 }
 

--- a/tests/config/legal.test.ts
+++ b/tests/config/legal.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { needsConsent, CURRENT_TERMS_VERSION, LEGAL_DOCS } from "@config/legal";
+
+/**
+ * Guards for the pure legal config driving the v0.28.0 consent gate. The gate
+ * is a boot-time blocker, so the version logic must be exactly right: anything
+ * below the current version (or a non-number) re-shows the gate; the current
+ * version (or higher) lets the app through.
+ */
+describe("needsConsent", () => {
+  it("requires consent at version 0 (never accepted)", () => {
+    expect(needsConsent(0)).toBe(true);
+  });
+
+  it("requires consent below the current version (terms changed)", () => {
+    expect(needsConsent(CURRENT_TERMS_VERSION - 1)).toBe(true);
+  });
+
+  it("passes once the current version is accepted", () => {
+    expect(needsConsent(CURRENT_TERMS_VERSION)).toBe(false);
+  });
+
+  it("passes for a future stored version (never downgrades)", () => {
+    expect(needsConsent(CURRENT_TERMS_VERSION + 5)).toBe(false);
+  });
+
+  it("treats a non-number as needing consent", () => {
+    expect(needsConsent(undefined as unknown as number)).toBe(true);
+    expect(needsConsent(NaN)).toBe(true);
+  });
+});
+
+describe("LEGAL_DOCS", () => {
+  it("covers all four documents with absolute https GitHub URLs + consentGate label keys", () => {
+    expect(LEGAL_DOCS.map((d) => d.id)).toEqual(["terms", "privacy", "disclaimer", "license"]);
+    for (const doc of LEGAL_DOCS) {
+      expect(doc.url).toMatch(/^https:\/\/github\.com\/poli0981\/youtube-generator\/blob\/main\//);
+      expect(doc.labelKey).toMatch(/^consentGate\.doc/);
+    }
+  });
+
+  it("has a unique id and url per doc", () => {
+    expect(new Set(LEGAL_DOCS.map((d) => d.id)).size).toBe(LEGAL_DOCS.length);
+    expect(new Set(LEGAL_DOCS.map((d) => d.url)).size).toBe(LEGAL_DOCS.length);
+  });
+});

--- a/tests/store/settings-heal.test.ts
+++ b/tests/store/settings-heal.test.ts
@@ -92,6 +92,8 @@ describe("healSettings", () => {
       editorAccordionState: { gameInfo: false, videoSettings: true },
       sidebarCollapsed: true,
       logRetentionDays: 14,
+      legalConsentVersion: 1,
+      legalConsentAt: "2026-06-13T00:00:00.000Z",
     };
     const healed = healSettings(complete);
     expect(healed).toEqual(complete);
@@ -213,5 +215,22 @@ describe("healSettings", () => {
     for (const healed of [healedFromNull, healedFromString]) {
       expect(healed.genrePlaylists).toEqual({});
     }
+  });
+
+  it("back-fills legalConsentVersion 0 + legalConsentAt null for a legacy payload (pre-v0.28)", () => {
+    // A settings file written before the consent gate existed has neither
+    // key — it must heal to "never accepted" so the gate shows on first run.
+    const healed = healSettings({ theme: "dark" as const, hashtagCount: 3 });
+    expect(healed.legalConsentVersion).toBe(0);
+    expect(healed.legalConsentAt).toBeNull();
+  });
+
+  it("preserves a stored legalConsentVersion and coerces malformed/negative values to 0", () => {
+    expect(healSettings({ legalConsentVersion: 1 }).legalConsentVersion).toBe(1);
+    expect(
+      healSettings({ legalConsentVersion: "nope" as unknown as number }).legalConsentVersion,
+    ).toBe(0);
+    expect(healSettings({ legalConsentVersion: -3 }).legalConsentVersion).toBe(0);
+    expect(healSettings({ legalConsentVersion: 2.9 }).legalConsentVersion).toBe(2);
   });
 });


### PR DESCRIPTION
## v0.28.0 — Legal Consent Gate

Adds a first-run **legal consent gate**. Before the app is usable, the user reviews the Terms of Use, Privacy Policy, Disclaimer, and License (already published at the repo root) and ticks a single "I agree" box. Acceptance is recorded and only re-prompts when the terms version changes — one-time in normal use, and it re-appears in fresh/incognito storage.

### What's in it
- **`ConsentGate`** (`src/components/ConsentGate.tsx`) + pure **`src/config/legal.ts`** (`CURRENT_TERMS_VERSION`, `LEGAL_DOCS`, `needsConsent`) — full-screen, non-dismissible gate rendered in place of the router until consent is recorded. Docs link to the GitHub copies (open in browser); one combined checkbox; Continue disabled until checked.
- **Persistence** — recorded in the existing settings record (`legalConsentVersion` + timestamp) via the established Zustand persist + Tauri dual-write. **No cookie, no new storage key.** Additive — no persist version bump; `healSettings` coerces a malformed value to `0` so a corrupt file re-shows the gate.
- **About → Legal** (`src/pages/AboutPage.tsx`) — all four docs now linked in-app (was License-only).
- **Windows installer license page** (`src-tauri/tauri.conf.json` `bundle.licenseFile` → `installer-license.txt`) — MSI/NSIS show an accept-the-terms page. macOS `.app`/Linux have no interactive license step → covered by the in-app gate.
- **`Checkbox`** primitive (`src/components/ui/Checkbox.tsx`) — accessible square checkbox, theme-aware.
- **i18n** — 60 new strings (10 keys × 6 locales); validator now 937 ui keys.

### Fixed
- **Persisted theme applied on boot** (`src/main.tsx`) — `index.html` hardcodes `class="dark"` and only the Header toggle wrote the theme class, so light-theme users saw a dark flash on cold start (and the gate, which renders before the shell, would render dark). Now applied before first paint.

### Quality gates (all green)
`typecheck` · `lint` · `knip` · `validate:locales` (937/542) · **509 tests** (500 → 509, +9 pure tests) · `build` · **`npm audit` 0 vulnerabilities** (vite 8 base).

### Verified in-browser
First-run gate (dark **and** light theme), Continue gating, accept → consent persists (`legalConsentVersion: 1` + timestamp) → app loads → reload does not re-prompt, About → Legal lists all four docs, header shows v0.28.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)