### PR TITLE
docs(android): requirements + tested versions (11–16, real device Android 12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Built for the gameplay no-commentary niche — especially horror / scary games �
 - **Batch mode** — generate metadata for all parts of a series in one pass.
 - **Cross-post captions** — a dedicated **Social** tab re-packages the same YouTube source into short-form captions for **TikTok** (4,000-char), **Instagram Reels**, and **Facebook Reels** — title, rig, content warnings, copyright, thanks, and hashtags (game + genre + curated per-platform popular tags). Single + bulk modes, per-platform character limits with smart overflow trimming, and JSON import/export.
 - **Desktop app** — Windows, macOS & Linux native binaries via Tauri (~8 MB).
-- **Android app** — installable, sideloadable `.apk` (Android 11+) built from the same Tauri 2 codebase. Grab it from [Releases](https://github.com/poli0981/youtube-generator/releases) and enable "Install unknown apps" to sideload.
+- **Android app** — installable, sideloadable `.apk` built from the same Tauri 2 codebase. **Requires Android 11+** (tested 11–16; real-device test on Android 12). Grab it from [Releases](https://github.com/poli0981/youtube-generator/releases) and enable "Install unknown apps" to sideload.
 - **Mobile-responsive web** — drawer navigation, touch-sized controls, iOS-safe text-input behavior. Tested down to 360 × 640.
 - **100% offline** — no server, no telemetry, no account. See [PRIVACY.md](./PRIVACY.md).
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -260,6 +260,7 @@ separate mobile project. Build with `cargo tauri android build --apk`; see
 |---------|-------------|
 | Same codebase | One Tauri 2 project produces web, desktop, and Android |
 | Min version | Android 11+ (minSdk 30); `targetSdk` 36 (Android 16) |
+| Tested | Android 11 → 16 (emulators); real device on Android 12 |
 | Signed APK | Self-signed release APK for sideloading; CI publishes it to GitHub Releases |
 | Responsive UI | Drawer navigation, touch-sized controls, safe-area insets |
 | File export | Routed through the WebView download (lands in Downloads) on Android |

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -283,17 +283,39 @@ point, and the Android launcher icons live in `src-tauri/icons/android/`. The
 desktop-only tray / single-instance / hide-to-tray logic in `src-tauri/src/lib.rs`
 is gated behind `#[cfg(desktop)]` so the library compiles for Android.
 
-> **Min version: Android 11 (minSdk 30), targetSdk 36.** Set via
-> `bundle.android.minSdkVersion` in `src-tauri/tauri.conf.json` (the source of
-> truth used by `tauri android init`) and the generated
-> `gen/android/app/build.gradle.kts` (`minSdk = 30` — edit this directly if you
-> change it without re-running `init`, since the gradle value is baked at init
-> time). Android 11+ covers the large majority of active devices and keeps a
-> modern, auto-updating System WebView (the WebView minimum is Android 10) plus
-> Google Play system/Play-services security updates, even though Google's
-> OS-level security bulletins for Android 11–13 have ended. Raising minSdk also
-> moots the ancient-WebView class of bug (e.g. the Chromium-91 `crypto.randomUUID`
-> boot crash fixed in this release).
+### Requirements & tested versions
+
+| | |
+|---|---|
+| **Minimum OS** | **Android 11** (API level 30, `minSdk 30`). The APK will not install below this. |
+| **Target OS** | **Android 16** (API level 36, `targetSdk 36`). |
+| **Architectures** | Universal APK — `arm64-v8a`, `armeabi-v7a`, `x86`, `x86_64`. |
+| **Tested** | **Android 11 → 16.** The v0.29.0 build was verified on Android emulators across this range **and on a real device running Android 12** (the maintainer's phone). |
+
+Where the value lives: `bundle.android.minSdkVersion` in
+[`src-tauri/tauri.conf.json`](../src-tauri/tauri.conf.json) is the source of
+truth used by `tauri android init`; the generated
+`gen/android/app/build.gradle.kts` carries the baked `minSdk = 30` — edit that
+directly if you change the floor without re-running `init`.
+
+**Why Android 11 is the floor (rationale):**
+
+- **Coverage.** Android 11+ accounts for the large majority of active devices in
+  2026 (Android 14/15 alone are the two biggest slices, and 11–13 together still
+  hold a sizeable share). Going lower buys few extra users at growing compat cost.
+- **A modern, patched WebView.** The app renders entirely in the system WebView,
+  whose minimum is Android 10. On Android 11+ the WebView auto-updates via Google
+  Play, so the rendering/JS engine stays current and patched. This is exactly why
+  the **real-device test on Android 12 worked**, while a *stale* Android-12
+  emulator stuck on WebView 91 showed a black screen (the `crypto.randomUUID`
+  boot crash) — that class of bug is fixed in v0.29.0 and is moot on an
+  up-to-date WebView.
+- **Security upkeep.** Even though Google's *OS-level* monthly security bulletins
+  for Android 11–13 have ended (Android 12 in 2025, Android 13 in early 2026),
+  Android 11+ keeps receiving security updates for the components that matter to a
+  sandboxed WebView app: Google Play system updates (Project Mainline), Google
+  Play services, and System WebView. Requiring strict OS-bulletin support would
+  mean Android 14+, which would drop more than half of users.
 
 ### Prerequisites
 


### PR DESCRIPTION
Adds an explicit **Requirements & tested versions** section to the Android docs (post-v0.29.0, docs-only):

- Minimum **Android 11** (minSdk 30), target **Android 16** (targetSdk 36), universal ABIs.
- **Tested Android 11 → 16** on emulators + a **real device on Android 12**.
- Rationale for the Android 11 floor: device coverage, a modern auto-updating WebView (why the Android 12 real device worked but a stale WebView-91 emulator black-screened), and component-level security upkeep (Play system updates / Play services / WebView) now that OS bulletins for 11–13 have ended.

Touches `docs/PACKAGING.md`, `docs/FEATURES.md`, `README.md` only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)