### PR TITLE
fix(hooks): AI-translation disclaimer missing in multi-language output (v0.29.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to YTDescGen ship as tagged releases on `main`.
 
+## v0.29.2 — 2026-06-20
+
+A one-line **hotfix**. The opt-in *"Show translation-quality notice"* setting
+(the AI-translation disclaimer, v0.24.0) had no effect when the Output page was
+showing **two or more languages at once** — the multi-language output hook had
+drifted out of sync with the single-language one and never forwarded the setting
+to the engine.
+
+### Fixed
+
+- **AI-translation disclaimer now appears in multi-language Output** ([src/hooks/use-multilang-output.ts](src/hooks/use-multilang-output.ts)) — the multi-language hook now forwards `showTranslationQuality` to `renderAll`, matching [useGeneratedOutput](src/hooks/use-generated-output.ts). The same patch also restores `showThirdPartyAds` (an identical latent gap — its disclaimer was dropped in multi-language mode too) and the always-English `tEn` translator, so the bilingual blocks render `EN · LOCAL` instead of target-language-only. Selecting 2+ languages and viewing a non-English/Vietnamese tab now shows the `▸ 🌐 ABOUT THIS TRANSLATION` block. Single-language output and the Batch page were already correct.
+
+### Under the hood
+
+- One-file fix; no engine, store, config, or i18n changes (the `translationQuality` template keys already exist in all six locales). typecheck, lint, locale validation (937/542), all **513 tests**, and the production build pass; verified live — the JA tab renders the block bilingually while the EN/VI tabs correctly omit it.
+- This hook has drifted out of sync before (a prior `showSponsorCredit` miss), so the recurrence is a known class of bug.
+- Five manifests bumped 0.29.1 → 0.29.2.
+
 ## v0.29.1 — 2026-06-17
 
 A UI/UX hotfix for **mobile viewport overflow**. On Android and narrow web

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yt-desc-gen",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yt-desc-gen",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yt-desc-gen",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5535,7 +5535,7 @@ dependencies = [
 
 [[package]]
 name = "yt-desc-gen"
-version = "0.29.1"
+version = "0.29.2"
 dependencies = [
  "tauri",
  "tauri-build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yt-desc-gen"
-version = "0.29.1"
+version = "0.29.2"
 description = "YouTube Gameplay Description Generator"
 authors = ["poli0981"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "YTDescGen",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "identifier": "com.skullmute.ytdescgen",
   "build": {
     "beforeBuildCommand": "npm run build",

--- a/src/hooks/use-multilang-output.ts
+++ b/src/hooks/use-multilang-output.ts
@@ -23,8 +23,16 @@ export function useMultilangOutput(
     showUsagePolicy,
     showSponsorCredit,
     showGameCopyright,
+    showThirdPartyAds,
+    showTranslationQuality,
     titleFormat,
   } = useSettingsStore();
+
+  // Always-English `t` for the bilingual content-warning / translation-quality
+  // blocks — must match `useGeneratedOutput` so multi-language tabs render the
+  // same `EN · LOCAL` output instead of falling back to target-language-only.
+  // `en` is eagerly bundled, so it never needs the readiness gate.
+  const tEn = useMemo(() => i18n.getFixedT("en", "templates"), []);
 
   return useMemo(() => {
     const results: Record<string, GeneratorOutput> = {};
@@ -41,7 +49,10 @@ export function useMultilangOutput(
         showUsagePolicy,
         showSponsorCredit,
         showGameCopyright,
+        showThirdPartyAds,
+        showTranslationQuality,
         titleFormat,
+        tEn,
       });
     }
     return results;
@@ -57,6 +68,9 @@ export function useMultilangOutput(
     showUsagePolicy,
     showSponsorCredit,
     showGameCopyright,
+    showThirdPartyAds,
+    showTranslationQuality,
     titleFormat,
+    tEn,
   ]);
 }


### PR DESCRIPTION
## Hotfix

The opt-in **"Show translation-quality notice"** setting (the AI-translation disclaimer, v0.24.0) had **no effect** whenever the Output page showed **two or more languages at once**.

### Root cause

`src/hooks/use-multilang-output.ts` (used by `OutputPage` in multi-language mode) had drifted out of sync with its single-language sibling `src/hooks/use-generated-output.ts`. It never forwarded three options to `renderAll`:

| Option | Effect when missing |
|--------|---------------------|
| `showTranslationQuality` | **The reported bug** — AI-translation disclaimer dropped for non-EN/VI tabs |
| `showThirdPartyAds` | Identical latent gap — third-party-ads disclaimer also dropped in multi-language mode |
| `tEn` (always-English `getFixedT`) | Bilingual blocks rendered target-language-only instead of `EN · LOCAL` |

Single-language output and the Batch page already passed all three, so the bug was specific to multi-language Output. This hook has drifted before (a prior `showSponsorCredit` miss).

### Fix

Bring the hook to parity: destructure both settings, build a memoized `tEn`, and pass all three into `renderAll` (plus the `useMemo` deps). One file changed — no engine, store, config, or i18n changes.

### Verification

- `typecheck`, `lint`, `validate:locales` (937/542), **513 tests**, and `build` all pass.
- Verified live (Preview MCP): with the setting on, selecting **VI + JA** and viewing the **JA** tab now shows the `▸ 🌐 ABOUT THIS TRANSLATION` block rendered bilingually (`EN · JA`); the **EN** tab correctly omits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)