### PR TITLE
fix(engine): keep multi-language content blocks single-language (v0.29.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to YTDescGen ship as tagged releases on `main`.
 
+## v0.29.3 — 2026-06-20
+
+A follow-up **hotfix** to v0.29.2. Forwarding the always-English `tEn` translator
+to multi-language Output (so the AI-translation disclaimer could render `EN · LOCAL`)
+also turned the **content-warnings, tech-notes, and playthrough-notes** blocks
+bilingual in every multi-language tab — because `tEn` was the single shared signal
+for bilingual rendering. Each multi-language tab is already a dedicated single
+language, so those "video" blocks should be that language only; only the
+translation disclaimer is meant to stay bilingual.
+
+### Fixed
+
+- **Multi-language tabs render content blocks single-language again** ([src/hooks/use-multilang-output.ts](src/hooks/use-multilang-output.ts), [src/engine/description-builder.ts](src/engine/description-builder.ts), [src/engine/template-renderer.ts](src/engine/template-renderer.ts)) — a new `bilingualContentBlocks` render option (default `true`) gates the three video blocks. The multi-language hook passes `false`, so content warnings / tech notes / playthrough notes show the target language only, while the `▸ 🌐 ABOUT THIS TRANSLATION` disclaimer keeps the raw `tEn` and stays bilingual `EN · LOCAL`. Single-language output is unchanged (default `true` preserves the v0.11/v0.12 bilingual blocks).
+
+### Under the hood
+
+- The Social / cross-post path ([src/engine/social-post-builder.ts](src/engine/social-post-builder.ts)) is intentionally left as-is — it is driven by separate hooks, never wired through the multi-language Output tabs, and its bilingual content warnings are long-standing v0.24.0 behavior. The asymmetry is deliberate.
+- Additive, default-preserving change: the engine option defaults to the old behavior, so every existing caller and test is unaffected. typecheck, lint, locale validation (937/542), and all **517 tests** (513 + 4 new `bilingualContentBlocks` gate tests) pass; verified live — multi-language JA tab shows JA-only content blocks with a bilingual disclaimer, the EN tab omits the disclaimer, and single-language JA still renders content warnings bilingually.
+- Five manifests bumped 0.29.2 → 0.29.3.
+
 ## v0.29.2 — 2026-06-20
 
 A one-line **hotfix**. The opt-in *"Show translation-quality notice"* setting

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yt-desc-gen",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yt-desc-gen",
-      "version": "0.29.2",
+      "version": "0.29.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yt-desc-gen",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5535,7 +5535,7 @@ dependencies = [
 
 [[package]]
 name = "yt-desc-gen"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "tauri",
  "tauri-build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yt-desc-gen"
-version = "0.29.2"
+version = "0.29.3"
 description = "YouTube Gameplay Description Generator"
 authors = ["poli0981"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "YTDescGen",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "identifier": "com.skullmute.ytdescgen",
   "build": {
     "beforeBuildCommand": "npm run build",

--- a/src/engine/description-builder.ts
+++ b/src/engine/description-builder.ts
@@ -260,6 +260,12 @@ export interface BuildDescriptionOptions {
    *  `EN · output-language`. When omitted, the warnings block falls
    *  back to single-language output via `t`. */
   tEn?: TranslationFn;
+  /** When false, content warnings / tech notes / playthrough notes render
+   *  single-language even when `tEn` is provided; the translation-quality
+   *  disclaimer stays bilingual. Multi-language Output tabs pass false so
+   *  each (single-language) tab doesn't show `EN · LOCAL` content blocks.
+   *  Defaults to true. v0.29.3. */
+  bilingualContentBlocks?: boolean;
 }
 
 export function buildDescription(
@@ -276,7 +282,12 @@ export function buildDescription(
     showGameCopyright = false,
     showTranslationQuality = false,
     tEn,
+    bilingualContentBlocks = true,
   } = options;
+  // Multi-language Output tabs set this false: each tab is one target
+  // language, so the v0.11/v0.12 content blocks must NOT render `EN · LOCAL`.
+  // The translation-quality disclaimer keeps the raw `tEn` and stays bilingual.
+  const contentBlockTEn = bilingualContentBlocks ? tEn : undefined;
   const sections: string[] = [];
   const gameName =
     input.gameNameLocalized?.[input.language] ?? input.gameName;
@@ -339,7 +350,7 @@ export function buildDescription(
   // are skipped; if every bullet is empty the whole block is skipped.
   // Bilingual when `tEn` is provided AND output language ≠ English —
   // pattern mirrors the v0.11 content-warnings block.
-  const pnBlock = buildPlaythroughNotesSection(input, t, tEn);
+  const pnBlock = buildPlaythroughNotesSection(input, t, contentBlockTEn);
   if (pnBlock) sections.push(pnBlock);
 
   // 2. No Commentary tagline
@@ -508,7 +519,7 @@ export function buildDescription(
     "description.contentWarnings",
     input.language,
     t,
-    tEn,
+    contentBlockTEn,
   );
   if (cwSection) sections.push(cwSection);
 
@@ -521,7 +532,7 @@ export function buildDescription(
     "description.techNotes",
     input.language,
     t,
-    tEn,
+    contentBlockTEn,
   );
   if (tnSection) sections.push(tnSection);
 

--- a/src/engine/template-renderer.ts
+++ b/src/engine/template-renderer.ts
@@ -67,6 +67,14 @@ export interface RenderOptions extends TagOptions {
    * to single-language output via `t`.
    */
   tEn?: TranslationFn;
+  /**
+   * When false, the three "video" content blocks (content warnings, tech
+   * notes, playthrough notes) render single-language even though `tEn` is
+   * supplied — used by the multi-language Output tabs, where each tab is
+   * already a single target language. The AI-translation disclaimer is
+   * unaffected and stays bilingual. Defaults to true. v0.29.3.
+   */
+  bilingualContentBlocks?: boolean;
 }
 
 export function renderAll(
@@ -89,6 +97,7 @@ export function renderAll(
     showGameCopyright: options?.showGameCopyright,
     showTranslationQuality: options?.showTranslationQuality,
     tEn: options?.tEn,
+    bilingualContentBlocks: options?.bilingualContentBlocks,
   });
   const tags = generateTags(input, options);
   const tagString = formatTagString(tags);

--- a/src/hooks/use-multilang-output.ts
+++ b/src/hooks/use-multilang-output.ts
@@ -28,9 +28,12 @@ export function useMultilangOutput(
     titleFormat,
   } = useSettingsStore();
 
-  // Always-English `t` for the bilingual content-warning / translation-quality
-  // blocks — must match `useGeneratedOutput` so multi-language tabs render the
-  // same `EN · LOCAL` output instead of falling back to target-language-only.
+  // Always-English `t` for the bilingual translation-quality disclaimer.
+  // In multi-language tabs each tab is already a single target language, so
+  // we pass `bilingualContentBlocks: false` below — `tEn` therefore drives
+  // ONLY the AI-translation disclaimer here (content warnings / tech notes /
+  // playthrough notes stay single-language per tab), unlike `useGeneratedOutput`
+  // where `tEn` also makes those blocks bilingual `EN · LOCAL`. v0.29.3.
   // `en` is eagerly bundled, so it never needs the readiness gate.
   const tEn = useMemo(() => i18n.getFixedT("en", "templates"), []);
 
@@ -53,6 +56,7 @@ export function useMultilangOutput(
         showTranslationQuality,
         titleFormat,
         tEn,
+        bilingualContentBlocks: false,
       });
     }
     return results;

--- a/tests/engine/description-builder.test.ts
+++ b/tests/engine/description-builder.test.ts
@@ -1498,6 +1498,84 @@ describe("buildDescription — translation quality notice (v0.24.0)", () => {
   });
 });
 
+describe("buildDescription — bilingualContentBlocks gate (v0.29.3)", () => {
+  it("multi-language tabs: content blocks single-language but translation-quality stays bilingual", () => {
+    const t = createMockT("ja");
+    const tEn = createMockT("en");
+    const result = buildDescription(
+      makeInput({
+        language: "ja",
+        contentWarnings: ["flashing_lights"],
+        techNotes: ["fps_drops_hardware"],
+        playthroughStatus: "blind",
+      }),
+      t,
+      { tEn, bilingualContentBlocks: false, showTranslationQuality: true },
+    );
+    // Content warnings: JA-only header + no EN pairing.
+    expect(result).toContain("▸ ⚠️ コンテンツ警告");
+    expect(result).not.toContain("▸ ⚠️ CONTENT WARNINGS");
+    expect(result).not.toContain(
+      "Flashing lights — photosensitive viewers take care",
+    );
+    // Tech notes: JA-only header + no EN pairing.
+    expect(result).toContain("▸ 🛠 技術メモ");
+    expect(result).not.toContain("▸ 🛠 TECH NOTES");
+    expect(result).not.toContain(
+      "FPS drops — caused by hardware (FPS counter visible top-left)",
+    );
+    // Playthrough notes: JA-only header + no EN pairing.
+    expect(result).toContain("▸ 🎮 プレイ情報");
+    expect(result).not.toContain("▸ 🎮 PLAYTHROUGH NOTES");
+    // Translation-quality disclaimer: STILL bilingual (the v0.29.2 goal).
+    expect(result).toContain("ABOUT THIS TRANSLATION"); // EN header via tEn
+    expect(result).toContain("翻訳について"); // JA header — proves bilingual
+  });
+
+  it("multi-language tabs: content warnings render single-language with no `· ` separator", () => {
+    const t = createMockT("vi");
+    const tEn = createMockT("en");
+    const result = buildDescription(
+      makeInput({
+        language: "vi",
+        contentWarnings: ["jump_scares", "flashing_lights"],
+      }),
+      t,
+      { tEn, bilingualContentBlocks: false },
+    );
+    expect(result).not.toContain(" · ");
+    expect(result).toContain("▸ ⚠️ CẢNH BÁO NỘI DUNG");
+    expect(result).not.toContain("▸ ⚠️ CONTENT WARNINGS");
+    expect(result).toContain("• Có jumpscare");
+  });
+
+  it("single-language mode (default true): content warnings stay bilingual", () => {
+    const t = createMockT("vi");
+    const tEn = createMockT("en");
+    const result = buildDescription(
+      makeInput({ language: "vi", contentWarnings: ["jump_scares"] }),
+      t,
+      { tEn }, // bilingualContentBlocks omitted → defaults to true
+    );
+    expect(result).toContain("▸ ⚠️ CONTENT WARNINGS / ▸ ⚠️ CẢNH BÁO NỘI DUNG");
+    expect(result).toContain("• Jumpscares · Có jumpscare");
+  });
+
+  it("explicit bilingualContentBlocks:true matches the default", () => {
+    const t = createMockT("vi");
+    const tEn = createMockT("en");
+    const base = makeInput({
+      language: "vi",
+      contentWarnings: ["jump_scares"],
+      techNotes: ["fps_drops_hardware"],
+      playthroughStatus: "blind",
+    });
+    const a = buildDescription(base, t, { tEn });
+    const b = buildDescription(base, t, { tEn, bilingualContentBlocks: true });
+    expect(a).toBe(b);
+  });
+});
+
 describe("checkDescriptionWarning", () => {
   it("returns null for description under limit", () => {
     expect(checkDescriptionWarning("Short description")).toBeNull();


### PR DESCRIPTION
## Context

Follow-up hotfix to v0.29.2. That release forwarded the always-English `tEn` translator to the multi-language Output hook so the AI-translation disclaimer could render bilingually (`EN · LOCAL`). But `tEn` is the **single shared signal** for bilingual rendering in the engine, so it also turned the **content-warnings, tech-notes, and playthrough-notes** blocks bilingual in every multi-language tab. Each multi-language tab is already a dedicated single language, so those "video" blocks should be that language only — only the translation disclaimer is meant to stay bilingual.

## Fix

- New `bilingualContentBlocks` render option (default `true`, additive) threaded `RenderOptions → renderAll → buildDescription`.
- The multi-language hook ([use-multilang-output.ts](src/hooks/use-multilang-output.ts)) passes `false`: content warnings / tech notes / playthrough notes render the target language only, while the `▸ 🌐 ABOUT THIS TRANSLATION` disclaimer keeps the raw `tEn` and stays bilingual `EN · LOCAL`.
- Single-language output unchanged (default `true` preserves the v0.11/v0.12 bilingual blocks).
- Social / cross-post path intentionally untouched (separate hooks, never wired through multi-language tabs; long-standing v0.24.0 behavior).

## Verification

- `typecheck` clean, `lint` clean, `validate:locales` 937/542.
- **517 tests** pass (513 + 4 new `bilingualContentBlocks` gate tests).
- Verified live via Preview MCP: multi-language JA tab → JA-only content blocks + bilingual disclaimer; EN tab → disclaimer omitted (trusted); single-language JA → content warnings still bilingual.
- Five manifests bumped 0.29.2 → 0.29.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)