### PR TITLE
ci(android): bump Node-20 actions to Node-24 majors

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -26,12 +26,12 @@ jobs:
           node-version: 22
           cache: npm
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
 
-      - uses: android-actions/setup-android@v3
+      - uses: android-actions/setup-android@v4
 
       - name: Install Android NDK (r27 LTS)
         run: sdkmanager "ndk;27.3.13750724"
@@ -41,7 +41,7 @@ jobs:
           targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -80,7 +80,7 @@ jobs:
         run: cargo tauri android build --apk
 
       - name: Upload APK to draft release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}
           draft: true


### PR DESCRIPTION
## What

GitHub deprecated the **Node.js 20 Actions runtime on 2026-06-16** (force-default to node24 soon, removal from runners **2026-09-16**). `release-android.yml` emitted a deprecation annotation for four actions still pinned to majors whose latest-supported runtime was node20. Each has a newer major declaring `runs.using: node24`, so this bumps to the floating major tag:

| Action | Before (node20) | After (node24) | Notes |
|---|---|---|---|
| `actions/setup-java` | `v4` | `v5` | pure runtime move; only behavior change is JetBrains pre-release handling (we use `temurin`) |
| `android-actions/setup-android` | `v3` | `v4` | node24 + defaults cmdline-tools 20.0; NDK install via `sdkmanager "ndk;27.3.13750724"` unaffected |
| `actions/cache` | `v4` | `v5` | pure runtime move, inputs unchanged |
| `softprops/action-gh-release` | `v2` | `v3` | pure runtime move, inputs unchanged |

All four are pure node20→node24 runtime migrations with **unchanged inputs**. No fallback comments were needed — every flagged action had a node24 major available.

## Scope

- **`release-android.yml` only.** It was the sole workflow using any of the flagged actions.
- **`ci.yml` / `release-desktop.yml`** use only `actions/checkout@v6` + `actions/setup-node@v6` (already node24) plus composite actions (`dtolnay/rust-toolchain`, `tauri-apps/tauri-action`) that run no Node runtime → **no changes**. `deploy-web.yml` similarly uses `@v6`/`@v5` pages actions (node24). Confirmed by grepping every `uses:` across `.github/workflows/`.
- This is **action runtimes only** — the JS app build `node-version` (already `22`, set in #95/#96) is untouched. **No version-manifest bump / tag** (CI-only change).

## Runner requirement

The node24 majors of `setup-java`/`cache` require **Actions Runner ≥ 2.327.1**. GitHub-hosted `ubuntu-latest` already ships well past this, so no runner pin is needed.

## Verification

- `actionlint v1.7.12` — clean (exit 0) on `release-android.yml`, `release-desktop.yml`, `ci.yml`.
- YAML parse of all 8 workflow files — OK.
- Confirmed each target major's `runs.using` via the GitHub contents API: `setup-java@v5`, `cache@v5`, `setup-android@v4`, `action-gh-release@v3` all report `node24` (the `@v4`/`@v3`/`@v2` predecessors report `node20`).

### A note on the workflow_dispatch dry-run
`release-android.yml`'s `workflow_dispatch` is **not a dry-run** — it does a full signed APK build and uploads to a draft release for an existing tag, so triggering it has outward-facing side effects (consumes Android signing secrets, mutates a GitHub release). I did **not** auto-trigger it. Since these are pure runtime bumps and v0.29.1 already built green on the old actions, the next real tag release will exercise the node24 actions; happy to dispatch a build against a throwaway tag first if you'd prefer to validate them before then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)